### PR TITLE
Add torch runtime auto-selection with fp16/bf16->fp32 fallback and persist runtime selectors in model artifacts

### DIFF
--- a/ser/repr/hf_xlsr.py
+++ b/ser/repr/hf_xlsr.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import importlib
 import importlib.util
 from collections.abc import Mapping, Sequence
-from contextlib import AbstractContextManager, nullcontext
+from contextlib import AbstractContextManager
 from pathlib import Path
 from typing import Protocol, cast
 
@@ -19,6 +19,17 @@ from ser.repr.backend import (
     PoolingWindow,
     overlap_frame_mask,
 )
+from ser.utils.logger import get_logger
+from ser.utils.torch_inference import (
+    TorchRuntime,
+    inference_context,
+    maybe_resolve_torch_runtime,
+    move_inputs_to_runtime,
+    move_model_to_runtime,
+    runtime_with_dtype,
+)
+
+logger = get_logger(__name__)
 
 
 class _FeatureExtractor(Protocol):
@@ -80,6 +91,8 @@ class XLSRBackend:
         model_id: str = "facebook/wav2vec2-xls-r-300m",
         max_chunk_seconds: float = 30.0,
         cache_dir: Path | None = None,
+        device: str = "auto",
+        dtype: str = "auto",
         feature_extractor: _FeatureExtractor | None = None,
         model: _EncoderModel | None = None,
     ) -> None:
@@ -106,8 +119,11 @@ class XLSRBackend:
         self._model_id = model_id
         self._max_chunk_seconds = max_chunk_seconds
         self._cache_dir = cache_dir
+        self._device = device
+        self._dtype = dtype
         self._feature_extractor = feature_extractor
         self._model = model
+        self._torch_runtime: TorchRuntime | None = None
 
     @property
     def backend_id(self) -> str:
@@ -231,9 +247,46 @@ class XLSRBackend:
             return_tensors="pt",
             padding=False,
         )
-        with self._no_grad_context():
-            outputs = model(**inputs)
-        return self._normalize_hidden_state(outputs.last_hidden_state)
+        runtime = self._get_torch_runtime()
+        if runtime is not None:
+            inputs = move_inputs_to_runtime(
+                inputs,
+                runtime,
+                dtype_keys=frozenset({"input_values"}),
+            )
+        embeddings = self._encode_with_model(model=model, inputs=inputs)
+        if runtime is None or runtime.dtype_name == "float32":
+            return embeddings
+        if np.all(np.isfinite(embeddings)):
+            return embeddings
+
+        fallback_runtime = runtime_with_dtype(runtime, dtype="float32")
+        if fallback_runtime is None:
+            raise RuntimeError(
+                "XLSR backend produced non-finite embeddings and torch is unavailable "
+                "for float32 fallback."
+            )
+        logger.warning(
+            "XLSR backend produced non-finite embeddings with dtype=%s. "
+            "Retrying chunk with float32 fallback.",
+            runtime.dtype_name,
+        )
+        move_model_to_runtime(model, fallback_runtime)
+        self._torch_runtime = fallback_runtime
+        fallback_inputs = move_inputs_to_runtime(
+            inputs,
+            fallback_runtime,
+            dtype_keys=frozenset({"input_values"}),
+        )
+        fallback_embeddings = self._encode_with_model(
+            model=model,
+            inputs=fallback_inputs,
+        )
+        if not np.all(np.isfinite(fallback_embeddings)):
+            raise RuntimeError(
+                "XLSR backend produced non-finite embeddings after float32 fallback."
+            )
+        return fallback_embeddings
 
     def _ensure_runtime_components(self) -> tuple[_FeatureExtractor, _EncoderModel]:
         """Loads runtime components lazily or returns injected test doubles."""
@@ -281,9 +334,21 @@ class XLSRBackend:
                 "upgrade torch to >=2.6 for legacy checkpoint loading."
             ) from err
         model.eval()
+        runtime = self._get_torch_runtime()
+        if runtime is not None:
+            move_model_to_runtime(model, runtime)
         self._feature_extractor = feature_extractor
         self._model = model
         return feature_extractor, model
