### PR TITLE
Introduce manifest-driven utterance loading and deterministic split hierarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,16 @@ cd ser
 <details>
 <summary>Advanced compatibility/setup notes (library users and contributors)</summary>
 
-- Intel macOS (`x86_64`): full-profile support uses Python `3.12`; `./scripts/setup_compatible_env.sh` auto-selects it and installs the required extras for fast/medium/accurate train+inference.
+- Intel macOS (`x86_64`) + Python `3.13` is currently **partial compatibility** (fast-profile oriented) and is **not** an officially supported full runtime lane.
+- Intel macOS (`x86_64`) non-fast runtime (`medium`, `accurate`, `accurate-research`) depends on optional `torch`/`transformers` wheels that are not currently published for the platform tag in Python `3.13`; use Python `3.12` (or Linux `3.13` workflows) for those smoke paths.
+- GitHub Darwin validation remains a Python `3.12` smoke lane (`.github/workflows/darwin-x86_64-validation.yml`) for hosted-runner parity.
 - Non-fast profile predict paths (`medium`, `accurate`, `accurate-research`) require profile-compatible model artifacts; they fail closed on backend/profile metadata mismatch.
 - `accurate-research` uses the FunASR/ModelScope `emotion2vec` runtime path and requires `--extra full`.
+- Runtime policy: `fast` is the default profile. `medium`, `accurate`, and `accurate-research` remain opt-in lanes.
+
+Current Darwin Intel policy shorthand:
+`darwin-x86_64-macos13-python3.12` -> full-profile support.
+`darwin-x86_64-macos13-python3.13` -> partial (fast-profile only), not officially supported as a full runtime lane.
 
 Platform-aware setup overrides:
 - `SER_SETUP_PYTHON` to force a specific Python version.

--- a/scripts/setup_compatible_env.sh
+++ b/scripts/setup_compatible_env.sh
@@ -57,9 +57,6 @@ done
 os_name="$(uname -s)"
 arch_name="$(uname -m)"
 default_python="3.13"
-if [[ "$os_name" == "Darwin" && "$arch_name" == "x86_64" ]]; then
-  default_python="3.12"
-fi
 
 python_version="${SER_SETUP_PYTHON:-$default_python}"
 include_dev="$(normalize_bool "${SER_SETUP_INCLUDE_DEV:-true}" "SER_SETUP_INCLUDE_DEV")"
@@ -100,14 +97,6 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-if [[ "$os_name" == "Darwin" && "$arch_name" == "x86_64" ]]; then
-  if [[ "$python_version" != "3.12" && "$python_version" != 3.12.* ]]; then
-    printf 'Unsupported combination for full-profile SER support: Darwin x86_64 + Python %s\n' "$python_version" >&2
-    printf 'Use Python 3.12 for setup + train + inference on fast/medium/accurate.\n' >&2
-    exit 2
-  fi
-fi
-
 sync_args=(--python "$python_version" --extra full)
 if [[ "$include_dev" == "true" ]]; then
   sync_args+=(--extra dev)
@@ -117,6 +106,13 @@ printf '[setup] platform: %s/%s\n' "$os_name" "$arch_name"
 printf '[setup] python: %s\n' "$python_version"
 printf '[setup] include dev tools: %s\n' "$include_dev"
 printf '[setup] ffmpeg check: %s\n' "$check_ffmpeg"
+
+if [[ "$os_name" == "Darwin" && "$arch_name" == "x86_64" ]]; then
+  if [[ "$python_version" == "3.13" || "$python_version" == 3.13.* ]]; then
+    printf '[setup] note: Darwin x86_64 + Python 3.13 is currently partial (fast-profile oriented) and not an officially supported full runtime lane.\n'
+    printf '[setup] note: medium/accurate/accurate-research runtime requires torch/transformers wheels not currently published for this platform tag.\n'
+  fi
+fi
 
 run_cmd uv python install "$python_version"
 run_cmd uv sync "${sync_args[@]}"

--- a/ser/config.py
+++ b/ser/config.py
@@ -179,6 +179,7 @@ class DatasetConfig:
     folder: Path
     subfolder_prefix: str = "Actor_*"
     extension: str = "*.wav"
+    manifest_paths: tuple[Path, ...] = ()
 
     @property
     def glob_pattern(self) -> str:
@@ -669,6 +670,14 @@ def _build_settings() -> AppConfig:
         }
     )
     dataset_folder: Path = Path(os.getenv("DATASET_FOLDER", "ser/dataset/ravdess"))