+
+    def _get_torch_runtime(self) -> TorchRuntime | None:
+        """Lazily resolves optional torch runtime selectors."""
+        if self._torch_runtime is None:
+            self._torch_runtime = maybe_resolve_torch_runtime(
+                device=self._device,
+                dtype=self._dtype,
+            )
+        return self._torch_runtime
 
     def _ensure_dependencies_available(self) -> None:
         """Validates optional backend dependencies and raises actionable errors."""
@@ -299,15 +364,19 @@ class XLSRBackend:
             )
 
     def _no_grad_context(self) -> AbstractContextManager[object]:
-        """Returns a torch.no_grad context when torch is available."""
-        try:
-            torch_module = importlib.import_module("torch")
-        except ModuleNotFoundError:
-            return nullcontext()
-        no_grad = getattr(torch_module, "no_grad", None)
-        if callable(no_grad):
-            return cast(AbstractContextManager[object], no_grad())
-        return nullcontext()
+        """Returns best-available inference context when torch is present."""
+        return inference_context()
+
+    def _encode_with_model(
+        self,
+        *,
+        model: _EncoderModel,
+        inputs: Mapping[str, object],
+    ) -> NDArray[np.float32]:
+        """Runs model forward pass and normalizes hidden-state outputs."""
+        with self._no_grad_context():
+            outputs = model(**inputs)
+        return self._normalize_hidden_state(outputs.last_hidden_state)
 
     def _normalize_hidden_state(self, hidden_state: object) -> NDArray[np.float32]:
         """Normalizes model hidden state output into `(frames, hidden)` matrix."""

--- a/ser/runtime/medium_inference.py
+++ b/ser/runtime/medium_inference.py
@@ -195,6 +195,11 @@ def run_medium_inference(
                 active_loaded_model,
                 expected_backend_model_id=expected_backend_model_id,
             )