+    dataset_manifests_raw = os.getenv("SER_DATASET_MANIFESTS", "").strip()
+    manifest_paths: tuple[Path, ...] = ()
+    if dataset_manifests_raw:
+        manifest_paths = tuple(
+            Path(item.strip()).expanduser()
+            for item in dataset_manifests_raw.split(",")
+            if item.strip()
+        )
     default_language: str = os.getenv("DEFAULT_LANGUAGE", "en")
     max_workers: int = _read_int_env("SER_MAX_WORKERS", 8, minimum=1)
     max_failed_file_ratio: float = _read_float_env(
@@ -794,7 +803,7 @@ def _build_settings() -> AppConfig:
         emotions=emotions,
         tmp_folder=tmp_folder,
         nn=NeuralNetConfig(random_state=random_state),
-        dataset=DatasetConfig(folder=dataset_folder),
+        dataset=DatasetConfig(folder=dataset_folder, manifest_paths=manifest_paths),
         data_loader=DataLoaderConfig(
             max_workers=max_workers,
             max_failed_file_ratio=max_failed_file_ratio,

--- a/ser/data/__init__.py
+++ b/ser/data/__init__.py
@@ -3,14 +3,18 @@ from .data_loader import (
     LabeledAudioSample,
     load_data,
     load_labeled_audio_paths,
+    load_utterances,
 )
 from .embedding_cache import EmbeddingCache, EmbeddingCacheEntry
+from .manifest import Utterance
 
 __all__ = [
     "DataSplit",
     "EmbeddingCache",
     "EmbeddingCacheEntry",
     "LabeledAudioSample",
+    "Utterance",
     "load_data",
     "load_labeled_audio_paths",
+    "load_utterances",
 ]

--- a/ser/data/adapters/__init__.py
+++ b/ser/data/adapters/__init__.py
@@ -1,0 +1,5 @@
+"""Dataset adapters that emit manifest-compatible utterances."""
+
+from __future__ import annotations
+
+__all__ = []

--- a/ser/data/adapters/ravdess.py
+++ b/ser/data/adapters/ravdess.py
@@ -1,0 +1,114 @@
+"""RAVDESS adapter that emits manifest-compatible utterances."""
+
+from __future__ import annotations
+
+import glob
+import os
+from collections.abc import Mapping
+from pathlib import Path
+
+from ser.data.manifest import MANIFEST_SCHEMA_VERSION, Utterance
+from ser.data.ontology import LabelOntology, remap_label
+from ser.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+RAVDESS_CORPUS_ID = "ravdess"
+
+
+def _extract_emotion_code(file_name: str) -> str | None:
+    parts = file_name.split("-")
+    return None if len(parts) < 3 else parts[2]
+
+
+def _extract_speaker_id(file_name: str) -> str | None:
+    parts = file_name.split("-")
+    if len(parts) < 7:
+        return None
+    speaker_id = parts[6].split(".")[0].strip()
+    return speaker_id or None
+
+
+def build_ravdess_utterances(
+    *,
+    dataset_root: Path,
+    dataset_glob_pattern: str,
+    emotion_code_map: Mapping[str, str],
+    default_language: str,
+    ontology: LabelOntology,
+    max_failed_file_ratio: float,
+) -> list[Utterance] | None:
+    """Builds utterances from a RAVDESS-style folder layout."""
+    files = sorted(glob.glob(dataset_glob_pattern))
+    if not files:
+        logger.warning("No dataset files found for pattern: %s", dataset_glob_pattern)
+        return None
+
+    utterances: list[Utterance] = []
+    parse_errors: list[str] = []
+    root = dataset_root.expanduser()
+    for file_path in files:
+        file_name = os.path.basename(file_path)
+        emotion_code = _extract_emotion_code(file_name)
+        if emotion_code is None:
+            parse_errors.append(
+                "Skipping file with unexpected name format "
+                f"(missing emotion code): {file_name}"
+            )
+            continue
+        mapped_label = remap_label(
+            raw_label=emotion_code,
+            mapping=emotion_code_map,
+            ontology=ontology,
+        )
+        if mapped_label is None:
+            continue
+
+        audio_path = Path(file_path).expanduser()
+        speaker_raw = _extract_speaker_id(file_name)
+        speaker_id = (
+            f"{RAVDESS_CORPUS_ID}:{speaker_raw}" if speaker_raw is not None else None
+        )
+        try:
+            rel_path = audio_path.relative_to(root).as_posix()
+            sample_id = f"{RAVDESS_CORPUS_ID}:{rel_path}"
+        except ValueError:
+            sample_id = f"{RAVDESS_CORPUS_ID}:{audio_path.name}"
+        utterances.append(
+            Utterance(
+                schema_version=MANIFEST_SCHEMA_VERSION,
+                sample_id=sample_id,
+                corpus=RAVDESS_CORPUS_ID,
+                audio_path=audio_path,
+                label=mapped_label,
+                raw_label=emotion_code,
+                speaker_id=speaker_id,
+                language=default_language,
+            )
+        )
+
+    if parse_errors:
+        logger.warning(
+            "Skipped %s/%s files while resolving labels.",
+            len(parse_errors),
+            len(files),
+        )
+        for error in parse_errors[:5]:
+            logger.warning("%s", error)
+
+    failure_ratio = float(len(parse_errors)) / float(len(files))
+    if failure_ratio > max_failed_file_ratio:
+        raise RuntimeError(
+            "Aborting data load: "
+            f"{failure_ratio * 100.0:.1f}% file failures exceeded configured "
+            "limit "
+            f"{max_failed_file_ratio * 100.0:.1f}%."
+        )
+    if not utterances:
+        logger.warning("No labeled audio samples matched configured emotions.")
+        return None
+    labels = [utterance.label for utterance in utterances]
+    if len(set(labels)) < 2:
+        logger.warning("At least two emotion classes are required to train the model.")
+        return None
+    return utterances

--- a/ser/data/data_loader.py
+++ b/ser/data/data_loader.py
@@ -6,13 +6,18 @@ import multiprocessing as mp
 import os
 from collections.abc import Collection
 from functools import partial
-from typing import Any, NamedTuple
+from pathlib import Path
+from typing import Any, NamedTuple, cast
 
 import numpy as np
 from numpy.typing import NDArray
 from sklearn.model_selection import train_test_split
 
 from ser.config import AppConfig, get_settings
+from ser.data.adapters.ravdess import build_ravdess_utterances
+from ser.data.manifest import Utterance
+from ser.data.manifest_jsonl import load_manifest_jsonl
+from ser.data.ontology import LabelOntology, UnknownLabelPolicy, normalize_label
 from ser.features import extract_feature
 from ser.utils.logger import get_logger
 
@@ -23,6 +28,82 @@ type FeatureMatrix = NDArray[np.float64]
 type LabelList = list[str]
 type DataSplit = tuple[FeatureMatrix, FeatureMatrix, LabelList, LabelList]
 type LabeledAudioSample = tuple[str, str]
+
+
+def _read_unknown_label_policy_env() -> UnknownLabelPolicy:
+    raw = os.getenv("SER_UNKNOWN_LABEL_POLICY", "drop").strip().lower()
+    if raw in {"drop", "error", "map_to_other"}:
+        return cast(UnknownLabelPolicy, raw)
+    return "drop"
+
+
+def _resolve_label_ontology(settings: AppConfig) -> LabelOntology:
+    ontology_id = os.getenv("SER_LABEL_ONTOLOGY_ID", "default_v1").strip()
+    if not ontology_id:
+        ontology_id = "default_v1"
+    allowed_labels_raw = os.getenv("SER_ALLOWED_LABELS", "").strip()
+    if allowed_labels_raw:
+        allowed_labels = {
+            normalize_label(item)
+            for item in allowed_labels_raw.split(",")
+            if normalize_label(item)
+        }
+    else:
+        allowed_labels = {normalize_label(label) for label in settings.emotions.values()}
+    if not allowed_labels:
+        raise RuntimeError(
+            "Resolved label ontology contains zero allowed labels. "
+            "Check SER_ALLOWED_LABELS or configured emotion mapping."
+        )
+    other_label_raw = os.getenv("SER_OTHER_LABEL", "other").strip()
+    other_label = normalize_label(other_label_raw) if other_label_raw else "other"
+    return LabelOntology(
+        ontology_id=ontology_id,
+        allowed_labels=frozenset(allowed_labels),
+        unknown_label_policy=_read_unknown_label_policy_env(),
+        other_label=other_label,
+    )
+
+
+def load_utterances() -> list[Utterance] | None:
+    """Loads utterances from manifests or from the legacy RAVDESS adapter path."""
+    settings: AppConfig = get_settings()
+    ontology = _resolve_label_ontology(settings)
+    manifest_paths: tuple[Path, ...] = settings.dataset.manifest_paths
+    if manifest_paths:
+        utterances: list[Utterance] = []
+        for manifest_path in manifest_paths:
+            utterances.extend(load_manifest_jsonl(Path(manifest_path), ontology=ontology))
+        if not utterances:
+            logger.warning("No utterances loaded from configured manifests.")
+            return None
+        seen_sample_ids: set[str] = set()
+        duplicate_sample_ids: set[str] = set()
+        for utterance in utterances:
+            if utterance.sample_id in seen_sample_ids:
+                duplicate_sample_ids.add(utterance.sample_id)
+            seen_sample_ids.add(utterance.sample_id)
+        if duplicate_sample_ids:
+            raise RuntimeError(
+                "Duplicate sample_id values across manifests: "
+                + ", ".join(sorted(duplicate_sample_ids))
+            )
+        labels = [utterance.label for utterance in utterances]
+        if len(set(labels)) < 2:
+            logger.warning("At least two emotion classes are required to train the model.")
+            return None
+        return utterances
+
+    dataset_folder = settings.dataset.folder
+    default_language = settings.default_language
+    return build_ravdess_utterances(
+        dataset_root=dataset_folder,
+        dataset_glob_pattern=settings.dataset.glob_pattern,
+        emotion_code_map=dict(settings.emotions),
+        default_language=default_language,
+        ontology=ontology,
+        max_failed_file_ratio=settings.data_loader.max_failed_file_ratio,
+    )
 
 
 class ProcessFileResult(NamedTuple):
@@ -105,53 +186,13 @@ def load_labeled_audio_paths() -> list[LabeledAudioSample] | None:
     Raises:
         RuntimeError: If filename-format failures exceed configured threshold.
     """
-    settings: AppConfig = get_settings()
-    observed_emotions: set[str] = set(settings.emotions.values())
-    files: list[str] = sorted(glob.glob(settings.dataset.glob_pattern))
-    if not files:
-        logger.warning(
-            "No dataset files found for pattern: %s", settings.dataset.glob_pattern
-        )
+    utterances = load_utterances()
+    if utterances is None:
         return None
 
-    samples: list[LabeledAudioSample] = []
-    parse_errors: list[str] = []
-    for file_path in files:
-        file_name: str = os.path.basename(file_path)
-        emotion_code: str | None = _extract_emotion_code(file_name)
-        if emotion_code is None:
-            parse_errors.append(
-                "Skipping file with unexpected name format "
-                f"(missing emotion code): {file_name}"
-            )
-            continue
-        emotion: str | None = settings.emotions.get(emotion_code)
-        if not emotion or emotion not in observed_emotions:
-            continue
-        samples.append((file_path, emotion))
-
-    if parse_errors:
-        logger.warning(
-            "Skipped %s/%s files while resolving labels.",
-            len(parse_errors),
-            len(files),
-        )
-        for error in parse_errors[:5]:
-            logger.warning("%s", error)
-
-    failure_ratio: float = len(parse_errors) / float(len(files))
-    if failure_ratio > settings.data_loader.max_failed_file_ratio:
-        raise RuntimeError(
-            "Aborting data load: "
-            f"{failure_ratio * 100.0:.1f}% file failures exceeded configured "
-            "limit "
-            f"{settings.data_loader.max_failed_file_ratio * 100.0:.1f}%."
-        )
-
-    if not samples:
-        logger.warning("No labeled audio samples matched configured emotions.")
-        return None
-
+    samples: list[LabeledAudioSample] = [
+        (str(utterance.audio_path), utterance.label) for utterance in utterances
+    ]
     labels: list[str] = [label for _, label in samples]
     if len(set(labels)) < 2:
         logger.warning("At least two emotion classes are required to train the model.")

--- a/ser/data/data_loader.py
+++ b/ser/data/data_loader.py
@@ -49,7 +49,9 @@ def _resolve_label_ontology(settings: AppConfig) -> LabelOntology:
             if normalize_label(item)
         }
     else:
-        allowed_labels = {normalize_label(label) for label in settings.emotions.values()}
+        allowed_labels = {
+            normalize_label(label) for label in settings.emotions.values()
+        }
     if not allowed_labels:
         raise RuntimeError(
             "Resolved label ontology contains zero allowed labels. "
@@ -73,7 +75,9 @@ def load_utterances() -> list[Utterance] | None:
     if manifest_paths:
         utterances: list[Utterance] = []
         for manifest_path in manifest_paths:
-            utterances.extend(load_manifest_jsonl(Path(manifest_path), ontology=ontology))
+            utterances.extend(
+                load_manifest_jsonl(Path(manifest_path), ontology=ontology)
+            )
         if not utterances:
             logger.warning("No utterances loaded from configured manifests.")
             return None
@@ -90,7 +94,9 @@ def load_utterances() -> list[Utterance] | None:
             )
         labels = [utterance.label for utterance in utterances]
         if len(set(labels)) < 2:
-            logger.warning("At least two emotion classes are required to train the model.")
+            logger.warning(
+                "At least two emotion classes are required to train the model."
+            )
             return None
         return utterances
 

--- a/ser/data/manifest.py
+++ b/ser/data/manifest.py
@@ -1,0 +1,172 @@
+"""Manifest schema for multi-corpus SER training."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, cast
+
+from ser.data.ontology import LabelOntology, ensure_label_allowed, normalize_label
+
+MANIFEST_SCHEMA_VERSION = 1
+
+type SplitName = Literal["train", "dev", "test"]
+
+
+def _read_text_field(record: Mapping[str, object], field: str) -> str | None:
+    raw = record.get(field)
+    if isinstance(raw, str) and raw.strip():
+        return raw.strip()
+    return None
+
+
+def _read_float_field(record: Mapping[str, object], field: str) -> float | None:
+    raw = record.get(field)
+    if isinstance(raw, int | float):
+        return float(raw)
+    return None
+
+
+def _resolve_audio_path(path_text: str, *, base_dir: Path) -> Path:
+    candidate = Path(path_text).expanduser()
+    if candidate.is_absolute():
+        return candidate
+    return (base_dir / candidate).expanduser()
+
+
+def _to_optional_split(value: str | None) -> SplitName | None:
+    if value in {"train", "dev", "test"}:
+        return cast(SplitName, value)
+    return None
+
+
+def _maybe_relative(path: Path, *, base_dir: Path) -> Path:
+    try:
+        return path.relative_to(base_dir)
+    except ValueError:
+        return path
+
+
+@dataclass(frozen=True)
+class Utterance:
+    """One training/inference-ready supervised utterance record."""
+
+    schema_version: int
+    sample_id: str
+    corpus: str
+    audio_path: Path
+    label: str
+    raw_label: str | None = None
+    speaker_id: str | None = None
+    language: str | None = None
+    split: SplitName | None = None
+    start_seconds: float | None = None
+    duration_seconds: float | None = None
+    dataset_policy_id: str | None = None
+    dataset_license_id: str | None = None
+    source_url: str | None = None
+
+    def validate(self, *, ontology: LabelOntology) -> None:
+        """Validates record invariants for robust multi-corpus loading."""
+        if self.schema_version != MANIFEST_SCHEMA_VERSION:
+            raise ValueError(
+                f"Unsupported manifest schema version {self.schema_version!r}; "
+                f"expected {MANIFEST_SCHEMA_VERSION}."
+            )
+        if not self.sample_id.strip():
+            raise ValueError("Utterance.sample_id must be non-empty.")
+        if not self.corpus.strip():
+            raise ValueError("Utterance.corpus must be non-empty.")
+        if not isinstance(self.audio_path, Path):
+            raise ValueError("Utterance.audio_path must be a Path.")
+        if not str(self.audio_path).strip():
+            raise ValueError("Utterance.audio_path must be non-empty.")
+        ensure_label_allowed(label=self.label, ontology=ontology)
+        if self.speaker_id is not None:
+            expected_prefix = f"{self.corpus}:"
+            if not self.speaker_id.startswith(expected_prefix):
+                raise ValueError(
+                    "speaker_id must be corpus-scoped to avoid collisions: "
+                    f"expected prefix {expected_prefix!r} in {self.speaker_id!r}."
+                )
+        if self.start_seconds is not None and self.start_seconds < 0.0:
+            raise ValueError("start_seconds must be non-negative.")
+        if self.duration_seconds is not None and self.duration_seconds <= 0.0:
+            raise ValueError("duration_seconds must be positive when provided.")
+
+    @staticmethod
+    def from_record(
+        record: Mapping[str, object],
+        *,
+        base_dir: Path,
+        ontology: LabelOntology,
+    ) -> Utterance:
+        """Builds one validated utterance from a JSON-like manifest record."""
+        schema_version_raw = record.get("schema_version", MANIFEST_SCHEMA_VERSION)
+        schema_version = (
+            int(schema_version_raw)
+            if isinstance(schema_version_raw, int)
+            else MANIFEST_SCHEMA_VERSION
+        )
+        sample_id = _read_text_field(record, "sample_id")
+        corpus = _read_text_field(record, "corpus")
+        audio_path_text = _read_text_field(record, "audio_path") or _read_text_field(
+            record, "path"
+        )
+        label_text = _read_text_field(record, "label")
+        if sample_id is None or corpus is None or audio_path_text is None:
+            raise ValueError(
+                "Manifest record must include sample_id, corpus, and audio_path."
+            )
+        if label_text is None:
+            raise ValueError("Manifest record must include a non-empty label.")
+
+        utterance = Utterance(
+            schema_version=schema_version,
+            sample_id=sample_id,
+            corpus=corpus,
+            audio_path=_resolve_audio_path(audio_path_text, base_dir=base_dir),
+            label=normalize_label(label_text),
+            raw_label=_read_text_field(record, "raw_label"),
+            speaker_id=_read_text_field(record, "speaker_id"),
+            language=_read_text_field(record, "language"),
+            split=_to_optional_split(_read_text_field(record, "split")),
+            start_seconds=_read_float_field(record, "start_seconds"),
+            duration_seconds=_read_float_field(record, "duration_seconds"),
+            dataset_policy_id=_read_text_field(record, "dataset_policy_id"),
+            dataset_license_id=_read_text_field(record, "dataset_license_id"),
+            source_url=_read_text_field(record, "source_url"),
+        )
+        utterance.validate(ontology=ontology)
+        return utterance
+
+    def to_record(self, *, base_dir: Path | None = None) -> dict[str, object]:
+        """Serializes one utterance into a JSON-compatible dictionary."""
+        path_value = (
+            str(_maybe_relative(self.audio_path, base_dir=base_dir))
+            if base_dir is not None
+            else str(self.audio_path)
+        )
+        record: dict[str, object] = {
+            "schema_version": self.schema_version,
+            "sample_id": self.sample_id,
+            "corpus": self.corpus,
+            "audio_path": path_value,
+            "label": self.label,
+        }
+        optional_fields: dict[str, object | None] = {
+            "raw_label": self.raw_label,
+            "speaker_id": self.speaker_id,
+            "language": self.language,
+            "split": self.split,
+            "start_seconds": self.start_seconds,
+            "duration_seconds": self.duration_seconds,
+            "dataset_policy_id": self.dataset_policy_id,
+            "dataset_license_id": self.dataset_license_id,
+            "source_url": self.source_url,
+        }
+        for key, value in optional_fields.items():
+            if value is not None:
+                record[key] = value
+        return record

--- a/ser/data/manifest_jsonl.py
+++ b/ser/data/manifest_jsonl.py
@@ -1,0 +1,65 @@
+"""JSONL helpers for multi-corpus SER manifest files."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+from pathlib import Path
+from typing import cast
+
+from ser.data.manifest import Utterance
+from ser.data.ontology import LabelOntology
+
+
+def load_manifest_jsonl(
+    path: Path,
+    *,
+    ontology: LabelOntology,
+    base_dir: Path | None = None,
+) -> list[Utterance]:
+    """Loads one manifest JSONL file into validated utterances."""
+    resolved_base_dir = base_dir if base_dir is not None else path.parent
+    utterances: list[Utterance] = []
+    seen_sample_ids: set[str] = set()
+    with path.open("r", encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            raw = line.strip()
+            if not raw or raw.startswith("#"):
+                continue
+            try:
+                payload = json.loads(raw)
+            except json.JSONDecodeError as err:
+                raise ValueError(
+                    f"Invalid JSON in manifest {path} at line {line_number}: {err}"
+                ) from err
+            if not isinstance(payload, dict):
+                raise ValueError(
+                    f"Manifest {path} line {line_number} must be a JSON object."
+                )
+            utterance = Utterance.from_record(
+                cast(dict[str, object], payload),
+                base_dir=resolved_base_dir,
+                ontology=ontology,
+            )
+            if utterance.sample_id in seen_sample_ids:
+                raise ValueError(
+                    f"Duplicate sample_id {utterance.sample_id!r} in manifest {path}."
+                )
+            seen_sample_ids.add(utterance.sample_id)
+            utterances.append(utterance)
+    return utterances
+
+
+def write_manifest_jsonl(
+    path: Path,
+    utterances: Sequence[Utterance],
+    *,
+    base_dir: Path | None = None,
+) -> None:
+    """Writes utterances to deterministic JSONL records."""
+    resolved_base_dir = base_dir if base_dir is not None else path.parent
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        for utterance in utterances:
+            handle.write(json.dumps(utterance.to_record(base_dir=resolved_base_dir)))
+            handle.write("\n")

--- a/ser/data/ontology.py
+++ b/ser/data/ontology.py
@@ -1,0 +1,57 @@
+"""Canonical label ontology utilities for multi-corpus SER training."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Literal
+
+type UnknownLabelPolicy = Literal["drop", "error", "map_to_other"]
+
+
+@dataclass(frozen=True)
+class LabelOntology:
+    """Defines canonical labels and unknown-label behavior for adapters/loaders."""
+
+    ontology_id: str
+    allowed_labels: frozenset[str]
+    unknown_label_policy: UnknownLabelPolicy = "drop"
+    other_label: str = "other"
+
+
+def normalize_label(label: str) -> str:
+    """Normalizes labels for stable cross-corpus comparisons."""
+    return label.strip().lower()
+
+
+def ensure_label_allowed(*, label: str, ontology: LabelOntology) -> None:
+    """Raises when a label is not part of the configured ontology."""
+    if label not in ontology.allowed_labels:
+        raise ValueError(
+            f"Label {label!r} is not part of ontology {ontology.ontology_id!r}."
+        )
+
+
+def remap_label(
+    *,
+    raw_label: str,
+    mapping: Mapping[str, str] | None,
+    ontology: LabelOntology,
+) -> str | None:
+    """Maps one raw corpus label into the configured canonical ontology."""
+    source = raw_label.strip()
+    mapped = mapping.get(source, "") if mapping is not None else source
+    canonical = normalize_label(mapped) if mapped else ""
+    if canonical and canonical in ontology.allowed_labels:
+        return canonical
+
+    policy = ontology.unknown_label_policy
+    if policy == "drop":
+        return None
+    if policy == "map_to_other":
+        other = normalize_label(ontology.other_label)
+        ensure_label_allowed(label=other, ontology=ontology)
+        return other
+    raise ValueError(
+        f"Unknown label {raw_label!r} under ontology {ontology.ontology_id!r}."
+    )

--- a/ser/models/emotion_model.py
+++ b/ser/models/emotion_model.py
@@ -1057,7 +1057,9 @@ def _split_utterances(
                     speaker_id_coverage=speaker_coverage,
                     train_unique_speakers=len(train_speakers),
                     test_unique_speakers=len(test_speakers),
-                    speaker_overlap_count=len(train_speakers.intersection(test_speakers)),
+                    speaker_overlap_count=len(
+                        train_speakers.intersection(test_speakers)
+                    ),
                 ),
             )
 
@@ -1659,7 +1661,7 @@ def train_accurate_model() -> None:
                 "train_unique_speakers": split_metadata.train_unique_speakers,
                 "test_unique_speakers": split_metadata.test_unique_speakers,
                 "speaker_overlap_count": split_metadata.speaker_overlap_count,
-            }
+            },
         },
     )
     _persist_training_report(report, settings.models.training_report_file)