+            _warn_on_runtime_selector_mismatch(
+                loaded_model=active_loaded_model,
+                settings=settings,
+                profile="medium",
+            )
             audio, sample_rate = read_audio_file(request.file_path)
             audio_array = np.asarray(audio, dtype=np.float32)
             active_backend = (
@@ -203,6 +208,8 @@ def run_medium_inference(
                 else XLSRBackend(
                     model_id=expected_backend_model_id,
                     cache_dir=settings.models.huggingface_cache_root,
+                    device=settings.torch_runtime.device,
+                    dtype=settings.torch_runtime.dtype,
                 )
             )
         except Exception:
@@ -641,11 +648,18 @@ def _prepare_process_operation(
         loaded_model,
         expected_backend_model_id=payload.expected_backend_model_id,
     )
+    _warn_on_runtime_selector_mismatch(
+        loaded_model=loaded_model,
+        settings=settings,
+        profile="medium",
+    )
     audio, sample_rate = read_audio_file(payload.request.file_path)
     audio_array = np.asarray(audio, dtype=np.float32)
     backend = XLSRBackend(
         model_id=payload.expected_backend_model_id,
         cache_dir=settings.models.huggingface_cache_root,
+        device=settings.torch_runtime.device,
+        dtype=settings.torch_runtime.dtype,
     )
     _prepare_medium_backend_runtime(backend=backend)
     return _PreparedMediumOperation(
@@ -802,6 +816,49 @@ def _ensure_medium_compatible_model(
             "No medium-profile model artifact is available. "
             f"Found backend_model_id={backend_model_id!r}; "
             f"expected {expected_backend_model_id!r}."
+        )
+
+
+def _warn_on_runtime_selector_mismatch(
+    *,
+    loaded_model: LoadedModel,
+    settings: AppConfig,
+    profile: str,
+) -> None:
+    """Warns when artifact runtime selectors differ from current runtime settings."""
+    metadata = loaded_model.artifact_metadata
+    if not isinstance(metadata, dict):
+        return
+
+    artifact_torch_device = metadata.get("torch_device")
+    artifact_torch_dtype = metadata.get("torch_dtype")
+    if not isinstance(artifact_torch_device, str) or not isinstance(
+        artifact_torch_dtype, str
+    ):
+        return
+
+    normalized_artifact_device = artifact_torch_device.strip().lower()
+    normalized_artifact_dtype = artifact_torch_dtype.strip().lower()
+    if not normalized_artifact_device or not normalized_artifact_dtype:
+        return
+
+    runtime_device = settings.torch_runtime.device.strip().lower()
+    runtime_dtype = settings.torch_runtime.dtype.strip().lower()
+    mismatch_components: list[str] = []
+    if normalized_artifact_device != runtime_device:
+        mismatch_components.append(
+            f"device artifact={normalized_artifact_device!r} runtime={runtime_device!r}"
+        )
+    if normalized_artifact_dtype != runtime_dtype:
+        mismatch_components.append(
+            f"dtype artifact={normalized_artifact_dtype!r} runtime={runtime_dtype!r}"
+        )
+    if mismatch_components:
+        logger.warning(
+            "Artifact torch runtime selectors differ from current settings for %s "
+            "profile (%s); embedding distribution may shift.",
+            profile,
+            ", ".join(mismatch_components),
         )
 
 

--- a/ser/utils/torch_inference.py
+++ b/ser/utils/torch_inference.py
@@ -1,0 +1,191 @@
+"""Torch runtime helpers for optional device and dtype selection."""
+
+from __future__ import annotations
+
+import importlib
+from collections.abc import Mapping
+from contextlib import AbstractContextManager, nullcontext
+from dataclasses import dataclass
+from typing import cast
+
+
+@dataclass(frozen=True)
+class TorchRuntime:
+    """Resolved runtime selectors for one torch-backed inference backend."""
+
+    device: object
+    dtype: object
+    device_spec: str
+    device_type: str
+    dtype_name: str
+
+
+def _cuda_is_available(torch_module: object) -> bool:
+    """Returns whether CUDA runtime is available in current environment."""
+    cuda = getattr(torch_module, "cuda", None)
+    is_available = getattr(cuda, "is_available", None)
+    return bool(is_available()) if callable(is_available) else False
+
+
+def _cuda_bf16_is_supported(torch_module: object) -> bool:
+    """Returns whether CUDA backend supports bfloat16 inference kernels."""
+    cuda = getattr(torch_module, "cuda", None)
+    is_bf16_supported = getattr(cuda, "is_bf16_supported", None)
+    return bool(is_bf16_supported()) if callable(is_bf16_supported) else False
+
+
+def _mps_is_available(torch_module: object) -> bool:
+    """Returns whether Apple MPS runtime is available and built."""
+    backends = getattr(torch_module, "backends", None)
+    mps = getattr(backends, "mps", None)
+    is_available = getattr(mps, "is_available", None)
+    is_built = getattr(mps, "is_built", None)
+    available = bool(is_available()) if callable(is_available) else False
+    built = bool(is_built()) if callable(is_built) else False
+    return available and built
+
+
+def _resolve_device_spec(torch_module: object, requested_device: str) -> str:
+    """Resolves runtime device selector from one requested device string."""
+    normalized = requested_device.strip().lower()
+    if normalized == "auto":
+        if _cuda_is_available(torch_module):
+            return "cuda"
+        if _mps_is_available(torch_module):
+            return "mps"
+        return "cpu"
+    if normalized.startswith("cuda"):
+        if not _cuda_is_available(torch_module):
+            raise RuntimeError(
+                "SER_TORCH_DEVICE requested CUDA, but CUDA is unavailable."
+            )
+        return normalized
+    if normalized == "mps":
+        if not _mps_is_available(torch_module):
+            raise RuntimeError("SER_TORCH_DEVICE requested MPS, but MPS is unavailable.")
+        return "mps"
+    return "cpu"
+
+
+def _resolve_dtype_name(
+    torch_module: object,
+    *,
+    requested_dtype: str,
+    device_type: str,
+) -> str:
+    """Resolves runtime dtype selector from requested dtype and device type."""
+    normalized = requested_dtype.strip().lower()
+    if normalized not in {"auto", "float32", "float16", "bfloat16"}:
+        raise RuntimeError(f"Unsupported torch dtype selector {requested_dtype!r}.")
+
+    if device_type == "cpu":
+        if normalized in {"auto", "float32"}:
+            return "float32"
+        raise RuntimeError("CPU runtime only supports SER_TORCH_DTYPE=float32.")
+
+    if normalized == "auto":
+        if device_type == "cuda" and _cuda_bf16_is_supported(torch_module):
+            if getattr(torch_module, "bfloat16", None) is not None:
+                return "bfloat16"
+        return "float16"
+
+    if normalized == "bfloat16":
+        if device_type == "mps":
+            raise RuntimeError("SER_TORCH_DTYPE=bfloat16 is unsupported for MPS.")
+        if device_type == "cuda" and not _cuda_bf16_is_supported(torch_module):
+            raise RuntimeError(
+                "SER_TORCH_DTYPE=bfloat16 requested, but CUDA bf16 is unsupported."
+            )
+        if getattr(torch_module, "bfloat16", None) is None:
+            raise RuntimeError("Installed torch build does not expose bfloat16 dtype.")
+    return normalized
+
+
+def maybe_resolve_torch_runtime(
+    *,
+    device: str = "auto",
+    dtype: str = "auto",
+) -> TorchRuntime | None:
+    """Resolves torch runtime selectors, or returns None when torch is absent."""
+    try:
+        torch_module = importlib.import_module("torch")
+    except ModuleNotFoundError:
+        return None
+
+    resolved_device_spec = _resolve_device_spec(torch_module, device)
+    resolved_device_type = (
+        "cuda"
+        if resolved_device_spec.startswith("cuda")
+        else ("mps" if resolved_device_spec == "mps" else "cpu")
+    )
+    resolved_dtype_name = _resolve_dtype_name(
+        torch_module,
+        requested_dtype=dtype,
+        device_type=resolved_device_type,
+    )
+
+    device_ctor = getattr(torch_module, "device", None)
+    if not callable(device_ctor):
+        raise RuntimeError("torch.device is unavailable in current torch installation.")
+    dtype_obj = getattr(torch_module, resolved_dtype_name, None)
+    if dtype_obj is None:
+        raise RuntimeError(
+            f"torch.{resolved_dtype_name} is unavailable in current torch installation."
+        )
+
+    return TorchRuntime(
+        device=device_ctor(resolved_device_spec),
+        dtype=dtype_obj,
+        device_spec=resolved_device_spec,
+        device_type=resolved_device_type,
+        dtype_name=resolved_dtype_name,
+    )
+
+
+def runtime_with_dtype(runtime: TorchRuntime, *, dtype: str) -> TorchRuntime | None:
+    """Builds a runtime clone with the same device selector and new dtype."""
+    return maybe_resolve_torch_runtime(device=runtime.device_spec, dtype=dtype)
+
+
+def move_model_to_runtime(model: object, runtime: TorchRuntime) -> None:
+    """Moves one backend model instance to selected device and dtype."""
+    to_method = getattr(model, "to", None)
+    if not callable(to_method):
+        return
+    to_method(device=runtime.device, dtype=runtime.dtype)
+
+
+def move_inputs_to_runtime(
+    inputs: Mapping[str, object],
+    runtime: TorchRuntime,
+    *,
+    dtype_keys: frozenset[str],
+) -> dict[str, object]:
+    """Moves tensor-like mapping values to selected runtime device and dtype."""
+    moved: dict[str, object] = {}
+    for key, value in inputs.items():
+        to_method = getattr(value, "to", None)
+        if callable(to_method):
+            if key in dtype_keys:
+                moved[key] = to_method(device=runtime.device, dtype=runtime.dtype)
+            else:
+                moved[key] = to_method(device=runtime.device)
+        else:
+            moved[key] = value
+    return moved
+
+
+def inference_context() -> AbstractContextManager[object]:
+    """Returns best-effort torch inference context when available."""
+    try:
+        torch_module = importlib.import_module("torch")
+    except ModuleNotFoundError:
+        return nullcontext()
+    inference_mode = getattr(torch_module, "inference_mode", None)
+    if callable(inference_mode):
+        return cast(AbstractContextManager[object], inference_mode())
+    no_grad = getattr(torch_module, "no_grad", None)
+    if callable(no_grad):
+        return cast(AbstractContextManager[object], no_grad())
+    return nullcontext()
+

--- a/tests/test_accurate_inference.py
+++ b/tests/test_accurate_inference.py
@@ -412,9 +412,18 @@ def test_accurate_inference_uses_configured_accurate_model_id(
     captured: dict[str, object] = {}
 
     class _BackendStub:
-        def __init__(self, *, model_id: str, cache_dir: Path) -> None:
+        def __init__(
+            self,
+            *,
+            model_id: str,
+            cache_dir: Path,
+            device: str = "auto",
+            dtype: str = "auto",
+        ) -> None:
             captured["model_id"] = model_id
             captured["cache_dir"] = cache_dir
+            captured["device"] = device
+            captured["dtype"] = dtype
 
     monkeypatch.setattr("ser.runtime.accurate_inference.WhisperBackend", _BackendStub)
     monkeypatch.setattr(
@@ -442,6 +451,8 @@ def test_accurate_inference_uses_configured_accurate_model_id(
 
     assert captured["model_id"] == "unit-test/whisper-tiny"
     assert captured["cache_dir"] == settings.models.huggingface_cache_root
+    assert captured["device"] == settings.torch_runtime.device
+    assert captured["dtype"] == settings.torch_runtime.dtype
     assert isinstance(captured["backend"], _BackendStub)
 
 
@@ -499,6 +510,59 @@ def test_accurate_inference_requires_backend_model_id_metadata(
             ),
             settings,
         )
+
+
+def test_accurate_inference_warns_on_torch_runtime_metadata_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Runtime should warn when artifact and runtime torch selectors differ."""
+    monkeypatch.setenv("SER_TORCH_DEVICE", "cpu")
+    monkeypatch.setenv("SER_TORCH_DTYPE", "float32")
+    settings = config.reload_settings()
+    metadata = _accurate_metadata(backend_model_id=settings.models.accurate_model_id)
+    metadata["torch_device"] = "cuda:0"
+    metadata["torch_dtype"] = "float16"
+    warnings: list[str] = []
+    monkeypatch.setattr(
+        "ser.runtime.accurate_inference.logger.warning",
+        lambda msg, *args: warnings.append(msg % args),
+    )
+    monkeypatch.setattr(
+        "ser.runtime.accurate_inference.load_model",
+        lambda **_kwargs: emotion_model.LoadedModel(
+            model=_PredictModel(),
+            expected_feature_size=4,
+            artifact_metadata=metadata,
+        ),
+    )
+    monkeypatch.setattr(
+        "ser.runtime.accurate_inference.read_audio_file",
+        lambda _file_path: (np.linspace(0.0, 1.0, 16, dtype=np.float32), 4),
+    )
+    monkeypatch.setattr(
+        "ser.runtime.accurate_inference.WhisperBackend",
+        lambda **_kwargs: object(),
+    )
+    monkeypatch.setattr(
+        "ser.runtime.accurate_inference._run_with_timeout",
+        lambda operation, timeout_seconds: operation(),
+    )
+    monkeypatch.setattr(
+        "ser.runtime.accurate_inference._run_accurate_inference_once",
+        lambda **_kwargs: InferenceResult(
+            schema_version=OUTPUT_SCHEMA_VERSION,
+            segments=[],
+            frames=[],
+        ),
+    )
+
+    run_accurate_inference(
+        InferenceRequest(file_path="sample.wav", language="en", save_transcript=False),
+        settings,
+    )
+
+    assert warnings
+    assert "torch runtime selectors differ" in warnings[0]
 
 
 def test_accurate_single_flight_serializes_same_profile_model_calls(

--- a/tests/test_artifact_upgrade_path.py
+++ b/tests/test_artifact_upgrade_path.py
@@ -110,6 +110,31 @@ def test_deserialize_round_trips_accurate_v2_artifact_metadata() -> None:
     assert loaded.artifact_metadata["feature_dim"] == 2560
 
 
+def test_deserialize_round_trips_optional_torch_runtime_metadata() -> None:
+    """Artifacts should preserve optional torch runtime selector metadata."""
+    artifact = em._build_model_artifact(
+        model=_build_classifier(),
+        feature_vector_size=2560,
+        training_samples=10,
+        labels=["sad", "happy", "angry"],
+        backend_id="hf_whisper",
+        profile="accurate",
+        feature_dim=2560,
+        frame_size_seconds=1.0,
+        frame_stride_seconds=1.0,
+        pooling_strategy="mean_std",
+        backend_model_id="openai/whisper-large-v3",
+        torch_device="cuda:0",
+        torch_dtype="float16",
+    )
+
+    loaded = em._deserialize_model_artifact(artifact)
+
+    assert loaded.artifact_metadata is not None
+    assert loaded.artifact_metadata["torch_device"] == "cuda:0"
+    assert loaded.artifact_metadata["torch_dtype"] == "float16"
+
+
 @pytest.mark.parametrize(
     ("field_name", "field_value", "error_match"),
     [

--- a/tests/test_medium_training_windowing.py
+++ b/tests/test_medium_training_windowing.py
@@ -49,7 +49,11 @@ def test_medium_train_and_infer_share_configured_temporal_window_policy(
     runtime_config = config.get_settings().medium_runtime
 
     encoded = _encoded_sequence()
-    train_windows = emotion_model._pooling_windows_from_encoded_frames(encoded)
+    train_windows = emotion_model._pooling_windows_from_encoded_frames(
+        encoded,
+        window_size_seconds=runtime_config.pool_window_size_seconds,
+        window_stride_seconds=runtime_config.pool_window_stride_seconds,
+    )
     infer_windows = medium_inference._pooling_windows_from_encoded_frames(
         encoded,
         runtime_config=runtime_config,

--- a/tests/test_torch_inference.py
+++ b/tests/test_torch_inference.py
@@ -1,0 +1,210 @@
+"""Tests for torch runtime inference helpers."""
+
+from __future__ import annotations
+
+from contextlib import nullcontext
+
+import pytest
+
+import ser.utils.torch_inference as torch_inference
+
+
+class _FakeCuda:
+    """Minimal CUDA capability stub."""
+
+    def __init__(self, *, available: bool, bf16_supported: bool) -> None:
+        self._available = available
+        self._bf16_supported = bf16_supported
+
+    def is_available(self) -> bool:
+        """Returns configured CUDA availability."""
+        return self._available
+
+    def is_bf16_supported(self) -> bool:
+        """Returns configured CUDA bf16 support."""
+        return self._bf16_supported
+
+
+class _FakeMps:
+    """Minimal MPS capability stub."""
+
+    def __init__(self, *, available: bool, built: bool) -> None:
+        self._available = available
+        self._built = built
+
+    def is_available(self) -> bool:
+        """Returns configured MPS availability."""
+        return self._available
+
+    def is_built(self) -> bool:
+        """Returns configured MPS build flag."""
+        return self._built
+
+
+class _FakeBackends:
+    """Container for torch.backends namespace stubs."""
+
+    def __init__(self, *, mps: _FakeMps) -> None:
+        self.mps = mps
+
+
+class _FakeTorchModule:
+    """Minimal torch-like module stub for runtime resolution tests."""
+
+    float32 = "float32"
+    float16 = "float16"
+    bfloat16 = "bfloat16"
+
+    def __init__(
+        self,
+        *,
+        cuda_available: bool,
+        cuda_bf16_supported: bool,
+        mps_available: bool,
+        mps_built: bool,
+    ) -> None:
+        self.cuda = _FakeCuda(
+            available=cuda_available,
+            bf16_supported=cuda_bf16_supported,
+        )
+        self.backends = _FakeBackends(
+            mps=_FakeMps(available=mps_available, built=mps_built)
+        )
+        self.context_calls: list[str] = []
+
+    def device(self, spec: str) -> str:
+        """Builds a deterministic device token."""
+        return f"device:{spec}"
+
+    def inference_mode(self) -> object:
+        """Tracks inference_mode usage and returns a null context."""
+        self.context_calls.append("inference_mode")
+        return nullcontext()
+
+    def no_grad(self) -> object:
+        """Tracks no_grad usage and returns a null context."""
+        self.context_calls.append("no_grad")
+        return nullcontext()
+
+
+class _FakeTensor:
+    """Tensor-like stub that records `.to(...)` argument dictionaries."""
+
+    def __init__(self) -> None:
+        self.to_calls: list[dict[str, object]] = []
+
+    def to(self, **kwargs: object) -> _FakeTensor:
+        """Records move/cast call and returns self for chaining."""
+        self.to_calls.append(dict(kwargs))
+        return self
+
+
+def test_maybe_resolve_torch_runtime_returns_none_when_torch_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Resolver should return None when torch import is unavailable."""
+    monkeypatch.setattr(
+        torch_inference.importlib,
+        "import_module",
+        lambda _name: (_ for _ in ()).throw(ModuleNotFoundError("torch missing")),
+    )
+    runtime = torch_inference.maybe_resolve_torch_runtime(device="auto", dtype="auto")
+    assert runtime is None
+
+
+def test_maybe_resolve_torch_runtime_prefers_cuda_and_bf16_when_supported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Auto selectors should pick CUDA + bf16 when available."""
+    fake_torch = _FakeTorchModule(
+        cuda_available=True,
+        cuda_bf16_supported=True,
+        mps_available=True,
+        mps_built=True,
+    )
+    monkeypatch.setattr(
+        torch_inference.importlib,
+        "import_module",
+        lambda name: fake_torch if name == "torch" else None,
+    )
+
+    runtime = torch_inference.maybe_resolve_torch_runtime(device="auto", dtype="auto")
+
+    assert runtime is not None
+    assert runtime.device_spec == "cuda"
+    assert runtime.device_type == "cuda"
+    assert runtime.dtype_name == "bfloat16"
+    assert runtime.device == "device:cuda"
+    assert runtime.dtype == "bfloat16"
+
+
+def test_maybe_resolve_torch_runtime_rejects_non_float32_cpu_dtype(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CPU selection should reject dtype choices other than float32/auto."""
+    fake_torch = _FakeTorchModule(
+        cuda_available=False,
+        cuda_bf16_supported=False,
+        mps_available=False,
+        mps_built=False,
+    )
+    monkeypatch.setattr(
+        torch_inference.importlib,
+        "import_module",
+        lambda name: fake_torch if name == "torch" else None,
+    )
+    with pytest.raises(RuntimeError, match="CPU runtime only supports"):
+        torch_inference.maybe_resolve_torch_runtime(device="cpu", dtype="float16")
+
+
+def test_move_inputs_to_runtime_casts_only_selected_dtype_keys() -> None:
+    """Input move helper should apply dtype cast only for configured keys."""
+    runtime = torch_inference.TorchRuntime(
+        device="device:cuda",
+        dtype="float16",
+        device_spec="cuda:0",
+        device_type="cuda",
+        dtype_name="float16",
+    )
+    input_values = _FakeTensor()
+    attention_mask = _FakeTensor()
+
+    moved = torch_inference.move_inputs_to_runtime(
+        {
+            "input_values": input_values,
+            "attention_mask": attention_mask,
+        },
+        runtime,
+        dtype_keys=frozenset({"input_values"}),
+    )
+
+    assert moved["input_values"] is input_values
+    assert moved["attention_mask"] is attention_mask
+    assert input_values.to_calls == [
+        {"device": "device:cuda", "dtype": "float16"},
+    ]
+    assert attention_mask.to_calls == [
+        {"device": "device:cuda"},
+    ]
+
+
+def test_inference_context_prefers_inference_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Context helper should use inference_mode when available."""
+    fake_torch = _FakeTorchModule(
+        cuda_available=False,
+        cuda_bf16_supported=False,
+        mps_available=False,
+        mps_built=False,
+    )
+    monkeypatch.setattr(
+        torch_inference.importlib,
+        "import_module",
+        lambda name: fake_torch if name == "torch" else None,
+    )
+
+    with torch_inference.inference_context():
+        pass
+
+    assert fake_torch.context_calls == ["inference_mode"]


### PR DESCRIPTION
## Summary

This PR introduces torch runtime controls for HF-backed embeddings and hardens inference/training behavior across medium and accurate profiles.

## What changed

- Added runtime config:
    - SER_TORCH_DEVICE: auto|cpu|mps|cuda|cuda:N
    - SER_TORCH_DTYPE: auto|float32|float16|bfloat16
- Added shared torch runtime helper module for:
    - device/dtype resolution
    - model/input placement
    - inference-mode context handling
- Updated Whisper/XLSR backends to:
    - honor configured runtime selectors
    - detect non-finite outputs in half precision and retry chunk in float32
- Persisted torch_device and torch_dtype into v2 artifact metadata during training
- Added inference warnings when artifact runtime selectors differ from current runtime config
- Corrected accurate profile pooling metadata/windowing to use accurate runtime settings (instead of medium settings)

## Why

- Improve hardware utilization via configurable device/dtype selection
- Increase numerical robustness in mixed precision
- Preserve training runtime provenance in artifacts
- Make runtime mismatches visible during inference to reduce silent drift risk

## Testing

- Added unit coverage for runtime resolution rules and inference context helper
- Added backend tests for non-finite fallback retry behavior
- Added inference tests for runtime-mismatch warnings
- Added artifact round-trip tests for optional torch runtime metadata
- Added config/env parsing tests for new runtime flags

## Backward compatibility

- Existing flows remain compatible; new artifact metadata fields are optional
- Invalid runtime env values safely fall back to auto