@@ -1787,7 +1789,7 @@ def train_accurate_research_model() -> None:
                 "train_unique_speakers": split_metadata.train_unique_speakers,
                 "test_unique_speakers": split_metadata.test_unique_speakers,
                 "speaker_overlap_count": split_metadata.speaker_overlap_count,
-            }
+            },
         },
     )
     _persist_training_report(report, settings.models.training_report_file)

--- a/tests/test_config_feature_flags.py
+++ b/tests/test_config_feature_flags.py
@@ -93,6 +93,7 @@ def test_runtime_flags_and_schema_defaults() -> None:
     assert settings.models.model_file_name == "ser_model.pkl"
     assert settings.models.secure_model_file_name == "ser_model.skops"
     assert settings.models.training_report_file_name == "training_report.json"
+    assert settings.dataset.manifest_paths == ()
 
 
 def test_runtime_flags_and_schema_env_overrides(
@@ -144,6 +145,10 @@ def test_runtime_flags_and_schema_env_overrides(
     monkeypatch.setenv("SER_ARTIFACT_SCHEMA_VERSION", "v3")
     monkeypatch.setenv("SER_TORCH_DEVICE", "cuda:0")
     monkeypatch.setenv("SER_TORCH_DTYPE", "bfloat16")
+    monkeypatch.setenv(
+        "SER_DATASET_MANIFESTS",
+        "unit-test/manifest_a.jsonl,unit-test/manifest_b.jsonl",
+    )
     monkeypatch.setenv("SER_MODEL_CACHE_DIR", "unit-test/model-cache")
     monkeypatch.setenv("SER_MEDIUM_MODEL_ID", "unit-test/xlsr")
     monkeypatch.setenv("SER_ACCURATE_MODEL_ID", "unit-test/whisper-tiny")
@@ -207,6 +212,10 @@ def test_runtime_flags_and_schema_env_overrides(
     assert settings.schema.artifact_schema_version == "v3"
     assert settings.torch_runtime.device == "cuda:0"
     assert settings.torch_runtime.dtype == "bfloat16"
+    assert settings.dataset.manifest_paths == (
+        Path("unit-test/manifest_a.jsonl"),
+        Path("unit-test/manifest_b.jsonl"),
+    )
     assert settings.models.model_cache_dir == Path("unit-test/model-cache")
     assert settings.models.huggingface_cache_root == Path(
         "unit-test/model-cache/huggingface"

--- a/tests/test_manifest_jsonl.py
+++ b/tests/test_manifest_jsonl.py
@@ -87,8 +87,14 @@ def test_remap_label_honors_unknown_policy() -> None:
         unknown_label_policy="error",
     )
 
-    assert remap_label(raw_label="03", mapping={"03": "happy"}, ontology=ontology_drop) == "happy"
-    assert remap_label(raw_label="99", mapping={"03": "happy"}, ontology=ontology_drop) is None
+    assert (
+        remap_label(raw_label="03", mapping={"03": "happy"}, ontology=ontology_drop)
+        == "happy"
+    )
+    assert (
+        remap_label(raw_label="99", mapping={"03": "happy"}, ontology=ontology_drop)
+        is None
+    )
     assert (
         remap_label(raw_label="99", mapping={"03": "happy"}, ontology=ontology_other)
         == "other"

--- a/tests/test_manifest_jsonl.py
+++ b/tests/test_manifest_jsonl.py
@@ -1,0 +1,97 @@
+"""Tests for manifest schema and JSONL loading utilities."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ser.data.manifest import MANIFEST_SCHEMA_VERSION, Utterance
+from ser.data.manifest_jsonl import load_manifest_jsonl, write_manifest_jsonl
+from ser.data.ontology import LabelOntology, remap_label
+
+
+def _ontology() -> LabelOntology:
+    return LabelOntology(
+        ontology_id="basic_v1",
+        allowed_labels=frozenset({"happy", "sad", "other"}),
+    )
+
+
+def test_manifest_loader_rejects_non_scoped_speaker_id(tmp_path: Path) -> None:
+    """speaker_id must be prefixed by corpus id."""
+    path = tmp_path / "bad.jsonl"
+    path.write_text(
+        (
+            '{"schema_version": 1, "sample_id": "id:1", "corpus": "ravdess", '
+            '"audio_path": "a.wav", "label": "happy", "speaker_id": "42"}\n'
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="speaker_id must be corpus-scoped"):
+        load_manifest_jsonl(path, ontology=_ontology())
+
+
+def test_manifest_loader_round_trip(tmp_path: Path) -> None:
+    """Writer and loader should preserve record essentials."""
+    path = tmp_path / "dataset.jsonl"
+    utterances = [
+        Utterance(
+            schema_version=MANIFEST_SCHEMA_VERSION,
+            sample_id="ravdess:a.wav",
+            corpus="ravdess",
+            audio_path=tmp_path / "audio" / "a.wav",
+            label="happy",
+            speaker_id="ravdess:1",
+            language="en",
+            split="train",
+        ),
+        Utterance(
+            schema_version=MANIFEST_SCHEMA_VERSION,
+            sample_id="ravdess:b.wav",
+            corpus="ravdess",
+            audio_path=tmp_path / "audio" / "b.wav",
+            label="sad",
+            speaker_id="ravdess:2",
+            language="en",
+            split="test",
+            start_seconds=1.5,
+            duration_seconds=2.0,
+        ),
+    ]
+
+    write_manifest_jsonl(path, utterances, base_dir=tmp_path)
+    loaded = load_manifest_jsonl(path, ontology=_ontology(), base_dir=tmp_path)
+
+    assert [item.sample_id for item in loaded] == ["ravdess:a.wav", "ravdess:b.wav"]
+    assert loaded[1].start_seconds == pytest.approx(1.5)
+    assert loaded[1].duration_seconds == pytest.approx(2.0)
+
+
+def test_remap_label_honors_unknown_policy() -> None:
+    """Unknown label policy should gate adapter remapping behavior."""
+    ontology_drop = LabelOntology(
+        ontology_id="drop_v1",
+        allowed_labels=frozenset({"happy", "sad", "other"}),
+        unknown_label_policy="drop",
+    )
+    ontology_other = LabelOntology(
+        ontology_id="other_v1",
+        allowed_labels=frozenset({"happy", "sad", "other"}),
+        unknown_label_policy="map_to_other",
+    )
+    ontology_error = LabelOntology(
+        ontology_id="error_v1",
+        allowed_labels=frozenset({"happy", "sad", "other"}),
+        unknown_label_policy="error",
+    )
+
+    assert remap_label(raw_label="03", mapping={"03": "happy"}, ontology=ontology_drop) == "happy"
+    assert remap_label(raw_label="99", mapping={"03": "happy"}, ontology=ontology_drop) is None
+    assert (
+        remap_label(raw_label="99", mapping={"03": "happy"}, ontology=ontology_other)
+        == "other"
+    )
+    with pytest.raises(ValueError, match="Unknown label"):
+        remap_label(raw_label="99", mapping={"03": "happy"}, ontology=ontology_error)

--- a/tests/test_medium_quality_report.py
+++ b/tests/test_medium_quality_report.py
@@ -22,8 +22,7 @@ def _sample_utterance(
 ) -> Utterance:
     """Builds deterministic RAVDESS-like utterances."""
     path = Path(
-        "ser/dataset/ravdess/"
-        f"Actor_{actor_id:02d}/03-01-03-01-01-01-{actor_id:02d}.wav"
+        f"ser/dataset/ravdess/Actor_{actor_id:02d}/03-01-03-01-01-01-{actor_id:02d}.wav"
     )
     resolved_speaker = speaker_id
     if speaker_id == "auto":

--- a/tests/test_medium_quality_report.py
+++ b/tests/test_medium_quality_report.py
@@ -2,18 +2,41 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
+from typing import Literal
 
 import pytest
 
+from ser.data.manifest import MANIFEST_SCHEMA_VERSION, Utterance
 from ser.models import emotion_model as em
 
 
-def _sample_path(actor_id: int, emotion_code: str) -> str:
-    """Builds deterministic RAVDESS-style sample paths."""
-    return (
+def _sample_utterance(
+    actor_id: int,
+    emotion_label: str,
+    *,
+    speaker_id: str | None = "auto",
+    split: Literal["train", "dev", "test"] | None = None,
+    corpus: str = "ravdess",
+) -> Utterance:
+    """Builds deterministic RAVDESS-like utterances."""
+    path = Path(
         "ser/dataset/ravdess/"
-        f"Actor_{actor_id:02d}/03-01-{emotion_code}-01-01-01-{actor_id:02d}.wav"
+        f"Actor_{actor_id:02d}/03-01-03-01-01-01-{actor_id:02d}.wav"
+    )
+    resolved_speaker = speaker_id
+    if speaker_id == "auto":
+        resolved_speaker = f"ravdess:{actor_id:02d}"
+    return Utterance(
+        schema_version=MANIFEST_SCHEMA_VERSION,
+        sample_id=f"{corpus}:{path.as_posix()}:{emotion_label}",
+        corpus=corpus,
+        audio_path=path,
+        label=emotion_label,
+        speaker_id=resolved_speaker,
+        split=split,
+        language="en",
     )
 
 
@@ -33,19 +56,17 @@ def test_medium_split_prefers_grouped_strategy_when_speaker_ids_are_available(
         ),
     )
     samples = [
-        (_sample_path(1, "03"), "happy"),
-        (_sample_path(1, "04"), "sad"),
-        (_sample_path(2, "03"), "happy"),
-        (_sample_path(2, "04"), "sad"),
-        (_sample_path(3, "03"), "happy"),
-        (_sample_path(3, "04"), "sad"),
-        (_sample_path(4, "03"), "happy"),
-        (_sample_path(4, "04"), "sad"),
+        _sample_utterance(1, "happy"),
+        _sample_utterance(1, "sad"),
+        _sample_utterance(2, "happy"),
+        _sample_utterance(2, "sad"),
+        _sample_utterance(3, "happy"),
+        _sample_utterance(3, "sad"),
+        _sample_utterance(4, "happy"),
+        _sample_utterance(4, "sad"),
     ]
 
-    train_samples, test_samples, split_metadata = em._split_labeled_audio_samples(
-        samples
-    )
+    train_samples, test_samples, split_metadata = em._split_utterances(samples)
 
     assert train_samples
     assert test_samples
@@ -71,14 +92,31 @@ def test_medium_split_falls_back_when_speaker_metadata_is_incomplete(
         ),
     )
     samples = [
-        ("ser/dataset/ravdess/invalid_01.wav", "happy"),
-        ("ser/dataset/ravdess/invalid_02.wav", "sad"),
-        (_sample_path(3, "03"), "happy"),
-        (_sample_path(4, "04"), "sad"),
+        _sample_utterance(1, "happy", speaker_id=None, corpus="custom"),
+        _sample_utterance(2, "sad", speaker_id=None, corpus="custom"),
+        _sample_utterance(3, "happy"),
+        _sample_utterance(4, "sad"),
     ]
 
-    _, _, split_metadata = em._split_labeled_audio_samples(samples)
+    _, _, split_metadata = em._split_utterances(samples)
 
-    assert split_metadata.split_strategy == "stratified_shuffle_split_fallback"
+    assert split_metadata.split_strategy == "hash_stratified_split"
     assert split_metadata.speaker_grouped is False
     assert split_metadata.speaker_id_coverage == pytest.approx(0.5)
+
+
+def test_medium_split_prefers_explicit_manifest_split() -> None:
+    """Explicit manifest split tags should take priority over speaker grouping."""
+    samples = [
+        _sample_utterance(1, "happy", split="train"),
+        _sample_utterance(1, "sad", split="train"),
+        _sample_utterance(2, "happy", split="test"),
+        _sample_utterance(2, "sad", split="test"),
+    ]
+
+    train_samples, test_samples, split_metadata = em._split_utterances(samples)
+
+    assert len(train_samples) == 2
+    assert len(test_samples) == 2
+    assert split_metadata.split_strategy == "manifest_split"
+    assert split_metadata.speaker_grouped is False


### PR DESCRIPTION
## Summary

This PR moves training data ingestion to a typed manifest-first model while preserving legacy RAVDESS glob loading as a compatibility path.

## Scope

- Adds a typed Utterance contract with validation (ser/data/manifest.py).
- Adds deterministic JSONL manifest read/write helpers (ser/data/manifest_jsonl.py).
- Adds canonical ontology + unknown-label policy utilities (ser/data/ontology.py).
- Adds first adapter: RAVDESS -> Utterance (ser/data/adapters/ravdess.py).
- Adds manifest config surface via SER_DATASET_MANIFESTS (ser/config.py).
- Adds ontology controls in loader (SER_LABEL_ONTOLOGY_ID, SER_ALLOWED_LABELS, SER_UNKNOWN_LABEL_POLICY, SER_OTHER_LABEL) and new load_utterances() bridge (ser/data/data_loader.py).
- Keeps load_labeled_audio_paths() but re-bases it on load_utterances() for additive compatibility.
- Rewires medium/accurate/accurate-research training to operate on utterances and applies deterministic split precedence:
    1. explicit manifest split (train/dev/test)
    2. speaker-grouped split
    3. hash-stratified fallback (SER_SPLIT_SALT)
- Extends training report data controls with dataset mode, manifest paths, corpus counts, and language counts (ser/models/emotion_model.py).
- Updates docs/setup messaging for Darwin x86_64 macos13 Python 3.13 partial compatibility and runtime lane policy (README.md, scripts/setup_compatible_env.sh).

## Validation

- Adds/updates tests for:
    - manifest schema + JSONL round-trip and validation
    - ontology remap unknown-label policy behavior
    - manifest env parsing in config
    - loader manifest preference + duplicate sample_id fail-closed behavior
    - new split strategy behavior in medium-quality reporting
    - accurate/accurate-research training artifact flow under utterance-based loading