### PR TITLE
Harden transcription backend: MPS admission control, fallback retries, stable_whisper hacks, faster-whisper process isolation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
     hooks:
       - id: pyright
         name: pyright
-        entry: uv run --frozen --extra dev pyright ser tests
+        entry: uv run --frozen --extra dev pyright --pythonversion 3.12 ser tests
         language: system
         pass_filenames: false
         stages: [pre-push]

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ lint:
 
 type:
 	uv run mypy ser tests
-	uv run pyright ser tests
+	uv run pyright --pythonversion 3.12 ser tests
 
 test:
 	uv run pytest -q

--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ uv run ruff check ser
 uv run black --check ser
 uv run isort --check-only ser
 uv run mypy ser tests
-uv run pyright ser tests
+uv run pyright --pythonversion 3.12 ser tests
 ```
 
 ### Git Hooks

--- a/ser/data/adapters/__init__.py
+++ b/ser/data/adapters/__init__.py
@@ -1,4 +1,4 @@
-"""Dataset adapters that emit manifest-compatible utterances."""
+"""Dataset adapters for building training manifests."""
 
 from __future__ import annotations
 

--- a/ser/transcript/backends/__init__.py
+++ b/ser/transcript/backends/__init__.py
@@ -1,0 +1,17 @@
+"""Transcription backend adapters."""
+
+from .base import (
+    BackendRuntimeRequest,
+    CompatibilityIssue,
+    CompatibilityReport,
+    TranscriptionBackendAdapter,
+)
+from .factory import resolve_transcription_backend_adapter
+
+__all__ = [
+    "BackendRuntimeRequest",
+    "CompatibilityIssue",
+    "CompatibilityReport",
+    "TranscriptionBackendAdapter",
+    "resolve_transcription_backend_adapter",
+]

--- a/ser/transcript/backends/base.py
+++ b/ser/transcript/backends/base.py
@@ -1,0 +1,102 @@
+"""Adapter contracts for transcription backends."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Protocol
+
+from ser.domain import TranscriptWord
+from ser.profiles import TranscriptionBackendId
+
+if TYPE_CHECKING:
+    from ser.config import AppConfig
+
+
+@dataclass(frozen=True, slots=True)
+class CompatibilityIssue:
+    """One compatibility issue discovered for a backend adapter."""
+
+    code: str
+    message: str
+
+
+@dataclass(frozen=True, slots=True)
+class CompatibilityReport:
+    """Compatibility findings for one backend/runtime request."""
+
+    backend_id: TranscriptionBackendId
+    functional_issues: tuple[CompatibilityIssue, ...] = ()
+    operational_issues: tuple[CompatibilityIssue, ...] = ()
+    noise_issues: tuple[CompatibilityIssue, ...] = ()
+    policy_ids: tuple[str, ...] = ()
+
+    @property
+    def has_blocking_issues(self) -> bool:
+        """Returns whether functional compatibility issues block execution."""
+        return bool(self.functional_issues)
+
+
+@dataclass(frozen=True, slots=True)
+class BackendRuntimeRequest:
+    """Transcription runtime request scoped to backend behavior."""
+
+    model_name: str
+    use_demucs: bool
+    use_vad: bool
+
+
+class TranscriptionBackendAdapter(Protocol):
+    """Stable adapter boundary for transcription backend integrations."""
+
+    @property
+    def backend_id(self) -> TranscriptionBackendId:
+        """Returns canonical backend identifier."""
+        ...
+
+    def check_compatibility(
+        self,
+        *,
+        runtime_request: BackendRuntimeRequest,
+        settings: AppConfig,
+    ) -> CompatibilityReport:
+        """Returns compatibility report for one runtime request."""
+        ...
+
+    def setup_required(
+        self,
+        *,
+        runtime_request: BackendRuntimeRequest,
+        settings: AppConfig,
+    ) -> bool:
+        """Returns whether setup/download must run before model load."""
+        ...
+
+    def prepare_assets(
+        self,
+        *,
+        runtime_request: BackendRuntimeRequest,
+        settings: AppConfig,
+    ) -> None:
+        """Ensures backend assets exist before model loading."""
+        ...
+
+    def load_model(
+        self,
+        *,
+        runtime_request: BackendRuntimeRequest,
+        settings: AppConfig,
+    ) -> object:
+        """Loads and returns one model handle."""
+        ...
+
+    def transcribe(
+        self,
+        *,
+        model: object,
+        runtime_request: BackendRuntimeRequest,
+        file_path: str,
+        language: str,
+        settings: AppConfig,
+    ) -> list[TranscriptWord]:
+        """Runs transcription and returns word-level transcript rows."""
+        ...

--- a/ser/transcript/backends/base.py
+++ b/ser/transcript/backends/base.py
@@ -43,6 +43,10 @@ class BackendRuntimeRequest:
     model_name: str
     use_demucs: bool
     use_vad: bool
+    device_spec: str = "cpu"
+    device_type: str = "cpu"
+    precision_candidates: tuple[str, ...] = ("float32",)
+    memory_tier: str = "not_applicable"
 
 
 class TranscriptionBackendAdapter(Protocol):

--- a/ser/transcript/backends/factory.py
+++ b/ser/transcript/backends/factory.py
@@ -9,7 +9,9 @@ from ser.transcript.backends.base import TranscriptionBackendAdapter
 from ser.transcript.backends.faster_whisper import FasterWhisperAdapter
 from ser.transcript.backends.stable_whisper import StableWhisperAdapter
 
-_TRANSCRIPTION_ADAPTERS: Final[dict[TranscriptionBackendId, TranscriptionBackendAdapter]] = {
+_TRANSCRIPTION_ADAPTERS: Final[
+    dict[TranscriptionBackendId, TranscriptionBackendAdapter]
+] = {
     "stable_whisper": StableWhisperAdapter(),
     "faster_whisper": FasterWhisperAdapter(),
 }

--- a/ser/transcript/backends/factory.py
+++ b/ser/transcript/backends/factory.py
@@ -2,19 +2,24 @@
 
 from __future__ import annotations
 
-from typing import Final
+from functools import lru_cache
 
 from ser.profiles import TranscriptionBackendId
 from ser.transcript.backends.base import TranscriptionBackendAdapter
-from ser.transcript.backends.faster_whisper import FasterWhisperAdapter
-from ser.transcript.backends.stable_whisper import StableWhisperAdapter
 
-_TRANSCRIPTION_ADAPTERS: Final[
-    dict[TranscriptionBackendId, TranscriptionBackendAdapter]
-] = {
-    "stable_whisper": StableWhisperAdapter(),
-    "faster_whisper": FasterWhisperAdapter(),
-}
+
+@lru_cache(maxsize=2)
+def _build_adapter(backend_id: TranscriptionBackendId) -> TranscriptionBackendAdapter:
+    """Builds one backend adapter lazily to avoid importing unused heavy stacks."""
+    if backend_id == "stable_whisper":
+        from ser.transcript.backends.stable_whisper import StableWhisperAdapter
+
+        return StableWhisperAdapter()
+    if backend_id == "faster_whisper":
+        from ser.transcript.backends.faster_whisper import FasterWhisperAdapter
+
+        return FasterWhisperAdapter()
+    raise KeyError(backend_id)
 
 
 def resolve_transcription_backend_adapter(
@@ -22,7 +27,7 @@ def resolve_transcription_backend_adapter(
 ) -> TranscriptionBackendAdapter:
     """Returns one adapter implementation for the requested backend id."""
     try:
-        return _TRANSCRIPTION_ADAPTERS[backend_id]
+        return _build_adapter(backend_id)
     except KeyError as err:
         raise RuntimeError(
             f"Unsupported transcription backend id configured: {backend_id!r}."

--- a/ser/transcript/backends/factory.py
+++ b/ser/transcript/backends/factory.py
@@ -1,0 +1,27 @@
+"""Factory for transcription backend adapters."""
+
+from __future__ import annotations
+
+from typing import Final
+
+from ser.profiles import TranscriptionBackendId
+from ser.transcript.backends.base import TranscriptionBackendAdapter
+from ser.transcript.backends.faster_whisper import FasterWhisperAdapter
+from ser.transcript.backends.stable_whisper import StableWhisperAdapter
+
+_TRANSCRIPTION_ADAPTERS: Final[dict[TranscriptionBackendId, TranscriptionBackendAdapter]] = {
+    "stable_whisper": StableWhisperAdapter(),
+    "faster_whisper": FasterWhisperAdapter(),
+}
+
+
+def resolve_transcription_backend_adapter(
+    backend_id: TranscriptionBackendId,
+) -> TranscriptionBackendAdapter:
+    """Returns one adapter implementation for the requested backend id."""
+    try:
+        return _TRANSCRIPTION_ADAPTERS[backend_id]
+    except KeyError as err:
+        raise RuntimeError(
+            f"Unsupported transcription backend id configured: {backend_id!r}."
+        ) from err

--- a/ser/transcript/backends/faster_whisper.py
+++ b/ser/transcript/backends/faster_whisper.py
@@ -1,0 +1,262 @@
+"""Faster-whisper transcription adapter implementation."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import logging
+import os
+import sys
+from collections.abc import Iterable
+from pathlib import Path
+from typing import TYPE_CHECKING, cast
+
+from ser.domain import TranscriptWord
+from ser.profiles import TranscriptionBackendId
+from ser.runtime.phase_contract import PHASE_TRANSCRIPTION
+from ser.transcript.backends.base import (
+    BackendRuntimeRequest,
+    CompatibilityIssue,
+    CompatibilityReport,
+    TranscriptionBackendAdapter,
+)
+from ser.utils.logger import (
+    DependencyLogPolicy,
+    DependencyPolicyContext,
+    scoped_dependency_log_policy,
+)
+
+if TYPE_CHECKING:
+    from ser.config import AppConfig
+
+_FASTER_WHISPER_INFO_POLICY_ID = "faster_whisper.info_demotion"
+_FASTER_WHISPER_INFO_POLICY = DependencyLogPolicy(
+    logger_prefixes=frozenset({"faster_whisper"}),
+    backend_ids=frozenset({"faster_whisper"}),
+    phase_names=frozenset({PHASE_TRANSCRIPTION}),
+    op_tags=frozenset({"faster_whisper.transcribe"}),
+)
+
+
+class FasterWhisperAdapter(TranscriptionBackendAdapter):
+    """Adapter for faster-whisper backend behavior and compatibility checks."""
+
+    @property
+    def backend_id(self) -> TranscriptionBackendId:
+        """Returns canonical backend identifier."""
+        return "faster_whisper"
+
+    def check_compatibility(
+        self,
+        *,
+        runtime_request: BackendRuntimeRequest,
+        settings: AppConfig,
+    ) -> CompatibilityReport:
+        """Checks faster-whisper dependency/runtime compatibility."""
+        del settings
+        functional_issues: list[CompatibilityIssue] = []
+        operational_issues: list[CompatibilityIssue] = []
+        noise_issues: list[CompatibilityIssue] = [
+            CompatibilityIssue(
+                code="faster_whisper_info_chatter",
+                message=(
+                    "faster-whisper may emit verbose INFO dependency logs during "
+                    "transcription; scoped log demotion policy is required."
+                ),
+            )
+        ]
+        if not self._is_module_available("faster_whisper"):
+            functional_issues.append(
+                CompatibilityIssue(
+                    code="missing_dependency_faster_whisper",
+                    message=(
+                        "Missing faster-whisper dependencies for transcription backend "
+                        "'faster_whisper'. Install faster-whisper (for example, "
+                        "`uv sync --extra full`) or switch to `stable_whisper`."
+                    ),
+                )
+            )
+        if runtime_request.use_demucs:
+            operational_issues.append(
+                CompatibilityIssue(
+                    code="faster_whisper_demucs_unsupported",
+                    message=(
+                        "faster-whisper backend does not support demucs preprocessing; "
+                        "demucs flag will be ignored."
+                    ),
+                )
+            )
+        return CompatibilityReport(
+            backend_id="faster_whisper",
+            functional_issues=tuple(functional_issues),
+            operational_issues=tuple(operational_issues),
+            noise_issues=tuple(noise_issues),
+            policy_ids=(_FASTER_WHISPER_INFO_POLICY_ID,),
+        )
+
+    def setup_required(
+        self,
+        *,
+        runtime_request: BackendRuntimeRequest,
+        settings: AppConfig,
+    ) -> bool:
+        """Returns whether local faster-whisper cache is missing for model."""
+        model_name = runtime_request.model_name.strip()
+        if not model_name or Path(model_name).is_dir():
+            return False
+        try:
+            fw_utils = importlib.import_module("faster_whisper.utils")
+        except ModuleNotFoundError:
+            return False
+        download_model = getattr(fw_utils, "download_model", None)
+        if not callable(download_model):
+            return False
+        try:
+            model_path = download_model(
+                model_name,
+                local_files_only=True,
+                cache_dir=str(settings.models.whisper_download_root),
+            )
+        except Exception:
+            return True
+        if isinstance(model_path, str):
+            return not Path(model_path).is_dir()
+        path_getter = getattr(model_path, "__fspath__", None)
+        if not callable(path_getter):
+            return False
+        resolved_path = path_getter()
+        if not isinstance(resolved_path, str):
+            return False
+        return not Path(resolved_path).is_dir()
+
+    def prepare_assets(
+        self,
+        *,
+        runtime_request: BackendRuntimeRequest,
+        settings: AppConfig,
+    ) -> None:
+        """Downloads faster-whisper assets when absent from local cache."""
+        model_name = runtime_request.model_name.strip()
+        if not model_name or Path(model_name).is_dir():
+            return
+        try:
+            fw_utils = importlib.import_module("faster_whisper.utils")
+        except ModuleNotFoundError:
+            return
+        download_model = getattr(fw_utils, "download_model", None)
+        if not callable(download_model):
+            return
+        os.makedirs(settings.models.whisper_download_root, exist_ok=True)
+        download_model(
+            model_name,
+            local_files_only=False,
+            cache_dir=str(settings.models.whisper_download_root),
+        )
+
+    def load_model(
+        self,
+        *,
+        runtime_request: BackendRuntimeRequest,
+        settings: AppConfig,
+    ) -> object:
+        """Loads one faster-whisper model for CPU inference."""
+        try:
+            faster_whisper_module = importlib.import_module("faster_whisper")
+        except ModuleNotFoundError as err:
+            raise RuntimeError(
+                "Missing faster-whisper dependencies for transcription backend "
+                "'faster_whisper'. Install faster-whisper (for example, "
+                "`uv sync --extra full`) or switch to `stable_whisper`."
+            ) from err
+        whisper_model = getattr(faster_whisper_module, "WhisperModel", None)
+        if whisper_model is None:
+            raise RuntimeError(
+                "faster-whisper package does not expose WhisperModel."
+            )
+        download_root: Path = settings.models.whisper_download_root
+        os.makedirs(download_root, exist_ok=True)
+        return whisper_model(
+            runtime_request.model_name,
+            device="cpu",
+            compute_type="int8",
+            download_root=str(download_root),
+        )
+
+    def transcribe(
+        self,
+        *,
+        model: object,
+        runtime_request: BackendRuntimeRequest,
+        file_path: str,
+        language: str,
+        settings: AppConfig,
+    ) -> list[TranscriptWord]:
+        """Runs one faster-whisper transcription call and formats words."""
+        del settings
+        transcribe = getattr(model, "transcribe", None)
+        if not callable(transcribe):
+            raise RuntimeError(
+                "Loaded faster-whisper model does not expose a callable transcribe()."
+            )
+        if runtime_request.use_demucs:
+            logging.getLogger(__name__).warning(
+                "faster-whisper backend does not support demucs preprocessing; "
+                "demucs flag is ignored."
+            )
+        raw_transcribe_result: object
+        try:
+            with scoped_dependency_log_policy(
+                policy=_FASTER_WHISPER_INFO_POLICY,
+                context=DependencyPolicyContext(
+                    backend_id=self.backend_id,
+                    phase_name=PHASE_TRANSCRIPTION,
+                    op_tag="faster_whisper.transcribe",
+                ),
+                keep_demoted=True,
+            ):
+                raw_transcribe_result = transcribe(
+                    audio=file_path,
+                    language=language,
+                    word_timestamps=True,
+                    vad_filter=runtime_request.use_vad,
+                    beam_size=5,
+                )
+        except Exception as err:
+            raise RuntimeError("Failed to transcribe audio.") from err
+        if not isinstance(raw_transcribe_result, tuple) or len(raw_transcribe_result) != 2:
+            raise RuntimeError(
+                "Unexpected result envelope returned by faster-whisper transcribe()."
+            )
+        segments = raw_transcribe_result[0]
+        if not isinstance(segments, Iterable):
+            raise RuntimeError(
+                "Unexpected segment stream type returned by faster-whisper."
+            )
+        transcript_words: list[TranscriptWord] = []
+        for segment in cast(Iterable[object], segments):
+            words = getattr(segment, "words", None)
+            if not isinstance(words, list | tuple):
+                continue
+            for word in words:
+                start = getattr(word, "start", None)
+                end = getattr(word, "end", None)
+                if start is None or end is None:
+                    continue
+                transcript_words.append(
+                    TranscriptWord(
+                        word=str(getattr(word, "word", "")),
+                        start_seconds=float(start),
+                        end_seconds=float(end),
+                    )
+                )
+        return transcript_words
+
+    @staticmethod
+    def _is_module_available(module_name: str) -> bool:
+        """Returns whether one Python module is available or already loaded."""
+        if module_name in sys.modules:
+            return True
+        try:
+            return importlib.util.find_spec(module_name) is not None
+        except ValueError:
+            return module_name in sys.modules

--- a/ser/transcript/backends/faster_whisper.py
+++ b/ser/transcript/backends/faster_whisper.py
@@ -170,9 +170,7 @@ class FasterWhisperAdapter(TranscriptionBackendAdapter):
             ) from err
         whisper_model = getattr(faster_whisper_module, "WhisperModel", None)
         if whisper_model is None:
-            raise RuntimeError(
-                "faster-whisper package does not expose WhisperModel."
-            )
+            raise RuntimeError("faster-whisper package does not expose WhisperModel.")
         download_root: Path = settings.models.whisper_download_root
         os.makedirs(download_root, exist_ok=True)
         return whisper_model(
@@ -223,7 +221,10 @@ class FasterWhisperAdapter(TranscriptionBackendAdapter):
                 )
         except Exception as err:
             raise RuntimeError("Failed to transcribe audio.") from err
-        if not isinstance(raw_transcribe_result, tuple) or len(raw_transcribe_result) != 2:
+        if (
+            not isinstance(raw_transcribe_result, tuple)
+            or len(raw_transcribe_result) != 2
+        ):
             raise RuntimeError(
                 "Unexpected result envelope returned by faster-whisper transcribe()."
             )

--- a/ser/transcript/backends/stable_whisper.py
+++ b/ser/transcript/backends/stable_whisper.py
@@ -2,14 +2,18 @@
 
 from __future__ import annotations
 
+import gc
 import importlib
 import importlib.util
 import inspect
+import logging
 import os
 import sys
 from collections.abc import Callable
+from contextlib import nullcontext
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from types import ModuleType
+from typing import TYPE_CHECKING, Literal, cast
 from urllib.parse import urlparse
 
 from ser.domain import TranscriptWord
@@ -24,11 +28,35 @@ from ser.transcript.backends.base import (
     CompatibilityReport,
     TranscriptionBackendAdapter,
 )
+from ser.transcript.backends.stable_whisper_mps_compat import (
+    enable_stable_whisper_mps_compatibility,
+    get_stable_whisper_runtime_device,
+    is_stable_whisper_mps_compatibility_enabled,
+    set_stable_whisper_mps_compatibility_enabled,
+    set_stable_whisper_runtime_device,
+    stable_whisper_mps_timing_compatibility_context,
+)
+from ser.transcript.mps_admission import (
+    MpsAdmissionDecision,
+    decide_mps_admission_for_transcription,
+    format_gib_short,
+)
+from ser.transcript.mps_admission_overrides import (
+    apply_calibrated_mps_admission_override,
+)
+from ser.transcript.runtime_failures import (
+    FailureDisposition,
+    TranscriptionFailureClassification,
+    classify_stable_whisper_transcription_failure,
+)
 from ser.utils.logger import (
     DependencyLogPolicy,
     DependencyPolicyContext,
     WarningPolicy,
     scoped_dependency_log_policy,
+)
+from ser.utils.transcription_compat import (
+    has_known_stable_whisper_sparse_mps_incompatibility,
 )
 
 if TYPE_CHECKING:
@@ -127,7 +155,8 @@ class StableWhisperAdapter(TranscriptionBackendAdapter):
                 code="stable_whisper_fp16_cpu_fallback_warning",
                 message=(
                     "stable-whisper may emit a CPU fp16 fallback UserWarning "
-                    "during transcription; adapter sets fp16=False and uses a "
+                    "during transcription; adapter resolves device-aware precision "
+                    "and uses a "
                     "scoped warning policy fallback."
                 ),
             ),
@@ -213,7 +242,7 @@ class StableWhisperAdapter(TranscriptionBackendAdapter):
         runtime_request: BackendRuntimeRequest,
         settings: AppConfig,
     ) -> object:
-        """Loads one stable-whisper model for CPU inference."""
+        """Loads one stable-whisper model for resolved runtime device inference."""
         with scoped_dependency_log_policy(
             policy=_STABLE_WHISPER_IMPORT_POLICY,
             context=DependencyPolicyContext(
@@ -240,13 +269,113 @@ class StableWhisperAdapter(TranscriptionBackendAdapter):
                 raise RuntimeError(
                     "stable-whisper package does not expose a callable load_model()."
                 )
-            model = load_model(
-                name=runtime_request.model_name,
-                device="cpu",
-                dq=False,
-                download_root=str(download_root),
-                in_memory=True,
-            )
+            if runtime_request.device_type == "mps":
+                load_admission = self._resolve_mps_admission_decision(
+                    settings=settings,
+                    runtime_request=runtime_request,
+                    phase="model_load",
+                )
+                if load_admission is not None and not load_admission.allow_mps:
+                    self._log_mps_admission_control_fallback(
+                        phase="model_load",
+                        decision=load_admission,
+                    )
+                    model = load_model(
+                        name=runtime_request.model_name,
+                        device="cpu",
+                        dq=False,
+                        download_root=str(download_root),
+                        in_memory=True,
+                    )
+                    set_stable_whisper_mps_compatibility_enabled(
+                        model,
+                        enabled=False,
+                    )
+                    set_stable_whisper_runtime_device(model, device_type="cpu")
+                else:
+                    model = load_model(
+                        name=runtime_request.model_name,
+                        device="cpu",
+                        dq=False,
+                        download_root=str(download_root),
+                        in_memory=True,
+                    )
+                    set_stable_whisper_runtime_device(model, device_type="cpu")
+                    try:
+                        model = enable_stable_whisper_mps_compatibility(model)
+                    except Exception as err:
+                        if not self._is_retryable_precision_failure(err):
+                            raise
+                        self._release_torch_runtime_memory_for_retry()
+                        error_summary = self._summarize_runtime_error(err)
+                        logging.getLogger(__name__).warning(
+                            "MPS compatibility mode failed; using cpu runtime (%s).",
+                            error_summary,
+                        )
+                        set_stable_whisper_mps_compatibility_enabled(
+                            model,
+                            enabled=False,
+                        )
+                        set_stable_whisper_runtime_device(model, device_type="cpu")
+                    else:
+                        set_stable_whisper_runtime_device(model, device_type="mps")
+                        if has_known_stable_whisper_sparse_mps_incompatibility():
+                            logging.getLogger(__name__).info(
+                                "MPS compatibility mode enabled "
+                                "(sparse_mps_operator_gap_detected)."
+                            )
+                        else:
+                            logging.getLogger(__name__).info(
+                                "MPS compatibility mode enabled."
+                            )
+            else:
+                try:
+                    model = load_model(
+                        name=runtime_request.model_name,
+                        device=runtime_request.device_spec,
+                        dq=False,
+                        download_root=str(download_root),
+                        in_memory=True,
+                    )
+                    set_stable_whisper_runtime_device(
+                        model,
+                        device_type=runtime_request.device_type,
+                    )
+                except Exception as err:
+                    should_retry_on_cpu = runtime_request.device_type in {
+                        "mps",
+                        "cuda",
+                    } and self._is_retryable_precision_failure(err)
+                    if not should_retry_on_cpu:
+                        raise
+                    self._release_torch_runtime_memory_for_retry()
+                    error_summary = self._summarize_runtime_error(err)
+                    logging.getLogger(__name__).warning(
+                        "Model load failed on %s due to retryable runtime "
+                        "error; retrying on cpu (%s).",
+                        runtime_request.device_spec,
+                        error_summary,
+                    )
+                    model = load_model(
+                        name=runtime_request.model_name,
+                        device="cpu",
+                        dq=False,
+                        download_root=str(download_root),
+                        in_memory=True,
+                    )
+                    set_stable_whisper_mps_compatibility_enabled(
+                        model,
+                        enabled=False,
+                    )
+                    set_stable_whisper_runtime_device(model, device_type="cpu")
+        resolved_device_type = get_stable_whisper_runtime_device(
+            model,
+            default_device_type=runtime_request.device_type,
+        )
+        logging.getLogger(__name__).info(
+            "Runtime device ready (%s).",
+            resolved_device_type,
+        )
         return model
 
     def transcribe(
@@ -259,33 +388,164 @@ class StableWhisperAdapter(TranscriptionBackendAdapter):
         settings: AppConfig,
     ) -> list[TranscriptWord]:
         """Runs one stable-whisper transcription call and formats word timings."""
-        del settings
         transcribe = getattr(model, "transcribe", None)
         if not callable(transcribe):
             raise RuntimeError(
                 "Loaded stable-whisper model does not expose a callable transcribe()."
             )
         typed_transcribe = cast(Callable[..., object], transcribe)
-        transcribe_kwargs = self._build_transcribe_kwargs(
-            transcribe_callable=typed_transcribe,
-            runtime_request=runtime_request,
-            file_path=file_path,
-            language=language,
+        runtime_device_type = get_stable_whisper_runtime_device(
+            model,
+            default_device_type=runtime_request.device_type,
         )
-        raw_transcript: object
-        try:
-            with scoped_dependency_log_policy(
-                policy=_STABLE_WHISPER_TRANSCRIBE_POLICY,
-                context=DependencyPolicyContext(
-                    backend_id=self.backend_id,
-                    phase_name=PHASE_TRANSCRIPTION,
-                    op_tag="stable_whisper.transcribe",
-                ),
-            ):
-                raw_transcript = typed_transcribe(**transcribe_kwargs)
-        except Exception as err:
-            raise RuntimeError("Failed to transcribe audio.") from err
-        return self._format_transcript(self._normalize_result(raw_transcript))
+        if runtime_device_type == "mps":
+            transcribe_admission = self._resolve_mps_admission_decision(
+                settings=settings,
+                runtime_request=runtime_request,
+                phase="transcribe",
+            )
+            if transcribe_admission is not None and not transcribe_admission.allow_mps:
+                if self._should_enforce_transcribe_admission(transcribe_admission):
+                    self._log_mps_admission_control_fallback(
+                        phase="transcribe",
+                        decision=transcribe_admission,
+                    )
+                    if self._move_model_to_cpu_runtime(model):
+                        set_stable_whisper_mps_compatibility_enabled(
+                            model,
+                            enabled=False,
+                        )
+                        set_stable_whisper_runtime_device(model, device_type="cpu")
+                        runtime_device_type = "cpu"
+                else:
+                    logging.getLogger(__name__).info(
+                        "MPS admission estimate below budget but confidence=%s; "
+                        "allowing one MPS attempt and relying on runtime fallback "
+                        "(reason=%s).",
+                        transcribe_admission.confidence,
+                        transcribe_admission.reason_code,
+                    )
+
+        precision_candidates = self._effective_precision_candidates(
+            runtime_request=runtime_request,
+            runtime_device_type=runtime_device_type,
+        )
+        last_error: Exception | None = None
+        for index, precision in enumerate(precision_candidates):
+            transcribe_kwargs = self._build_transcribe_kwargs(
+                transcribe_callable=typed_transcribe,
+                runtime_request=runtime_request,
+                file_path=file_path,
+                language=language,
+                precision=precision,
+            )
+            raw_transcript: object
+            try:
+                with scoped_dependency_log_policy(
+                    policy=_STABLE_WHISPER_TRANSCRIBE_POLICY,
+                    context=DependencyPolicyContext(
+                        backend_id=self.backend_id,
+                        phase_name=PHASE_TRANSCRIPTION,
+                        op_tag="stable_whisper.transcribe",
+                    ),
+                ):
+                    mps_compat_context = (
+                        stable_whisper_mps_timing_compatibility_context()
+                        if (
+                            runtime_device_type == "mps"
+                            and is_stable_whisper_mps_compatibility_enabled(model)
+                        )
+                        else nullcontext()
+                    )
+                    with mps_compat_context:
+                        raw_transcript = typed_transcribe(**transcribe_kwargs)
+                return self._format_transcript(self._normalize_result(raw_transcript))
+            except Exception as err:
+                last_error = err
+                failure_classification = self._classify_transcription_failure(
+                    err=err,
+                    runtime_device_type=runtime_device_type,
+                    precision=precision,
+                    settings=settings,
+                )
+                if failure_classification.is_retryable:
+                    self._release_torch_runtime_memory_for_retry()
+                should_force_cpu_now = (
+                    failure_classification.disposition
+                    == FailureDisposition.FAILOVER_CPU_NOW
+                    and runtime_device_type in {"mps", "cuda"}
+                )
+                is_final_candidate = index >= len(precision_candidates) - 1
+                is_terminal_candidate = is_final_candidate or should_force_cpu_now
+                if (
+                    is_terminal_candidate
+                    and failure_classification.is_retryable
+                    and runtime_device_type in {"mps", "cuda"}
+                ):
+                    error_summary = self._summarize_runtime_error(err)
+                    if should_force_cpu_now:
+                        logging.getLogger(__name__).info(
+                            "Transcription hard MPS OOM on %s; switching directly "
+                            "to cpu (reason=%s, error=%s).",
+                            precision,
+                            failure_classification.reason_code,
+                            error_summary,
+                        )
+                    else:
+                        logging.getLogger(__name__).warning(
+                            "Transcription retrying on cpu runtime after %s "
+                            "failure (%s).",
+                            runtime_device_type,
+                            error_summary,
+                        )
+                    if self._move_model_to_cpu_runtime(model):
+                        set_stable_whisper_mps_compatibility_enabled(
+                            model,
+                            enabled=False,
+                        )
+                        set_stable_whisper_runtime_device(model, device_type="cpu")
+                        runtime_device_type = "cpu"
+                        cpu_kwargs = self._build_transcribe_kwargs(
+                            transcribe_callable=typed_transcribe,
+                            runtime_request=BackendRuntimeRequest(
+                                model_name=runtime_request.model_name,
+                                use_demucs=runtime_request.use_demucs,
+                                use_vad=runtime_request.use_vad,
+                                device_spec="cpu",
+                                device_type="cpu",
+                                precision_candidates=("float32",),
+                                memory_tier="not_applicable",
+                            ),
+                            file_path=file_path,
+                            language=language,
+                            precision="float32",
+                        )
+                        try:
+                            raw_transcript = typed_transcribe(**cpu_kwargs)
+                            return self._format_transcript(
+                                self._normalize_result(raw_transcript)
+                            )
+                        except Exception as cpu_err:
+                            raise RuntimeError(
+                                "Failed to transcribe audio."
+                            ) from cpu_err
+
+                if (
+                    is_terminal_candidate
+                    or failure_classification.disposition
+                    == FailureDisposition.FAIL_FAST
+                ):
+                    raise RuntimeError("Failed to transcribe audio.") from err
+                logging.getLogger(__name__).warning(
+                    "Transcription retrying with fallback precision after "
+                    "failure using %s on %s: %s",
+                    precision,
+                    runtime_device_type,
+                    err,
+                )
+        if last_error is not None:
+            raise RuntimeError("Failed to transcribe audio.") from last_error
+        raise RuntimeError("Failed to transcribe audio.")
 
     @classmethod
     def _build_transcribe_kwargs(
@@ -295,6 +555,7 @@ class StableWhisperAdapter(TranscriptionBackendAdapter):
         runtime_request: BackendRuntimeRequest,
         file_path: str,
         language: str,
+        precision: str,
     ) -> dict[str, object]:
         """Builds stable-whisper transcribe kwargs for cross-version compatibility."""
         kwargs: dict[str, object] = {
@@ -309,7 +570,7 @@ class StableWhisperAdapter(TranscriptionBackendAdapter):
             transcribe_callable,
             parameter_name="fp16",
         ):
-            kwargs["fp16"] = False
+            kwargs["fp16"] = precision == "float16"
         if runtime_request.use_demucs:
             if cls._supports_keyword_argument(
                 transcribe_callable,
@@ -327,6 +588,218 @@ class StableWhisperAdapter(TranscriptionBackendAdapter):
         ):
             kwargs["demucs"] = False
         return kwargs
+
+    @staticmethod
+    def _is_retryable_precision_failure(err: Exception) -> bool:
+        """Returns whether one transcription failure may succeed on fallback precision."""
+        message = str(err).strip().lower()
+        if isinstance(err, NotImplementedError):
+            not_implemented_markers = (
+                "sparsemps",
+                "could not run",
+                "aten::",
+                "backend",
+                "mps",
+            )
+            if all(marker in message for marker in not_implemented_markers):
+                return True
+            if "std_mean" in message and "mps" in message:
+                return True
+        retryable_markers = (
+            "out of memory",
+            "mps backend out of memory",
+            "fp16 is not supported on cpu",
+            "fp16 is not supported",
+            "half precision is not supported",
+            "bfloat16 is not supported",
+            "unsupported dtype",
+            "sparsemps",
+            "aten::empty.memory_format",
+            "cannot convert a mps tensor to float64 dtype",
+            "std_mean.correction",
+        )
+        return any(marker in message for marker in retryable_markers)
+
+    @staticmethod
+    def _classify_transcription_failure(
+        *,
+        err: Exception,
+        runtime_device_type: str,
+        precision: str,
+        settings: AppConfig,
+    ) -> TranscriptionFailureClassification:
+        """Classifies one stable-whisper transcription failure into action buckets."""
+        classification = classify_stable_whisper_transcription_failure(
+            err=err,
+            runtime_device_type=runtime_device_type,
+            precision=precision,
+        )
+        if (
+            classification.disposition == FailureDisposition.FAILOVER_CPU_NOW
+            and not StableWhisperAdapter._mps_hard_oom_shortcut_enabled(settings)
+        ):
+            return TranscriptionFailureClassification(
+                disposition=FailureDisposition.RETRY_NEXT_PRECISION,
+                reason_code=f"{classification.reason_code}_disabled",
+                is_retryable=True,
+            )
+        return classification
+
+    @staticmethod
+    def _move_model_to_cpu_runtime(model: object) -> bool:
+        """Moves one loaded model to CPU runtime when supported by model object."""
+        to_method = getattr(model, "to", None)
+        if not callable(to_method):
+            return False
+        to_method(device="cpu")
+        return True
+
+    @staticmethod
+    def _effective_precision_candidates(
+        *,
+        runtime_request: BackendRuntimeRequest,
+        runtime_device_type: str,
+    ) -> tuple[str, ...]:
+        """Resolves one runtime precision order using actual loaded model device."""
+        if runtime_device_type == "cpu":
+            return ("float32",)
+        return runtime_request.precision_candidates or ("float32",)
+
+    @staticmethod
+    def _resolve_mps_admission_decision(
+        *,
+        settings: AppConfig,
+        runtime_request: BackendRuntimeRequest,
+        phase: Literal["model_load", "transcribe"],
+    ) -> MpsAdmissionDecision | None:
+        """Returns one dynamic MPS admission decision when control is enabled."""
+        if not StableWhisperAdapter._mps_admission_control_enabled(settings):
+            return None
+        transcription_settings = getattr(settings, "transcription", None)
+        configured_min_headroom_mb = getattr(
+            transcription_settings,
+            "mps_admission_min_headroom_mb",
+            64.0,
+        )
+        configured_safety_margin_mb = getattr(
+            transcription_settings,
+            "mps_admission_safety_margin_mb",
+            64.0,
+        )
+        min_headroom_mb = (
+            configured_min_headroom_mb
+            if isinstance(configured_min_headroom_mb, int | float)
+            and not isinstance(configured_min_headroom_mb, bool)
+            else 64.0
+        )
+        safety_margin_mb = (
+            configured_safety_margin_mb
+            if isinstance(configured_safety_margin_mb, int | float)
+            and not isinstance(configured_safety_margin_mb, bool)
+            else 64.0
+        )
+        heuristic_decision = decide_mps_admission_for_transcription(
+            model_name=runtime_request.model_name,
+            phase=phase,
+            min_headroom_mb=float(min_headroom_mb),
+            safety_margin_mb=float(safety_margin_mb),
+        )
+        resolved_decision = apply_calibrated_mps_admission_override(
+            settings=settings,
+            runtime_request=runtime_request,
+            phase=phase,
+            heuristic_decision=heuristic_decision,
+        )
+        if resolved_decision.reason_code != heuristic_decision.reason_code:
+            logging.getLogger(__name__).info(
+                "MPS admission calibrated override applied for %s "
+                "(model=%s, reason=%s, confidence=%s).",
+                phase,
+                runtime_request.model_name,
+                resolved_decision.reason_code,
+                resolved_decision.confidence,
+            )
+        return resolved_decision
+
+    @staticmethod
+    def _mps_admission_control_enabled(settings: AppConfig) -> bool:
+        """Returns whether dynamic MPS admission control is enabled by config."""
+        transcription_settings = getattr(settings, "transcription", None)
+        enabled = getattr(transcription_settings, "mps_admission_control_enabled", True)
+        return bool(enabled)
+
+    @staticmethod
+    def _mps_hard_oom_shortcut_enabled(settings: AppConfig) -> bool:
+        """Returns whether hard MPS OOM shortcut is enabled by config."""
+        transcription_settings = getattr(settings, "transcription", None)
+        enabled = getattr(transcription_settings, "mps_hard_oom_shortcut_enabled", True)
+        return bool(enabled)
+
+    @staticmethod
+    def _log_mps_admission_control_fallback(
+        *,
+        phase: str,
+        decision: MpsAdmissionDecision,
+    ) -> None:
+        """Logs one concise MPS admission-control fallback message."""
+        logging.getLogger(__name__).info(
+            "MPS admission control switched %s to cpu "
+            "(reason=%s, confidence=%s, required_%s=%s, available_%s=%s).",
+            phase,
+            decision.reason_code,
+            decision.confidence,
+            decision.required_metric,
+            format_gib_short(decision.required_bytes),
+            decision.available_metric,
+            format_gib_short(decision.available_bytes),
+        )
+
+    @staticmethod
+    def _should_enforce_transcribe_admission(decision: MpsAdmissionDecision) -> bool:
+        """Returns whether one pre-transcribe admission decision should be enforced."""
+        if decision.confidence == "high":
+            return True
+        return decision.reason_code == "mps_headroom_unknown_large_model"
+
+    @staticmethod
+    def _release_torch_runtime_memory_for_retry() -> None:
+        """Releases best-effort torch runtime caches before retry attempts."""
+        gc.collect()
+        torch_module = sys.modules.get("torch")
+        if not isinstance(torch_module, ModuleType):
+            return
+        mps_module = getattr(torch_module, "mps", None)
+        if isinstance(mps_module, ModuleType):
+            is_available = getattr(mps_module, "is_available", None)
+            empty_cache = getattr(mps_module, "empty_cache", None)
+            try:
+                if callable(is_available) and is_available() and callable(empty_cache):
+                    empty_cache()
+            except Exception:
+                logging.getLogger(__name__).debug(
+                    "Ignored failure while emptying torch MPS cache before retry.",
+                    exc_info=True,
+                )
+        cuda_module = getattr(torch_module, "cuda", None)
+        if isinstance(cuda_module, ModuleType):
+            is_available = getattr(cuda_module, "is_available", None)
+            empty_cache = getattr(cuda_module, "empty_cache", None)
+            try:
+                if callable(is_available) and is_available() and callable(empty_cache):
+                    empty_cache()
+            except Exception:
+                logging.getLogger(__name__).debug(
+                    "Ignored failure while emptying torch CUDA cache before retry.",
+                    exc_info=True,
+                )
+
+    @staticmethod
+    def _summarize_runtime_error(err: Exception, max_chars: int = 180) -> str:
+        """Returns one single-line runtime error summary for retry logs."""
+        normalized = " ".join(str(err).split())
+        if len(normalized) <= max_chars:
+            return normalized
+        return f"{normalized[: max_chars - 3]}..."
 
     @staticmethod
     def _supports_keyword_argument(

--- a/ser/transcript/backends/stable_whisper.py
+++ b/ser/transcript/backends/stable_whisper.py
@@ -38,12 +38,10 @@ _INVALID_ESCAPE_POLICY_ID = "stable_whisper.invalid_escape_sequence"
 _INVALID_ESCAPE_MESSAGE_REGEX = r"^invalid escape sequence '\\,'$"
 _INVALID_ESCAPE_MODULE_REGEX = r"^stable_whisper\.result$"
 _FP16_CPU_WARNING_POLICY_ID = "stable_whisper.fp16_cpu_fallback_warning"
-_FP16_CPU_WARNING_MESSAGE_REGEX = (
-    r"^FP16 is not supported on CPU; using FP32 instead$"
-)
+_FP16_CPU_WARNING_MESSAGE_REGEX = r"^FP16 is not supported on CPU; using FP32 instead$"
 _DEMUCS_DEPRECATED_POLICY_ID = "stable_whisper.demucs_deprecated_warning"
 _DEMUCS_DEPRECATED_MESSAGE_REGEX = (
-    r'^``demucs`` is deprecated and will be removed in future versions\. '
+    r"^``demucs`` is deprecated and will be removed in future versions\. "
     r'Use ``denoiser="demucs"`` instead\.$'
 )
 _TRANSCRIBE_WARNING_MODULE_REGEX = (

--- a/ser/transcript/backends/stable_whisper.py
+++ b/ser/transcript/backends/stable_whisper.py
@@ -1,0 +1,437 @@
+"""Stable-whisper transcription adapter implementation."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import inspect
+import os
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import TYPE_CHECKING, cast
+from urllib.parse import urlparse
+
+from ser.domain import TranscriptWord
+from ser.profiles import TranscriptionBackendId
+from ser.runtime.phase_contract import (
+    PHASE_TRANSCRIPTION,
+    PHASE_TRANSCRIPTION_MODEL_LOAD,
+)
+from ser.transcript.backends.base import (
+    BackendRuntimeRequest,
+    CompatibilityIssue,
+    CompatibilityReport,
+    TranscriptionBackendAdapter,
+)
+from ser.utils.logger import (
+    DependencyLogPolicy,
+    DependencyPolicyContext,
+    WarningPolicy,
+    scoped_dependency_log_policy,
+)
+
+if TYPE_CHECKING:
+    from ser.config import AppConfig
+
+_INVALID_ESCAPE_POLICY_ID = "stable_whisper.invalid_escape_sequence"
+_INVALID_ESCAPE_MESSAGE_REGEX = r"^invalid escape sequence '\\,'$"
+_INVALID_ESCAPE_MODULE_REGEX = r"^stable_whisper\.result$"
+_FP16_CPU_WARNING_POLICY_ID = "stable_whisper.fp16_cpu_fallback_warning"
+_FP16_CPU_WARNING_MESSAGE_REGEX = (
+    r"^FP16 is not supported on CPU; using FP32 instead$"
+)
+_DEMUCS_DEPRECATED_POLICY_ID = "stable_whisper.demucs_deprecated_warning"
+_DEMUCS_DEPRECATED_MESSAGE_REGEX = (
+    r'^``demucs`` is deprecated and will be removed in future versions\. '
+    r'Use ``denoiser="demucs"`` instead\.$'
+)
+_TRANSCRIBE_WARNING_MODULE_REGEX = (
+    r"^stable_whisper\.whisper_word_level\.original_whisper$"
+)
+_STABLE_WHISPER_IMPORT_POLICY = DependencyLogPolicy(
+    logger_prefixes=frozenset(),
+    backend_ids=frozenset({"stable_whisper"}),
+    warning_policies=(
+        WarningPolicy(
+            policy_id=_INVALID_ESCAPE_POLICY_ID,
+            action="ignore",
+            message_regex=_INVALID_ESCAPE_MESSAGE_REGEX,
+            module_regex=_INVALID_ESCAPE_MODULE_REGEX,
+            category=SyntaxWarning,
+            backend_ids=frozenset({"stable_whisper"}),
+            op_tags=frozenset(
+                {
+                    "stable_whisper.import",
+                    "stable_whisper.result.import",
+                }
+            ),
+        ),
+    ),
+)
+_STABLE_WHISPER_TRANSCRIBE_POLICY = DependencyLogPolicy(
+    logger_prefixes=frozenset(),
+    backend_ids=frozenset({"stable_whisper"}),
+    phase_names=frozenset({PHASE_TRANSCRIPTION}),
+    op_tags=frozenset({"stable_whisper.transcribe"}),
+    warning_policies=(
+        WarningPolicy(
+            policy_id=_FP16_CPU_WARNING_POLICY_ID,
+            action="ignore",
+            message_regex=_FP16_CPU_WARNING_MESSAGE_REGEX,
+            module_regex=_TRANSCRIBE_WARNING_MODULE_REGEX,
+            category=UserWarning,
+            backend_ids=frozenset({"stable_whisper"}),
+            phase_names=frozenset({PHASE_TRANSCRIPTION}),
+            op_tags=frozenset({"stable_whisper.transcribe"}),
+        ),
+        WarningPolicy(
+            policy_id=_DEMUCS_DEPRECATED_POLICY_ID,
+            action="ignore",
+            message_regex=_DEMUCS_DEPRECATED_MESSAGE_REGEX,
+            module_regex=_TRANSCRIBE_WARNING_MODULE_REGEX,
+            category=UserWarning,
+            backend_ids=frozenset({"stable_whisper"}),
+            phase_names=frozenset({PHASE_TRANSCRIPTION}),
+            op_tags=frozenset({"stable_whisper.transcribe"}),
+        ),
+    ),
+)
+
+
+class StableWhisperAdapter(TranscriptionBackendAdapter):
+    """Adapter for stable-whisper backend behavior and compatibility checks."""
+
+    @property
+    def backend_id(self) -> TranscriptionBackendId:
+        """Returns canonical backend identifier."""
+        return "stable_whisper"
+
+    def check_compatibility(
+        self,
+        *,
+        runtime_request: BackendRuntimeRequest,
+        settings: AppConfig,
+    ) -> CompatibilityReport:
+        """Checks stable-whisper dependency/runtime compatibility."""
+        del runtime_request
+        del settings
+        functional_issues: list[CompatibilityIssue] = []
+        noise_issues: list[CompatibilityIssue] = [
+            CompatibilityIssue(
+                code="stable_whisper_invalid_escape_sequence",
+                message=(
+                    "stable-whisper may emit SyntaxWarning invalid escape sequence "
+                    "during module import; scoped warning policy is required."
+                ),
+            ),
+            CompatibilityIssue(
+                code="stable_whisper_fp16_cpu_fallback_warning",
+                message=(
+                    "stable-whisper may emit a CPU fp16 fallback UserWarning "
+                    "during transcription; adapter sets fp16=False and uses a "
+                    "scoped warning policy fallback."
+                ),
+            ),
+            CompatibilityIssue(
+                code="stable_whisper_demucs_deprecated_warning",
+                message=(
+                    "stable-whisper may emit a demucs deprecation UserWarning "
+                    "when legacy demucs argument is used; adapter prefers "
+                    "denoiser='demucs' and keeps a scoped warning policy fallback."
+                ),
+            ),
+        ]
+        if not self._is_module_available("stable_whisper"):
+            functional_issues.append(
+                CompatibilityIssue(
+                    code="missing_dependency_stable_whisper",
+                    message=(
+                        "Missing stable-whisper dependencies. Ensure project dependencies "
+                        "are installed."
+                    ),
+                )
+            )
+        return CompatibilityReport(
+            backend_id="stable_whisper",
+            functional_issues=tuple(functional_issues),
+            noise_issues=tuple(noise_issues),
+            policy_ids=(
+                _INVALID_ESCAPE_POLICY_ID,
+                _FP16_CPU_WARNING_POLICY_ID,
+                _DEMUCS_DEPRECATED_POLICY_ID,
+            ),
+        )
+
+    def setup_required(
+        self,
+        *,
+        runtime_request: BackendRuntimeRequest,
+        settings: AppConfig,
+    ) -> bool:
+        """Returns whether stable-whisper checkpoint assets are missing."""
+        target_path = self._stable_whisper_download_target(
+            model_name=runtime_request.model_name,
+            settings=settings,
+        )
+        if target_path is None:
+            return False
+        return not target_path.is_file()
+
+    def prepare_assets(
+        self,
+        *,
+        runtime_request: BackendRuntimeRequest,
+        settings: AppConfig,
+    ) -> None:
+        """Downloads stable-whisper checkpoint assets when required."""
+        target_path = self._stable_whisper_download_target(
+            model_name=runtime_request.model_name,
+            settings=settings,
+        )
+        if target_path is None or target_path.is_file():
+            return
+        try:
+            whisper_module = importlib.import_module("whisper")
+        except ModuleNotFoundError:
+            return
+        model_registry = getattr(whisper_module, "_MODELS", None)
+        download_fn = getattr(whisper_module, "_download", None)
+        if not isinstance(model_registry, dict) or not callable(download_fn):
+            return
+        model_url = model_registry.get(runtime_request.model_name)
+        if not isinstance(model_url, str):
+            return
+        os.makedirs(settings.models.whisper_download_root, exist_ok=True)
+        download_fn(
+            model_url,
+            str(settings.models.whisper_download_root),
+            False,
+        )
+
+    def load_model(
+        self,
+        *,
+        runtime_request: BackendRuntimeRequest,
+        settings: AppConfig,
+    ) -> object:
+        """Loads one stable-whisper model for CPU inference."""
+        with scoped_dependency_log_policy(
+            policy=_STABLE_WHISPER_IMPORT_POLICY,
+            context=DependencyPolicyContext(
+                backend_id=self.backend_id,
+                phase_name=PHASE_TRANSCRIPTION_MODEL_LOAD,
+                op_tag="stable_whisper.import",
+            ),
+        ):
+            try:
+                stable_whisper = importlib.import_module("stable_whisper")
+            except ModuleNotFoundError as err:
+                raise RuntimeError(
+                    "Missing stable-whisper dependencies. Ensure project dependencies "
+                    "are installed."
+                ) from err
+
+            download_root: Path = settings.models.whisper_download_root
+            torch_cache_root: Path = settings.models.torch_cache_root
+            os.makedirs(download_root, exist_ok=True)
+            os.makedirs(torch_cache_root, exist_ok=True)
+            os.environ["TORCH_HOME"] = str(torch_cache_root)
+            load_model = getattr(stable_whisper, "load_model", None)
+            if not callable(load_model):
+                raise RuntimeError(
+                    "stable-whisper package does not expose a callable load_model()."
+                )
+            model = load_model(
+                name=runtime_request.model_name,
+                device="cpu",
+                dq=False,
+                download_root=str(download_root),
+                in_memory=True,
+            )
+        return model
+
+    def transcribe(
+        self,
+        *,
+        model: object,
+        runtime_request: BackendRuntimeRequest,
+        file_path: str,
+        language: str,
+        settings: AppConfig,
+    ) -> list[TranscriptWord]:
+        """Runs one stable-whisper transcription call and formats word timings."""
+        del settings
+        transcribe = getattr(model, "transcribe", None)
+        if not callable(transcribe):
+            raise RuntimeError(
+                "Loaded stable-whisper model does not expose a callable transcribe()."
+            )
+        typed_transcribe = cast(Callable[..., object], transcribe)
+        transcribe_kwargs = self._build_transcribe_kwargs(
+            transcribe_callable=typed_transcribe,
+            runtime_request=runtime_request,
+            file_path=file_path,
+            language=language,
+        )
+        raw_transcript: object
+        try:
+            with scoped_dependency_log_policy(
+                policy=_STABLE_WHISPER_TRANSCRIBE_POLICY,
+                context=DependencyPolicyContext(
+                    backend_id=self.backend_id,
+                    phase_name=PHASE_TRANSCRIPTION,
+                    op_tag="stable_whisper.transcribe",
+                ),
+            ):
+                raw_transcript = typed_transcribe(**transcribe_kwargs)
+        except Exception as err:
+            raise RuntimeError("Failed to transcribe audio.") from err
+        return self._format_transcript(self._normalize_result(raw_transcript))
+
+    @classmethod
+    def _build_transcribe_kwargs(
+        cls,
+        *,
+        transcribe_callable: Callable[..., object],
+        runtime_request: BackendRuntimeRequest,
+        file_path: str,
+        language: str,
+    ) -> dict[str, object]:
+        """Builds stable-whisper transcribe kwargs for cross-version compatibility."""
+        kwargs: dict[str, object] = {
+            "audio": file_path,
+            "language": language,
+            "verbose": False,
+            "word_timestamps": True,
+            "no_speech_threshold": None,
+            "vad": runtime_request.use_vad,
+        }
+        if cls._supports_keyword_argument(
+            transcribe_callable,
+            parameter_name="fp16",
+        ):
+            kwargs["fp16"] = False
+        if runtime_request.use_demucs:
+            if cls._supports_keyword_argument(
+                transcribe_callable,
+                parameter_name="denoiser",
+            ):
+                kwargs["denoiser"] = "demucs"
+            elif cls._supports_keyword_argument(
+                transcribe_callable,
+                parameter_name="demucs",
+            ):
+                kwargs["demucs"] = True
+        elif cls._supports_keyword_argument(
+            transcribe_callable,
+            parameter_name="demucs",
+        ):
+            kwargs["demucs"] = False
+        return kwargs
+
+    @staticmethod
+    def _supports_keyword_argument(
+        callable_obj: Callable[..., object],
+        *,
+        parameter_name: str,
+    ) -> bool:
+        """Returns whether one callable supports one keyword argument."""
+        try:
+            callable_signature = inspect.signature(callable_obj)
+        except (TypeError, ValueError):
+            return True
+        parameter = callable_signature.parameters.get(parameter_name)
+        if parameter is not None:
+            return parameter.kind in (
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                inspect.Parameter.KEYWORD_ONLY,
+                inspect.Parameter.VAR_KEYWORD,
+            )
+        return any(
+            existing_parameter.kind is inspect.Parameter.VAR_KEYWORD
+            for existing_parameter in callable_signature.parameters.values()
+        )
+
+    @staticmethod
+    def _stable_whisper_download_target(
+        *,
+        model_name: str,
+        settings: AppConfig,
+    ) -> Path | None:
+        """Returns expected checkpoint path for registry-backed stable-whisper models."""
+        normalized_name = model_name.strip()
+        if not normalized_name:
+            raise RuntimeError("Transcription model name must be a non-empty string.")
+        if Path(normalized_name).is_file():
+            return None
+        try:
+            whisper_module = importlib.import_module("whisper")
+        except ModuleNotFoundError:
+            return None
+        model_registry = getattr(whisper_module, "_MODELS", None)
+        if not isinstance(model_registry, dict):
+            return None
+        model_url = model_registry.get(normalized_name)
+        if not isinstance(model_url, str):
+            return None
+        filename = Path(urlparse(model_url).path).name
+        if not filename:
+            return None
+        return settings.models.whisper_download_root / filename
+
+    def _normalize_result(self, raw_transcript: object) -> object:
+        """Normalizes raw stable-whisper outputs to a WhisperResult instance."""
+        with scoped_dependency_log_policy(
+            policy=_STABLE_WHISPER_IMPORT_POLICY,
+            context=DependencyPolicyContext(
+                backend_id=self.backend_id,
+                phase_name=PHASE_TRANSCRIPTION,
+                op_tag="stable_whisper.result.import",
+            ),
+        ):
+            stable_result_module = importlib.import_module("stable_whisper.result")
+        whisper_result_ctor = getattr(stable_result_module, "WhisperResult", None)
+        if whisper_result_ctor is None:
+            raise RuntimeError(
+                "stable-whisper package does not expose stable_whisper.result.WhisperResult."
+            )
+        if isinstance(raw_transcript, whisper_result_ctor):
+            return raw_transcript
+        if isinstance(raw_transcript, dict | list | str):
+            return whisper_result_ctor(raw_transcript)
+        raise RuntimeError("Unexpected transcription result type from stable-whisper.")
+
+    @staticmethod
+    def _format_transcript(result: object) -> list[TranscriptWord]:
+        """Formats a stable-whisper result into transcript words."""
+        all_words = getattr(result, "all_words", None)
+        if not callable(all_words):
+            raise RuntimeError("Invalid Whisper result object.")
+        words = all_words()
+        if not isinstance(words, list | tuple):
+            raise RuntimeError("Invalid stable-whisper words payload.")
+        transcript: list[TranscriptWord] = []
+        for word in words:
+            start = getattr(word, "start", None)
+            end = getattr(word, "end", None)
+            if start is None or end is None:
+                continue
+            transcript.append(
+                TranscriptWord(
+                    word=str(getattr(word, "word", "")),
+                    start_seconds=float(start),
+                    end_seconds=float(end),
+                )
+            )
+        return transcript
+
+    @staticmethod
+    def _is_module_available(module_name: str) -> bool:
+        """Returns whether one Python module is available or already loaded."""
+        if module_name in sys.modules:
+            return True
+        try:
+            return importlib.util.find_spec(module_name) is not None
+        except ValueError:
+            return module_name in sys.modules

--- a/ser/transcript/backends/stable_whisper_mps_compat.py
+++ b/ser/transcript/backends/stable_whisper_mps_compat.py
@@ -1,0 +1,447 @@
+"""MPS compatibility helpers for stable-whisper model load and timing paths."""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import logging
+import threading
+from contextlib import contextmanager
+from typing import Any, cast
+
+import numpy as np
+import torch
+
+_MPS_COMPAT_MODEL_ATTR = "_ser_stable_whisper_mps_compat_enabled"
+_RUNTIME_DEVICE_MODEL_ATTR = "_ser_stable_whisper_runtime_device"
+_TIMING_PATCH_LOCK = threading.RLock()
+
+type _StdMeanCallable = Any
+type _DtwCpuCallable = Any
+type _DtwCallable = Any
+type _ComputeQksCallable = Any
+type _DisableSdpaCallable = Any
+
+_logger = logging.getLogger(__name__)
+
+
+def enable_stable_whisper_mps_compatibility(model: object) -> object:
+    """Moves one stable-whisper model to MPS with sparse-buffer safeguards."""
+    moved_model = move_model_to_mps_with_alignment_placeholder(model)
+    set_stable_whisper_mps_compatibility_enabled(moved_model, enabled=True)
+    return moved_model
+
+
+def move_model_to_mps_with_alignment_placeholder(model: object) -> object:
+    """Moves one model to MPS while preserving sparse alignment buffers on CPU."""
+    to_method = getattr(model, "to", None)
+    if not callable(to_method):
+        raise RuntimeError(
+            "Loaded stable-whisper model does not expose a callable to()."
+        )
+
+    register_buffer = getattr(model, "register_buffer", None)
+    alignment_heads_obj = getattr(model, "alignment_heads", None)
+    has_sparse_alignment = isinstance(alignment_heads_obj, torch.Tensor) and bool(
+        alignment_heads_obj.is_sparse
+    )
+    if not callable(register_buffer) or not has_sparse_alignment:
+        return to_method(device="mps")
+
+    original_alignment_heads = cast(torch.Tensor, alignment_heads_obj)
+    dense_placeholder = torch.zeros(
+        tuple(int(dim) for dim in original_alignment_heads.shape),
+        dtype=torch.bool,
+        device="cpu",
+    )
+    register_buffer("alignment_heads", dense_placeholder, persistent=False)
+    try:
+        moved_model = to_method(device="mps")
+    except Exception as move_error:
+        rollback_error: Exception | None = None
+        try:
+            # Best-effort transactional rollback for partial in-place MPS moves.
+            to_method(device="cpu")
+        except Exception as err:
+            rollback_error = err
+        register_buffer(
+            "alignment_heads",
+            original_alignment_heads,
+            persistent=False,
+        )
+        if rollback_error is not None:
+            raise RuntimeError(
+                "Failed to move stable-whisper model to MPS and failed to roll back to CPU."
+            ) from move_error
+        raise
+
+    moved_register_buffer = getattr(moved_model, "register_buffer", None)
+    if not callable(moved_register_buffer):
+        raise RuntimeError(
+            "Loaded stable-whisper model does not expose register_buffer() after MPS move."
+        )
+    moved_register_buffer(
+        "alignment_heads",
+        original_alignment_heads.cpu(),
+        persistent=False,
+    )
+    return moved_model
+
+
+def set_stable_whisper_mps_compatibility_enabled(
+    model: object,
+    *,
+    enabled: bool,
+) -> None:
+    """Marks one model as requiring MPS timing compatibility patches."""
+    try:
+        setattr(model, _MPS_COMPAT_MODEL_ATTR, enabled)
+    except Exception:
+        return
+
+
+def is_stable_whisper_mps_compatibility_enabled(model: object) -> bool:
+    """Returns whether one model needs stable-whisper MPS timing compatibility."""
+    return bool(getattr(model, _MPS_COMPAT_MODEL_ATTR, False))
+
+
+def set_stable_whisper_runtime_device(
+    model: object,
+    *,
+    device_type: str,
+) -> None:
+    """Stores one model-level runtime device hint for transcription execution."""
+    try:
+        setattr(model, _RUNTIME_DEVICE_MODEL_ATTR, device_type)
+    except Exception:
+        return
+
+
+def get_stable_whisper_runtime_device(
+    model: object,
+    *,
+    default_device_type: str,
+) -> str:
+    """Returns model runtime device hint or one conservative default."""
+    runtime_device = getattr(model, _RUNTIME_DEVICE_MODEL_ATTR, default_device_type)
+    if runtime_device in {"cpu", "mps", "cuda"}:
+        return cast(str, runtime_device)
+    return default_device_type
+
+
+@contextmanager
+def stable_whisper_mps_timing_compatibility_context() -> Any:
+    """Patches stable-whisper timing aliases for MPS-compatible word alignment."""
+    with _TIMING_PATCH_LOCK:
+        timing_module = importlib.import_module("stable_whisper.timing")
+        compatibility_module = importlib.import_module(
+            "stable_whisper.whisper_compatibility"
+        )
+        timing_module_any = cast(Any, timing_module)
+        compatibility_module_any = cast(Any, compatibility_module)
+        whisper_timing_module = importlib.import_module("whisper.timing")
+        dtw_cpu = getattr(whisper_timing_module, "dtw_cpu", None)
+        if not callable(dtw_cpu):
+            raise RuntimeError("whisper.timing does not expose dtw_cpu().")
+
+        original_std_mean = cast(_StdMeanCallable, torch.std_mean)
+        original_compat_dtw = cast(_DtwCallable, compatibility_module_any.dtw)
+        original_timing_dtw = cast(_DtwCallable, timing_module_any.dtw)
+        original_timing_compute_qks = getattr(timing_module_any, "_compute_qks", None)
+
+        safe_dtw = _build_cpu_safe_dtw(dtw_cpu)
+        safe_std_mean = _build_mps_safe_std_mean(original_std_mean)
+
+        compatibility_module_any.dtw = safe_dtw
+        timing_module_any.dtw = safe_dtw
+        torch.std_mean = cast(_StdMeanCallable, safe_std_mean)
+        if callable(original_timing_compute_qks):
+            disable_sdpa = getattr(compatibility_module_any, "disable_sdpa", None)
+            if callable(disable_sdpa):
+                timing_module_any._compute_qks = _build_cpu_offloaded_compute_qks(
+                    original_compute_qks=original_timing_compute_qks,
+                    disable_sdpa=disable_sdpa,
+                )
+                _logger.debug(
+                    "Enabled stable-whisper timing QK CPU offload patch for MPS compatibility context."
+                )
+            else:
+                _logger.debug(
+                    "Skipped stable-whisper timing QK offload patch: disable_sdpa unavailable."
+                )
+        else:
+            _logger.debug(
+                "Skipped stable-whisper timing QK offload patch: _compute_qks unavailable."
+            )
+        try:
+            yield
+        finally:
+            torch.std_mean = original_std_mean
+            compatibility_module_any.dtw = original_compat_dtw
+            timing_module_any.dtw = original_timing_dtw
+            if original_timing_compute_qks is not None:
+                timing_module_any._compute_qks = original_timing_compute_qks
+
+
+def _build_cpu_safe_dtw(dtw_cpu: _DtwCpuCallable) -> _DtwCallable:
+    """Builds one DTW adapter that moves MPS tensors to CPU before float64 cast."""
+
+    def _dtw_cpu_safe(x: torch.Tensor) -> Any:
+        return dtw_cpu(x.cpu().double().numpy())
+
+    return _dtw_cpu_safe
+
+
+def _build_cpu_offloaded_compute_qks(
+    *,
+    original_compute_qks: _ComputeQksCallable,
+    disable_sdpa: _DisableSdpaCallable,
+) -> _ComputeQksCallable:
+    """Builds one _compute_qks adapter that offloads layer QKs to CPU immediately."""
+
+    def _compute_qks_cpu_offload(*args: object, **kwargs: object) -> Any:
+        bound = _bind_compute_qks_arguments(
+            compute_qks=original_compute_qks,
+            args=args,
+            kwargs=kwargs,
+        )
+        if bound is None:
+            return original_compute_qks(*args, **kwargs)
+
+        model = bound["model"]
+        tokenizer = bound["tokenizer"]
+        text_tokens = bound["text_tokens"]
+        mel = bound["mel"]
+        tokens = bound["tokens"]
+        cache = bound["cache"]
+        if not (
+            isinstance(mel, torch.Tensor)
+            and isinstance(tokens, torch.Tensor)
+            and isinstance(cache, dict)
+        ):
+            return original_compute_qks(*args, **kwargs)
+        if not isinstance(text_tokens, list | tuple):
+            return original_compute_qks(*args, **kwargs)
+        text_token_ids = [int(token_id) for token_id in text_tokens]
+
+        sot_sequence = getattr(tokenizer, "sot_sequence", None)
+        eot = getattr(tokenizer, "eot", None)
+        if not isinstance(sot_sequence, list | tuple) or not isinstance(eot, int):
+            return original_compute_qks(*args, **kwargs)
+
+        dims = getattr(model, "dims", None)
+        n_text_layer = getattr(dims, "n_text_layer", None)
+        decoder = getattr(model, "decoder", None)
+        encoder = getattr(model, "encoder", None)
+        if (
+            not isinstance(n_text_layer, int)
+            or n_text_layer <= 0
+            or not callable(decoder)
+            or not callable(encoder)
+        ):
+            return original_compute_qks(*args, **kwargs)
+
+        decoder_blocks_obj = getattr(decoder, "blocks", None)
+        if isinstance(decoder_blocks_obj, list | tuple):
+            decoder_blocks: list[object] = list(decoder_blocks_obj)
+        elif hasattr(decoder_blocks_obj, "__iter__"):
+            decoder_blocks = list(cast(Any, decoder_blocks_obj))
+        else:
+            return original_compute_qks(*args, **kwargs)
+
+        cache["qks"] = [None] * n_text_layer
+        hooks: list[Any] = []
+        for index, block in enumerate(decoder_blocks):
+            cross_attn = getattr(block, "cross_attn", None)
+            register_forward_hook = getattr(cross_attn, "register_forward_hook", None)
+            if not callable(register_forward_hook):
+                for hook in hooks:
+                    _remove_hook_safely(hook)
+                return original_compute_qks(*args, **kwargs)
+            hook = register_forward_hook(
+                _build_qk_offload_hook(
+                    cache=cache,
+                    index=index,
+                )
+            )
+            hooks.append(hook)
+
+        try:
+            with torch.no_grad(), disable_sdpa():
+                audio_features = cache.get("audio_features")
+                if audio_features is None:
+                    audio_features = encoder(mel.unsqueeze(0))
+                    cache["audio_features"] = audio_features
+                decoder_output = cast(Any, decoder(tokens.unsqueeze(0), audio_features))
+                logits = cast(torch.Tensor, decoder_output[0])
+                sampled_logits = logits[len(sot_sequence) :, :eot]
+                token_probs = sampled_logits.softmax(dim=-1)
+                token_index = np.arange(len(text_token_ids))
+                cache["text_token_probs"] = token_probs[
+                    token_index, text_token_ids
+                ].tolist()
+        finally:
+            for hook in hooks:
+                _remove_hook_safely(hook)
+        return None
+
+    return _compute_qks_cpu_offload
+
+
+def _bind_compute_qks_arguments(
+    *,
+    compute_qks: _ComputeQksCallable,
+    args: tuple[object, ...],
+    kwargs: dict[str, object],
+) -> dict[str, object] | None:
+    """Binds arguments for one stable-whisper _compute_qks-style callable."""
+    try:
+        signature = inspect.signature(compute_qks)
+        bound = signature.bind_partial(*args, **kwargs)
+    except (TypeError, ValueError):
+        return None
+    required = ("model", "tokenizer", "text_tokens", "mel", "tokens", "cache")
+    if not all(name in bound.arguments for name in required):
+        return None
+    return {name: bound.arguments[name] for name in required}
+
+
+def _build_qk_offload_hook(
+    *,
+    cache: dict[str, object],
+    index: int,
+) -> Any:
+    """Builds one forward hook that stores detached QK tensors on CPU."""
+
+    def _offload_qk_hook(
+        _module: object,
+        _inputs: object,
+        outputs: object,
+    ) -> None:
+        qk_cache = cache.get("qks")
+        if not isinstance(qk_cache, list) or index >= len(qk_cache):
+            return
+        if not isinstance(outputs, list | tuple) or not outputs:
+            qk_cache[index] = None
+            return
+        qk = outputs[-1]
+        if not isinstance(qk, torch.Tensor):
+            qk_cache[index] = qk
+            return
+        detached_qk = qk.detach()
+        if detached_qk.device.type != "cpu":
+            detached_qk = detached_qk.to(device="cpu")
+        qk_cache[index] = detached_qk
+
+    return _offload_qk_hook
+
+
+def _remove_hook_safely(hook: object) -> None:
+    """Removes one torch forward-hook handle defensively."""
+    remove = getattr(hook, "remove", None)
+    if callable(remove):
+        remove()
+
+
+def _build_mps_safe_std_mean(
+    original_std_mean: _StdMeanCallable,
+) -> _StdMeanCallable:
+    """Builds one std_mean adapter with MPS fallbacks."""
+
+    def _std_mean_safe(
+        input_tensor: torch.Tensor,
+        *args: object,
+        **kwargs: object,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        try:
+            return cast(
+                tuple[torch.Tensor, torch.Tensor],
+                original_std_mean(input_tensor, *args, **kwargs),
+            )
+        except NotImplementedError as err:
+            if not _is_mps_std_mean_not_implemented(err, input_tensor=input_tensor):
+                raise
+            try:
+                return _std_mean_var_mean_fallback(
+                    input_tensor=input_tensor,
+                    args=args,
+                    kwargs=kwargs,
+                )
+            except Exception:
+                return _std_mean_cpu_fallback(
+                    original_std_mean=original_std_mean,
+                    input_tensor=input_tensor,
+                    args=args,
+                    kwargs=kwargs,
+                )
+
+    return _std_mean_safe
+
+
+def _std_mean_var_mean_fallback(
+    *,
+    input_tensor: torch.Tensor,
+    args: tuple[object, ...],
+    kwargs: dict[str, object],
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Computes std/mean on MPS using var_mean+sqrt when std_mean is unsupported."""
+    if args:
+        raise RuntimeError(
+            "std_mean fallback only supports keyword-argument invocation."
+        )
+    dim = kwargs.get("dim", None)
+    keepdim = bool(kwargs.get("keepdim", False))
+    correction_arg = kwargs.get("correction", None)
+    if correction_arg is None:
+        unbiased = bool(kwargs.get("unbiased", True))
+        correction: float = 1.0 if unbiased else 0.0
+    elif isinstance(correction_arg, bool):
+        correction = 1.0 if correction_arg else 0.0
+    elif isinstance(correction_arg, int | float):
+        correction = float(correction_arg)
+    else:
+        raise RuntimeError("Unsupported std_mean correction argument type.")
+    variance, mean = torch.var_mean(
+        input_tensor,
+        dim=cast(Any, dim),
+        keepdim=keepdim,
+        correction=correction,
+    )
+    return torch.sqrt(variance), mean
+
+
+def _std_mean_cpu_fallback(
+    *,
+    original_std_mean: _StdMeanCallable,
+    input_tensor: torch.Tensor,
+    args: tuple[object, ...],
+    kwargs: dict[str, object],
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Computes std/mean on CPU and returns tensors on the original input device."""
+    cpu_std, cpu_mean = cast(
+        tuple[torch.Tensor, torch.Tensor],
+        original_std_mean(input_tensor.float().cpu(), *args, **kwargs),
+    )
+    target_dtype = (
+        input_tensor.dtype if input_tensor.is_floating_point() else cpu_std.dtype
+    )
+    std = cpu_std.to(device=input_tensor.device, dtype=target_dtype)
+    mean = cpu_mean.to(device=input_tensor.device, dtype=target_dtype)
+    return std, mean
+
+
+def _is_mps_std_mean_not_implemented(
+    err: NotImplementedError,
+    *,
+    input_tensor: torch.Tensor,
+) -> bool:
+    """Returns whether one error is the known std_mean MPS operator gap."""
+    if input_tensor.device.type != "mps":
+        return False
+    message = str(err).lower()
+    required_markers = (
+        "std_mean",
+        "not currently implemented",
+        "mps",
+    )
+    return all(marker in message for marker in required_markers)

--- a/ser/transcript/mps_admission.py
+++ b/ser/transcript/mps_admission.py
@@ -1,0 +1,335 @@
+"""Dynamic MPS admission control for transcription runtime decisions."""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from types import ModuleType
+from typing import Literal
+
+DEFAULT_MPS_ADMISSION_MIN_HEADROOM_MB: float = 64.0
+DEFAULT_MPS_ADMISSION_SAFETY_MARGIN_MB: float = 64.0
+
+type TranscriptionPhase = Literal["model_load", "transcribe"]
+
+
+@dataclass(frozen=True, slots=True)
+class MpsPressureSnapshot:
+    """Best-effort snapshot of current MPS allocator pressure."""
+
+    is_available: bool
+    current_allocated_bytes: int | None
+    driver_allocated_bytes: int | None
+    recommended_max_bytes: int | None
+    headroom_bytes: int | None
+
+
+@dataclass(frozen=True, slots=True)
+class MpsAdmissionDecision:
+    """Decision for whether MPS should be used for a transcription phase."""
+
+    allow_mps: bool
+    reason_code: str
+    required_bytes: int | None
+    available_bytes: int | None
+    required_metric: str
+    available_metric: str
+    confidence: Literal["high", "medium", "low"]
+
+
+def decide_mps_admission_for_transcription(
+    *,
+    model_name: str,
+    phase: TranscriptionPhase,
+    min_headroom_mb: float = DEFAULT_MPS_ADMISSION_MIN_HEADROOM_MB,
+    safety_margin_mb: float = DEFAULT_MPS_ADMISSION_SAFETY_MARGIN_MB,
+) -> MpsAdmissionDecision:
+    """Decides whether current MPS headroom can safely run one transcription phase."""
+    snapshot = capture_mps_pressure_snapshot()
+    model_required_bytes = _estimate_required_headroom_bytes(
+        model_name=model_name,
+        phase=phase,
+    )
+    min_required_bytes = _mb_to_bytes(min_headroom_mb)
+    safety_margin_bytes = _mb_to_bytes(safety_margin_mb)
+    required_headroom_bytes = (
+        max(min_required_bytes, model_required_bytes) + safety_margin_bytes
+    )
+    if not snapshot.is_available:
+        return MpsAdmissionDecision(
+            allow_mps=True,
+            reason_code="mps_pressure_unavailable",
+            required_bytes=None,
+            available_bytes=None,
+            required_metric="headroom_budget",
+            available_metric="headroom_estimate",
+            confidence="low",
+        )
+    if snapshot.headroom_bytes is None:
+        if phase == "model_load" and _is_large_whisper_model(model_name):
+            estimated_model_footprint_bytes = _estimate_model_footprint_bytes(
+                model_name
+            )
+            return MpsAdmissionDecision(
+                allow_mps=False,
+                reason_code="mps_headroom_unknown_large_model",
+                required_bytes=estimated_model_footprint_bytes,
+                available_bytes=snapshot.driver_allocated_bytes,
+                required_metric="model_footprint_estimate",
+                available_metric="driver_allocated",
+                confidence="medium",
+            )
+        estimated_headroom_bytes = _estimate_headroom_without_recommended_max(
+            snapshot=snapshot,
+            model_name=model_name,
+            phase=phase,
+        )
+        if estimated_headroom_bytes is None:
+            return MpsAdmissionDecision(
+                allow_mps=True,
+                reason_code="mps_headroom_unknown",
+                required_bytes=None,
+                available_bytes=None,
+                required_metric="headroom_budget",
+                available_metric="headroom_estimate",
+                confidence="low",
+            )
+        allow_mps = estimated_headroom_bytes >= required_headroom_bytes
+        return MpsAdmissionDecision(
+            allow_mps=allow_mps,
+            reason_code=(
+                "mps_headroom_estimate_sufficient"
+                if allow_mps
+                else "mps_headroom_estimate_below_required_budget"
+            ),
+            required_bytes=required_headroom_bytes,
+            available_bytes=estimated_headroom_bytes,
+            required_metric="headroom_budget",
+            available_metric="headroom_estimate",
+            confidence="low",
+        )
+    allow_mps = snapshot.headroom_bytes >= required_headroom_bytes
+    return MpsAdmissionDecision(
+        allow_mps=allow_mps,
+        reason_code=(
+            "mps_headroom_sufficient"
+            if allow_mps
+            else "mps_headroom_below_required_budget"
+        ),
+        required_bytes=required_headroom_bytes,
+        available_bytes=snapshot.headroom_bytes,
+        required_metric="headroom_budget",
+        available_metric="headroom",
+        confidence="high",
+    )
+
+
+def capture_mps_pressure_snapshot() -> MpsPressureSnapshot:
+    """Captures one best-effort MPS memory pressure snapshot."""
+    torch_module = sys.modules.get("torch")
+    if not isinstance(torch_module, ModuleType):
+        return MpsPressureSnapshot(
+            is_available=False,
+            current_allocated_bytes=None,
+            driver_allocated_bytes=None,
+            recommended_max_bytes=None,
+            headroom_bytes=None,
+        )
+    backends = getattr(torch_module, "backends", None)
+    mps_backend = getattr(backends, "mps", None)
+    is_available = getattr(mps_backend, "is_available", None)
+    is_built = getattr(mps_backend, "is_built", None)
+    if not callable(is_available) or not callable(is_built):
+        return MpsPressureSnapshot(
+            is_available=False,
+            current_allocated_bytes=None,
+            driver_allocated_bytes=None,
+            recommended_max_bytes=None,
+            headroom_bytes=None,
+        )
+    try:
+        if not is_available() or not is_built():
+            return MpsPressureSnapshot(
+                is_available=False,
+                current_allocated_bytes=None,
+                driver_allocated_bytes=None,
+                recommended_max_bytes=None,
+                headroom_bytes=None,
+            )
+    except Exception:
+        return MpsPressureSnapshot(
+            is_available=False,
+            current_allocated_bytes=None,
+            driver_allocated_bytes=None,
+            recommended_max_bytes=None,
+            headroom_bytes=None,
+        )
+    mps_module = getattr(torch_module, "mps", None)
+    if not isinstance(mps_module, ModuleType):
+        return MpsPressureSnapshot(
+            is_available=False,
+            current_allocated_bytes=None,
+            driver_allocated_bytes=None,
+            recommended_max_bytes=None,
+            headroom_bytes=None,
+        )
+
+    current_allocated_bytes = _safe_read_mps_bytes(
+        module=mps_module,
+        attribute_name="current_allocated_memory",
+    )
+    driver_allocated_bytes = _safe_read_mps_bytes(
+        module=mps_module,
+        attribute_name="driver_allocated_memory",
+    )
+    recommended_max_bytes = _safe_read_mps_bytes(
+        module=mps_module,
+        attribute_name="recommended_max_memory",
+    )
+    used_candidates = tuple(
+        value
+        for value in (current_allocated_bytes, driver_allocated_bytes)
+        if value is not None
+    )
+    effective_used_bytes = max(used_candidates) if used_candidates else None
+    headroom_bytes = None
+    if recommended_max_bytes is not None and effective_used_bytes is not None:
+        headroom_bytes = max(recommended_max_bytes - effective_used_bytes, 0)
+    return MpsPressureSnapshot(
+        is_available=True,
+        current_allocated_bytes=current_allocated_bytes,
+        driver_allocated_bytes=driver_allocated_bytes,
+        recommended_max_bytes=recommended_max_bytes,
+        headroom_bytes=headroom_bytes,
+    )
+
+
+def format_gib_short(value_bytes: int | None) -> str:
+    """Formats one byte value as a short GiB string for concise logs."""
+    if value_bytes is None:
+        return "unknown"
+    gib_value = float(value_bytes) / float(1024**3)
+    return f"{gib_value:.2f} GiB"
+
+
+def _safe_read_mps_bytes(*, module: ModuleType, attribute_name: str) -> int | None:
+    """Reads one optional MPS memory counter."""
+    reader = getattr(module, attribute_name, None)
+    if not callable(reader):
+        return None
+    try:
+        value = reader()
+    except Exception:
+        return None
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int | float):
+        parsed = int(value)
+        return parsed if parsed >= 0 else None
+    return None
+
+
+def _estimate_required_headroom_bytes(
+    *,
+    model_name: str,
+    phase: TranscriptionPhase,
+) -> int:
+    """Estimates required MPS headroom for one model and transcription phase."""
+    normalized = model_name.strip().lower()
+    if phase == "model_load":
+        # Model load requires room for weights and allocator overhead.
+        model_footprint_bytes = _estimate_model_footprint_bytes(model_name)
+        minimum_budget_bytes = _mb_to_bytes(96.0)
+        return max(model_footprint_bytes, minimum_budget_bytes)
+    if normalized in {"large", "large-v1", "large-v2", "large-v3"}:
+        return _mb_to_bytes(128.0)
+    if normalized in {"turbo", "large-v3-turbo", "distil-large-v3"}:
+        return _mb_to_bytes(96.0)
+    if normalized.startswith("medium"):
+        return _mb_to_bytes(96.0)
+    if normalized.startswith("small"):
+        return _mb_to_bytes(64.0)
+    if normalized.startswith("base") or normalized.startswith("tiny"):
+        return _mb_to_bytes(48.0)
+    return _mb_to_bytes(64.0)
+
+
+def _estimate_driver_allocation_guard_bytes(
+    *,
+    model_name: str,
+    phase: TranscriptionPhase,
+) -> int:
+    """Estimates one absolute driver-allocation guard when headroom is unavailable."""
+    normalized = model_name.strip().lower()
+    if phase == "model_load":
+        if normalized in {"large", "large-v1", "large-v2", "large-v3"}:
+            return int(3.10 * float(1024**3))
+        if normalized in {"turbo", "large-v3-turbo", "distil-large-v3"}:
+            return int(3.25 * float(1024**3))
+        return int(3.20 * float(1024**3))
+    if normalized in {"large", "large-v1", "large-v2", "large-v3"}:
+        return int(3.20 * float(1024**3))
+    if normalized in {"turbo", "large-v3-turbo", "distil-large-v3"}:
+        return int(3.25 * float(1024**3))
+    return int(3.30 * float(1024**3))
+
+
+def _estimate_headroom_without_recommended_max(
+    *,
+    snapshot: MpsPressureSnapshot,
+    model_name: str,
+    phase: TranscriptionPhase,
+) -> int | None:
+    """Estimates headroom when torch does not expose recommended_max_memory()."""
+    if snapshot.driver_allocated_bytes is None:
+        return None
+    driver_guard_bytes = _estimate_driver_allocation_guard_bytes(
+        model_name=model_name,
+        phase=phase,
+    )
+    guard_headroom_bytes = max(driver_guard_bytes - snapshot.driver_allocated_bytes, 0)
+    system_available_bytes = _read_system_available_memory_bytes()
+    if system_available_bytes is None:
+        return guard_headroom_bytes
+    return min(guard_headroom_bytes, system_available_bytes)
+
+
+def _read_system_available_memory_bytes() -> int | None:
+    """Reads host available memory as one soft upper bound for unified-memory pressure."""
+    try:
+        import psutil
+    except ModuleNotFoundError:
+        return None
+    try:
+        available_bytes = int(psutil.virtual_memory().available)
+    except (AttributeError, OSError, ValueError):
+        return None
+    return available_bytes if available_bytes >= 0 else None
+
+
+def _is_large_whisper_model(model_name: str) -> bool:
+    """Returns whether one model belongs to Whisper large family variants."""
+    normalized = model_name.strip().lower()
+    return normalized in {"large", "large-v1", "large-v2", "large-v3"}
+
+
+def _estimate_model_footprint_bytes(model_name: str) -> int:
+    """Estimates one model footprint for conservative admission diagnostics."""
+    normalized = model_name.strip().lower()
+    if normalized in {"large", "large-v1", "large-v2", "large-v3"}:
+        return int(3.10 * float(1024**3))
+    if normalized in {"turbo", "large-v3-turbo", "distil-large-v3"}:
+        return int(1.55 * float(1024**3))
+    if normalized.startswith("medium"):
+        return int(1.20 * float(1024**3))
+    if normalized.startswith("small"):
+        return int(0.75 * float(1024**3))
+    if normalized.startswith("base") or normalized.startswith("tiny"):
+        return int(0.45 * float(1024**3))
+    return int(1.00 * float(1024**3))
+
+
+def _mb_to_bytes(value_mb: float) -> int:
+    """Converts one MB value to bytes with input normalization."""
+    normalized = value_mb if value_mb > 0.0 else 0.0
+    return int(normalized * float(1024**2))

--- a/ser/transcript/mps_admission_overrides.py
+++ b/ser/transcript/mps_admission_overrides.py
@@ -1,0 +1,335 @@
+"""Calibration-driven overrides for dynamic MPS admission decisions."""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from functools import lru_cache
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal, cast
+
+from ser.transcript.backends.base import BackendRuntimeRequest
+from ser.transcript.mps_admission import MpsAdmissionDecision
+
+if TYPE_CHECKING:
+    from ser.config import AppConfig
+
+type RecommendationConfidence = Literal["high", "medium", "low"]
+type RuntimeRecommendation = Literal["prefer_cpu", "prefer_mps", "mps_with_failover"]
+type TranscriptionPhase = Literal["model_load", "transcribe"]
+
+_REPORT_FILE_NAME = "transcription_runtime_calibration_report.json"
+_CONFIDENCE_RANK: dict[RecommendationConfidence, int] = {
+    "low": 1,
+    "medium": 2,
+    "high": 3,
+}
+_RECOMMENDATION_PRIORITY: dict[RuntimeRecommendation, int] = {
+    "prefer_cpu": 3,
+    "mps_with_failover": 2,
+    "prefer_mps": 1,
+}
+
+
+@dataclass(frozen=True, slots=True)
+class CalibrationRecommendation:
+    """One calibration recommendation row keyed by backend/model."""
+
+    backend_id: str
+    model_name: str
+    recommendation: RuntimeRecommendation
+    confidence: RecommendationConfidence
+    reason: str
+    source_profile: str
+
+
+def apply_calibrated_mps_admission_override(
+    *,
+    settings: AppConfig,
+    runtime_request: BackendRuntimeRequest,
+    phase: TranscriptionPhase,
+    heuristic_decision: MpsAdmissionDecision,
+) -> MpsAdmissionDecision:
+    """Applies one optional calibration-based override over heuristic admission."""
+    recommendation = _resolve_recommendation(
+        settings=settings,
+        runtime_request=runtime_request,
+    )
+    if recommendation is None:
+        return heuristic_decision
+
+    if recommendation.recommendation == "prefer_cpu":
+        return MpsAdmissionDecision(
+            allow_mps=False,
+            reason_code=f"calibration_prefer_cpu_{phase}",
+            required_bytes=heuristic_decision.required_bytes,
+            available_bytes=heuristic_decision.available_bytes,
+            required_metric=heuristic_decision.required_metric,
+            available_metric=heuristic_decision.available_metric,
+            confidence=recommendation.confidence,
+        )
+
+    if recommendation.recommendation == "prefer_mps":
+        if heuristic_decision.allow_mps or heuristic_decision.confidence == "high":
+            return heuristic_decision
+        return MpsAdmissionDecision(
+            allow_mps=True,
+            reason_code=f"calibration_prefer_mps_{phase}",
+            required_bytes=heuristic_decision.required_bytes,
+            available_bytes=heuristic_decision.available_bytes,
+            required_metric=heuristic_decision.required_metric,
+            available_metric=heuristic_decision.available_metric,
+            confidence=recommendation.confidence,
+        )
+
+    if heuristic_decision.allow_mps or heuristic_decision.confidence == "high":
+        return heuristic_decision
+    return MpsAdmissionDecision(
+        allow_mps=True,
+        reason_code=f"calibration_mps_with_failover_{phase}",
+        required_bytes=heuristic_decision.required_bytes,
+        available_bytes=heuristic_decision.available_bytes,
+        required_metric=heuristic_decision.required_metric,
+        available_metric=heuristic_decision.available_metric,
+        confidence=recommendation.confidence,
+    )
+
+
+def _resolve_recommendation(
+    *,
+    settings: AppConfig,
+    runtime_request: BackendRuntimeRequest,
+) -> CalibrationRecommendation | None:
+    """Resolves one recommendation matching runtime backend/model selectors."""
+    logger = logging.getLogger(__name__)
+    transcription_settings = getattr(settings, "transcription", None)
+    if transcription_settings is None:
+        logger.debug(
+            "MPS admission calibrated override skipped: transcription settings unavailable."
+        )
+        return None
+    if not bool(
+        getattr(
+            transcription_settings,
+            "mps_admission_calibration_overrides_enabled",
+            True,
+        )
+    ):
+        logger.debug(
+            "MPS admission calibrated override skipped for %s: disabled by config.",
+            runtime_request.model_name,
+        )
+        return None
+    report_path = _resolve_report_path(settings)
+    created_at_utc, recommendations = _read_report(path=report_path)
+    if created_at_utc is None:
+        logger.debug(
+            "MPS admission calibrated override skipped for %s: report unavailable or invalid (%s).",
+            runtime_request.model_name,
+            report_path,
+        )
+        return None
+    max_age_hours = _resolve_max_age_hours(settings)
+    if datetime.now(tz=UTC) - created_at_utc > timedelta(hours=max_age_hours):
+        logger.debug(
+            "MPS admission calibrated override skipped for %s: report is stale "
+            "(created_at=%s, max_age_hours=%.1f).",
+            runtime_request.model_name,
+            created_at_utc.isoformat(),
+            max_age_hours,
+        )
+        return None
+    backend_id = (
+        str(getattr(transcription_settings, "backend_id", "stable_whisper"))
+        .strip()
+        .lower()
+    )
+    key = (backend_id, runtime_request.model_name)
+    recommendation = recommendations.get(key)
+    if recommendation is None:
+        logger.debug(
+            "MPS admission calibrated override skipped for %s: no matching recommendation "
+            "(backend=%s).",
+            runtime_request.model_name,
+            backend_id,
+        )
+        return None
+    minimum_confidence = _resolve_minimum_confidence(settings)
+    if not _confidence_at_least(
+        recommendation.confidence,
+        threshold=minimum_confidence,
+    ):
+        logger.debug(
+            "MPS admission calibrated override skipped for %s: confidence %s below threshold %s.",
+            runtime_request.model_name,
+            recommendation.confidence,
+            minimum_confidence,
+        )
+        return None
+    logger.debug(
+        "MPS admission calibrated override candidate loaded for %s/%s "
+        "(recommendation=%s, confidence=%s).",
+        backend_id,
+        runtime_request.model_name,
+        recommendation.recommendation,
+        recommendation.confidence,
+    )
+    return recommendation
+
+
+def _resolve_report_path(settings: AppConfig) -> Path:
+    """Resolves report path using explicit config or default models folder path."""
+    transcription_settings = getattr(settings, "transcription", None)
+    configured = getattr(
+        transcription_settings,
+        "mps_admission_calibration_report_path",
+        None,
+    )
+    if isinstance(configured, Path):
+        return configured
+    if isinstance(configured, str) and configured.strip():
+        return Path(configured).expanduser()
+    models = getattr(settings, "models", None)
+    folder = getattr(models, "folder", None)
+    if isinstance(folder, Path):
+        return folder / _REPORT_FILE_NAME
+    if isinstance(folder, str) and folder.strip():
+        return Path(folder).expanduser() / _REPORT_FILE_NAME
+    return Path(_REPORT_FILE_NAME)
+
+
+def _resolve_minimum_confidence(settings: AppConfig) -> RecommendationConfidence:
+    """Reads minimum confidence threshold for calibrated overrides."""
+    transcription_settings = getattr(settings, "transcription", None)
+    configured = (
+        str(
+            getattr(
+                transcription_settings,
+                "mps_admission_calibration_min_confidence",
+                "high",
+            )
+        )
+        .strip()
+        .lower()
+    )
+    if configured in {"high", "medium", "low"}:
+        return cast(RecommendationConfidence, configured)
+    return "high"
+
+
+def _resolve_max_age_hours(settings: AppConfig) -> float:
+    """Reads maximum accepted calibration report age in hours."""
+    transcription_settings = getattr(settings, "transcription", None)
+    configured = getattr(
+        transcription_settings,
+        "mps_admission_calibration_report_max_age_hours",
+        168.0,
+    )
+    if isinstance(configured, int | float) and not isinstance(configured, bool):
+        return max(float(configured), 1.0)
+    return 168.0
+
+
+def _confidence_at_least(
+    value: RecommendationConfidence,
+    *,
+    threshold: RecommendationConfidence,
+) -> bool:
+    """Returns whether recommendation confidence meets configured threshold."""
+    return _CONFIDENCE_RANK[value] >= _CONFIDENCE_RANK[threshold]
+
+
+@lru_cache(maxsize=8)
+def _read_report_cached(
+    resolved_path: str,
+    mtime_ns: int,
+) -> tuple[datetime | None, dict[tuple[str, str], CalibrationRecommendation]]:
+    """Reads one calibration report from disk with mtime-aware cache key."""
+    del mtime_ns
+    path = Path(resolved_path)
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        logging.getLogger(__name__).debug(
+            "Failed to load transcription runtime calibration report from %s.",
+            path,
+            exc_info=True,
+        )
+        return None, {}
+
+    created_at_raw = payload.get("created_at_utc")
+    if not isinstance(created_at_raw, str) or not created_at_raw.strip():
+        return None, {}
+    try:
+        created_at_utc = datetime.fromisoformat(created_at_raw)
+    except ValueError:
+        return None, {}
+    if created_at_utc.tzinfo is None:
+        created_at_utc = created_at_utc.replace(tzinfo=UTC)
+    rows = payload.get("profiles")
+    if not isinstance(rows, list):
+        return created_at_utc, {}
+    recommendations: dict[tuple[str, str], CalibrationRecommendation] = {}
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        backend_id_raw = row.get("backend_id")
+        model_name_raw = row.get("model_name")
+        recommendation_raw = row.get("recommendation")
+        confidence_raw = row.get("confidence")
+        if not (
+            isinstance(backend_id_raw, str)
+            and isinstance(model_name_raw, str)
+            and isinstance(recommendation_raw, str)
+            and isinstance(confidence_raw, str)
+        ):
+            continue
+        backend_id = backend_id_raw.strip().lower()
+        model_name = model_name_raw.strip()
+        recommendation_text = recommendation_raw.strip().lower()
+        confidence_text = confidence_raw.strip().lower()
+        if recommendation_text not in _RECOMMENDATION_PRIORITY:
+            continue
+        if confidence_text not in _CONFIDENCE_RANK:
+            continue
+        recommendation = CalibrationRecommendation(
+            backend_id=backend_id,
+            model_name=model_name,
+            recommendation=cast(RuntimeRecommendation, recommendation_text),
+            confidence=cast(RecommendationConfidence, confidence_text),
+            reason=str(row.get("reason", "")).strip(),
+            source_profile=str(row.get("profile", "")).strip(),
+        )
+        key = (backend_id, model_name)
+        existing = recommendations.get(key)
+        if existing is None:
+            recommendations[key] = recommendation
+            continue
+        if (
+            _CONFIDENCE_RANK[recommendation.confidence]
+            > _CONFIDENCE_RANK[existing.confidence]
+        ):
+            recommendations[key] = recommendation
+            continue
+        if (
+            _CONFIDENCE_RANK[recommendation.confidence]
+            == _CONFIDENCE_RANK[existing.confidence]
+            and _RECOMMENDATION_PRIORITY[recommendation.recommendation]
+            > _RECOMMENDATION_PRIORITY[existing.recommendation]
+        ):
+            recommendations[key] = recommendation
+    return created_at_utc, recommendations
+
+
+def _read_report(
+    *,
+    path: Path,
+) -> tuple[datetime | None, dict[tuple[str, str], CalibrationRecommendation]]:
+    """Reads one calibration report using cached parser keyed by mtime."""
+    try:
+        stat_result = path.stat()
+    except OSError:
+        return None, {}
+    return _read_report_cached(str(path), stat_result.st_mtime_ns)

--- a/ser/transcript/runtime_failures.py
+++ b/ser/transcript/runtime_failures.py
@@ -1,0 +1,101 @@
+"""Failure classification utilities for transcription runtime retries."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class FailureDisposition(StrEnum):
+    """Action to take after one runtime transcription failure."""
+
+    RETRY_NEXT_PRECISION = "retry_next_precision"
+    FAILOVER_CPU_NOW = "failover_cpu_now"
+    FAIL_FAST = "fail_fast"
+
+
+@dataclass(frozen=True, slots=True)
+class TranscriptionFailureClassification:
+    """Outcome of classifying one transcription failure."""
+
+    disposition: FailureDisposition
+    reason_code: str
+    is_retryable: bool
+
+
+def classify_stable_whisper_transcription_failure(
+    *,
+    err: Exception,
+    runtime_device_type: str,
+    precision: str,
+) -> TranscriptionFailureClassification:
+    """Classifies stable-whisper transcription failures into retry/failover actions."""
+    message = " ".join(str(err).split()).lower()
+    is_retryable = _is_retryable_runtime_failure(message=message, err=err)
+    if not is_retryable:
+        return TranscriptionFailureClassification(
+            disposition=FailureDisposition.FAIL_FAST,
+            reason_code="non_retryable_runtime_error",
+            is_retryable=False,
+        )
+    if (
+        runtime_device_type == "mps"
+        and precision == "float16"
+        and _is_pure_mps_oom(message)
+    ):
+        return TranscriptionFailureClassification(
+            disposition=FailureDisposition.FAILOVER_CPU_NOW,
+            reason_code="mps_oom_hard_float16",
+            is_retryable=True,
+        )
+    return TranscriptionFailureClassification(
+        disposition=FailureDisposition.RETRY_NEXT_PRECISION,
+        reason_code="retryable_runtime_failure",
+        is_retryable=True,
+    )
+
+
+def _is_retryable_runtime_failure(*, message: str, err: Exception) -> bool:
+    """Returns whether one runtime failure is likely to succeed with fallback."""
+    if isinstance(err, NotImplementedError):
+        not_implemented_markers = (
+            "sparsemps",
+            "could not run",
+            "aten::",
+            "backend",
+            "mps",
+        )
+        if all(marker in message for marker in not_implemented_markers):
+            return True
+        if "std_mean" in message and "mps" in message:
+            return True
+    retryable_markers = (
+        "out of memory",
+        "mps backend out of memory",
+        "fp16 is not supported on cpu",
+        "fp16 is not supported",
+        "half precision is not supported",
+        "bfloat16 is not supported",
+        "unsupported dtype",
+        "sparsemps",
+        "aten::empty.memory_format",
+        "cannot convert a mps tensor to float64 dtype",
+        "std_mean.correction",
+    )
+    return any(marker in message for marker in retryable_markers)
+
+
+def _is_pure_mps_oom(message: str) -> bool:
+    """Returns whether one failure is a hard MPS OOM, not an operator/type gap."""
+    if "out of memory" not in message or "mps" not in message:
+        return False
+    compatibility_gap_markers = (
+        "sparsemps",
+        "aten::empty.memory_format",
+        "std_mean",
+        "unsupported dtype",
+        "cannot convert a mps tensor to float64 dtype",
+        "not currently implemented",
+        "could not run",
+    )
+    return not any(marker in message for marker in compatibility_gap_markers)

--- a/ser/transcript/runtime_policy.py
+++ b/ser/transcript/runtime_policy.py
@@ -1,0 +1,162 @@
+"""Runtime policy resolution for transcription backends."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from ser.profiles import TranscriptionBackendId
+from ser.utils.torch_inference import maybe_resolve_torch_runtime
+
+_SUPPORTED_DTYPE_SELECTORS: frozenset[str] = frozenset(
+    {"auto", "float16", "float32", "bfloat16"}
+)
+DEFAULT_MPS_LOW_MEMORY_THRESHOLD_GB: float = 16.0
+_BACKEND_SUPPORTED_PRECISIONS: dict[TranscriptionBackendId, frozenset[str]] = {
+    "stable_whisper": frozenset({"float16", "float32"}),
+    "faster_whisper": frozenset({"float16", "float32"}),
+}
+_BACKEND_SUPPORTED_DEVICE_TYPES: dict[TranscriptionBackendId, frozenset[str]] = {
+    "stable_whisper": frozenset({"cpu", "cuda", "mps"}),
+    "faster_whisper": frozenset({"cpu", "cuda"}),
+}
+
+MemoryTier = Literal["low", "high", "unknown", "not_applicable"]
+
+
+@dataclass(frozen=True, slots=True)
+class TranscriptionRuntimePolicy:
+    """Resolved runtime selectors and precision fallback order for transcription."""
+
+    device_spec: str
+    device_type: str
+    precision_candidates: tuple[str, ...]
+    memory_tier: MemoryTier
+    reason: str
+
+
+def _normalize_dtype_selector(dtype: str) -> str:
+    """Returns validated dtype selector or auto fallback."""
+    normalized = dtype.strip().lower()
+    return normalized if normalized in _SUPPORTED_DTYPE_SELECTORS else "auto"
+
+
+def _normalize_mps_low_memory_threshold_gb(value: float) -> float:
+    """Normalizes one configured MPS low-memory threshold value."""
+    return value if value > 0.0 else DEFAULT_MPS_LOW_MEMORY_THRESHOLD_GB
+
+
+def _resolve_mps_memory_tier(*, low_memory_threshold_gb: float) -> MemoryTier:
+    """Classifies host memory tier for MPS precision ordering decisions."""
+    try:
+        import psutil
+    except ModuleNotFoundError:
+        return "unknown"
+    try:
+        total_memory_bytes = float(psutil.virtual_memory().total)
+    except (AttributeError, OSError, ValueError):
+        return "unknown"
+    if total_memory_bytes <= 0.0:
+        return "unknown"
+    threshold_bytes = low_memory_threshold_gb * (1024.0**3)
+    return "low" if total_memory_bytes <= threshold_bytes else "high"
+
+
+def _dedupe_candidates(candidates: tuple[str, ...]) -> tuple[str, ...]:
+    """Returns candidates with stable ordering and no duplicates."""
+    deduped = tuple(dict.fromkeys(candidates))
+    return deduped if deduped else ("float32",)
+
+
+def _base_precision_candidates(
+    *,
+    device_type: str,
+    requested_dtype: str,
+    memory_tier: MemoryTier,
+) -> tuple[str, ...]:
+    """Returns backend-agnostic base precision fallback order."""
+    if device_type == "cpu":
+        return ("float32",)
+    if requested_dtype == "float16":
+        return ("float16",)
+    if requested_dtype == "float32":
+        return ("float32",)
+    if requested_dtype == "bfloat16":
+        return ("bfloat16", "float16", "float32")
+    if device_type == "cuda":
+        return ("float16", "float32")
+    if device_type == "mps":
+        del memory_tier
+        return ("float16", "float32")
+    return ("float32",)
+
+
+def resolve_transcription_runtime_policy(
+    *,
+    backend_id: TranscriptionBackendId,
+    requested_device: str,
+    requested_dtype: str,
+    mps_low_memory_threshold_gb: float = DEFAULT_MPS_LOW_MEMORY_THRESHOLD_GB,
+) -> TranscriptionRuntimePolicy:
+    """Resolves runtime device and precision fallback order for one backend."""
+    normalized_dtype = _normalize_dtype_selector(requested_dtype)
+    normalized_mps_threshold_gb = _normalize_mps_low_memory_threshold_gb(
+        mps_low_memory_threshold_gb
+    )
+    reason_tokens: list[str] = []
+    memory_tier: MemoryTier = "not_applicable"
+    device_spec = "cpu"
+    device_type = "cpu"
+    try:
+        runtime = maybe_resolve_torch_runtime(device=requested_device, dtype="float32")
+    except RuntimeError as err:
+        reason_tokens.append(f"device_resolution_fallback_cpu({err})")
+        runtime = None
+    if runtime is None:
+        reason_tokens.append("torch_runtime_unavailable")
+    else:
+        device_spec = runtime.device_spec
+        device_type = runtime.device_type
+
+    supported_device_types = _BACKEND_SUPPORTED_DEVICE_TYPES[backend_id]
+    if device_type not in supported_device_types:
+        reason_tokens.append(
+            f"backend_{backend_id}_does_not_support_device_{device_type}"
+        )
+        device_spec = "cpu"
+        device_type = "cpu"
+
+    if device_type == "mps":
+        memory_tier = _resolve_mps_memory_tier(
+            low_memory_threshold_gb=normalized_mps_threshold_gb,
+        )
+        reason_tokens.append(f"mps_memory_tier_{memory_tier}_informational_only")
+
+    base_candidates = _base_precision_candidates(
+        device_type=device_type,
+        requested_dtype=normalized_dtype,
+        memory_tier=memory_tier,
+    )
+    supported_precisions = _BACKEND_SUPPORTED_PRECISIONS[backend_id]
+    filtered_candidates = tuple(
+        precision for precision in base_candidates if precision in supported_precisions
+    )
+    if not filtered_candidates:
+        filtered_candidates = ("float32",)
+        reason_tokens.append("precision_fallback_float32")
+    elif len(filtered_candidates) != len(base_candidates):
+        reason_tokens.append("precision_candidates_filtered_by_backend_capabilities")
+
+    if not reason_tokens:
+        if normalized_dtype == "auto":
+            reason_tokens.append("auto_precision_policy")
+        else:
+            reason_tokens.append(f"explicit_precision_{normalized_dtype}")
+
+    return TranscriptionRuntimePolicy(
+        device_spec=device_spec,
+        device_type=device_type,
+        precision_candidates=_dedupe_candidates(filtered_candidates),
+        memory_tier=memory_tier,
+        reason=";".join(reason_tokens),
+    )

--- a/ser/transcript/transcript_extractor.py
+++ b/ser/transcript/transcript_extractor.py
@@ -2,9 +2,15 @@
 
 from __future__ import annotations
 
+import gc
 import logging
+import multiprocessing as mp
+import sys
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Protocol, cast
+from multiprocessing.connection import Connection
+from multiprocessing.process import BaseProcess
+from types import ModuleType
+from typing import TYPE_CHECKING, Literal, Never, Protocol, cast
 
 from ser.config import AppConfig, get_settings
 from ser.domain import TranscriptWord
@@ -24,12 +30,18 @@ from ser.transcript.backends import (
     CompatibilityReport,
     resolve_transcription_backend_adapter,
 )
+from ser.transcript.runtime_policy import (
+    DEFAULT_MPS_LOW_MEMORY_THRESHOLD_GB,
+    resolve_transcription_runtime_policy,
+)
 from ser.utils.logger import get_logger
 
 if TYPE_CHECKING:
     from stable_whisper.result import WhisperResult
 
 logger: logging.Logger = get_logger(__name__)
+_TERMINATE_GRACE_SECONDS = 5.0
+_KILL_GRACE_SECONDS = 2.0
 
 
 class TranscriptionError(RuntimeError):
@@ -52,6 +64,22 @@ class TranscriptionProfile:
     model_name: str = "large-v2"
     use_demucs: bool = True
     use_vad: bool = True
+
+
+@dataclass(frozen=True)
+class _TranscriptionProcessPayload:
+    """Serializable payload for one process-isolated transcription attempt."""
+
+    file_path: str
+    language: str
+    profile: TranscriptionProfile
+
+
+type _WorkerPhase = Literal["setup_complete", "model_loaded"]
+type _WorkerPhaseMessage = tuple[Literal["phase"], _WorkerPhase]
+type _WorkerSuccessMessage = tuple[Literal["ok"], list[tuple[str, float, float]]]
+type _WorkerErrorMessage = tuple[Literal["err"], str, str, str]
+type _WorkerMessage = _WorkerPhaseMessage | _WorkerSuccessMessage | _WorkerErrorMessage
 
 
 def _resolve_backend_id(raw_backend_id: object) -> TranscriptionBackendId:
@@ -81,12 +109,41 @@ def resolve_transcription_profile(
 
 def _runtime_request_from_profile(
     active_profile: TranscriptionProfile,
+    settings: AppConfig,
 ) -> BackendRuntimeRequest:
     """Builds one backend runtime request from transcription profile settings."""
+    torch_runtime = getattr(settings, "torch_runtime", None)
+    transcription_settings = getattr(settings, "transcription", None)
+    requested_device = getattr(torch_runtime, "device", "cpu")
+    requested_dtype = getattr(torch_runtime, "dtype", "auto")
+    requested_mps_low_memory_threshold = getattr(
+        transcription_settings,
+        "mps_low_memory_threshold_gb",
+        DEFAULT_MPS_LOW_MEMORY_THRESHOLD_GB,
+    )
+    runtime_policy = resolve_transcription_runtime_policy(
+        backend_id=active_profile.backend_id,
+        requested_device=(
+            requested_device if isinstance(requested_device, str) else "cpu"
+        ),
+        requested_dtype=requested_dtype if isinstance(requested_dtype, str) else "auto",
+        mps_low_memory_threshold_gb=(
+            requested_mps_low_memory_threshold
+            if (
+                isinstance(requested_mps_low_memory_threshold, int | float)
+                and not isinstance(requested_mps_low_memory_threshold, bool)
+            )
+            else DEFAULT_MPS_LOW_MEMORY_THRESHOLD_GB
+        ),
+    )
     return BackendRuntimeRequest(
         model_name=active_profile.model_name,
         use_demucs=active_profile.use_demucs,
         use_vad=active_profile.use_vad,
+        device_spec=runtime_policy.device_spec,
+        device_type=runtime_policy.device_type,
+        precision_candidates=runtime_policy.precision_candidates,
+        memory_tier=runtime_policy.memory_tier,
     )
 
 
@@ -94,12 +151,17 @@ def _check_adapter_compatibility(
     *,
     active_profile: TranscriptionProfile,
     settings: AppConfig,
+    runtime_request: BackendRuntimeRequest | None = None,
 ) -> CompatibilityReport:
     """Validates backend compatibility and logs non-blocking compatibility issues."""
     adapter = resolve_transcription_backend_adapter(active_profile.backend_id)
-    runtime_request = _runtime_request_from_profile(active_profile)
+    resolved_runtime_request = (
+        _runtime_request_from_profile(active_profile, settings)
+        if runtime_request is None
+        else runtime_request
+    )
     report = adapter.check_compatibility(
-        runtime_request=runtime_request,
+        runtime_request=resolved_runtime_request,
         settings=settings,
     )
     if report.noise_issues:
@@ -133,13 +195,15 @@ def _transcription_setup_required(
     settings: AppConfig,
 ) -> bool:
     """Returns whether a setup/download phase is needed before model load."""
+    runtime_request = _runtime_request_from_profile(active_profile, settings)
     _check_adapter_compatibility(
         active_profile=active_profile,
         settings=settings,
+        runtime_request=runtime_request,
     )
     adapter = resolve_transcription_backend_adapter(active_profile.backend_id)
     return adapter.setup_required(
-        runtime_request=_runtime_request_from_profile(active_profile),
+        runtime_request=runtime_request,
         settings=settings,
     )
 
@@ -150,38 +214,290 @@ def _prepare_transcription_assets(
     settings: AppConfig,
 ) -> None:
     """Ensures required stable-whisper model assets are present locally."""
+    runtime_request = _runtime_request_from_profile(active_profile, settings)
     _check_adapter_compatibility(
         active_profile=active_profile,
         settings=settings,
+        runtime_request=runtime_request,
     )
     adapter = resolve_transcription_backend_adapter(active_profile.backend_id)
     adapter.prepare_assets(
-        runtime_request=_runtime_request_from_profile(active_profile),
+        runtime_request=runtime_request,
         settings=settings,
     )
 
 
 def load_whisper_model(profile: TranscriptionProfile | None = None) -> object:
-    """Loads the configured transcription model for CPU inference.
+    """Loads the configured transcription model for resolved runtime settings.
 
     Returns:
         The loaded Whisper model instance.
     """
     settings: AppConfig = get_settings()
     active_profile: TranscriptionProfile = resolve_transcription_profile(profile)
+    runtime_request = _runtime_request_from_profile(active_profile, settings)
     try:
         _check_adapter_compatibility(
             active_profile=active_profile,
             settings=settings,
+            runtime_request=runtime_request,
+        )
+        logger.info(
+            "Transcription runtime resolved (backend=%s, device=%s, precision=%s, memory_tier=%s).",
+            active_profile.backend_id,
+            runtime_request.device_spec,
+            ",".join(runtime_request.precision_candidates),
+            runtime_request.memory_tier,
         )
         adapter = resolve_transcription_backend_adapter(active_profile.backend_id)
         return adapter.load_model(
-            runtime_request=_runtime_request_from_profile(active_profile),
+            runtime_request=runtime_request,
             settings=settings,
         )
     except Exception as err:
         logger.error(msg=f"Failed to load transcription model: {err}", exc_info=True)
         raise TranscriptionError("Failed to load transcription model.") from err
+
+
+def _should_use_process_isolated_path(profile: TranscriptionProfile) -> bool:
+    """Returns whether one transcription profile should execute in a worker process."""
+    return profile.backend_id == "faster_whisper"
+
+
+def _runtime_request_for_isolated_faster_whisper(
+    *,
+    profile: TranscriptionProfile,
+    settings: AppConfig,
+) -> BackendRuntimeRequest:
+    """Builds one faster-whisper runtime request without importing torch in worker."""
+    torch_runtime = getattr(settings, "torch_runtime", None)
+    requested_device = getattr(torch_runtime, "device", "cpu")
+    requested_dtype = getattr(torch_runtime, "dtype", "auto")
+    device_text = (
+        requested_device.strip().lower() if isinstance(requested_device, str) else "cpu"
+    )
+    dtype_text = (
+        requested_dtype.strip().lower() if isinstance(requested_dtype, str) else "auto"
+    )
+    if device_text.startswith("cuda"):
+        device_spec = requested_device.strip() or "cuda"
+        precision_candidates = (
+            (dtype_text,)
+            if dtype_text in {"float16", "float32"}
+            else ("float16", "float32")
+        )
+        return BackendRuntimeRequest(
+            model_name=profile.model_name,
+            use_demucs=profile.use_demucs,
+            use_vad=profile.use_vad,
+            device_spec=device_spec,
+            device_type="cuda",
+            precision_candidates=precision_candidates,
+            memory_tier="not_applicable",
+        )
+    return BackendRuntimeRequest(
+        model_name=profile.model_name,
+        use_demucs=profile.use_demucs,
+        use_vad=profile.use_vad,
+        device_spec="cpu",
+        device_type="cpu",
+        precision_candidates=("float32",),
+        memory_tier="not_applicable",
+    )
+
+
+def _run_faster_whisper_process_isolated(
+    *,
+    file_path: str,
+    language: str,
+    profile: TranscriptionProfile,
+) -> list[TranscriptWord]:
+    """Runs faster-whisper setup/load/transcribe inside one spawned worker process."""
+    payload = _TranscriptionProcessPayload(
+        file_path=file_path,
+        language=language,
+        profile=profile,
+    )
+    context = mp.get_context("spawn")
+    parent_conn, child_conn = context.Pipe(duplex=False)
+    process = context.Process(
+        target=_transcription_worker_entry,
+        args=(payload, child_conn),
+        daemon=False,
+    )
+    setup_started_at = log_phase_started(
+        logger,
+        phase_name=PHASE_TRANSCRIPTION_SETUP,
+    )
+    model_load_started_at: float | None = None
+    transcription_started_at: float | None = None
+    process.start()
+    child_conn.close()
+    try:
+        setup_message = _recv_worker_message(parent_conn, stage="setup")
+        if setup_message == ("phase", "setup_complete"):
+            log_phase_completed(
+                logger,
+                phase_name=PHASE_TRANSCRIPTION_SETUP,
+                started_at=setup_started_at,
+            )
+            model_load_started_at = log_phase_started(
+                logger,
+                phase_name=PHASE_TRANSCRIPTION_MODEL_LOAD,
+            )
+        else:
+            _raise_worker_error(setup_message)
+
+        model_load_message = _recv_worker_message(parent_conn, stage="model_load")
+        if model_load_message == ("phase", "model_loaded"):
+            if model_load_started_at is None:
+                raise TranscriptionError(
+                    "Transcription worker completed model load before phase timer start."
+                )
+            log_phase_completed(
+                logger,
+                phase_name=PHASE_TRANSCRIPTION_MODEL_LOAD,
+                started_at=model_load_started_at,
+            )
+            transcription_started_at = log_phase_started(
+                logger,
+                phase_name=PHASE_TRANSCRIPTION,
+            )
+        else:
+            _raise_worker_error(model_load_message)
+
+        completion_message = _recv_worker_message(parent_conn, stage="transcription")
+        if (
+            isinstance(completion_message, tuple)
+            and len(completion_message) == 2
+            and completion_message[0] == "ok"
+            and isinstance(completion_message[1], list)
+        ):
+            serialized_words = completion_message[1]
+            if transcription_started_at is None:
+                raise TranscriptionError(
+                    "Transcription worker completed transcription before phase timer start."
+                )
+            log_phase_completed(
+                logger,
+                phase_name=PHASE_TRANSCRIPTION,
+                started_at=transcription_started_at,
+            )
+            return [
+                TranscriptWord(word, start_seconds, end_seconds)
+                for word, start_seconds, end_seconds in serialized_words
+            ]
+        _raise_worker_error(completion_message)
+    except Exception:
+        if transcription_started_at is not None:
+            log_phase_failed(
+                logger,
+                phase_name=PHASE_TRANSCRIPTION,
+                started_at=transcription_started_at,
+            )
+        elif model_load_started_at is not None:
+            log_phase_failed(
+                logger,
+                phase_name=PHASE_TRANSCRIPTION_MODEL_LOAD,
+                started_at=model_load_started_at,
+            )
+        else:
+            log_phase_failed(
+                logger,
+                phase_name=PHASE_TRANSCRIPTION_SETUP,
+                started_at=setup_started_at,
+            )
+        raise
+    finally:
+        parent_conn.close()
+        if process.is_alive():
+            _terminate_worker_process(process)
+        else:
+            process.join(timeout=_TERMINATE_GRACE_SECONDS)
+        process.close()
+
+
+def _recv_worker_message(connection: Connection, *, stage: str) -> _WorkerMessage:
+    """Receives one worker message and validates tuple envelope shape."""
+    try:
+        raw_message = connection.recv()
+    except EOFError as err:
+        raise TranscriptionError(
+            f"Transcription worker exited before sending {stage} payload."
+        ) from err
+    if not isinstance(raw_message, tuple) or not raw_message:
+        raise TranscriptionError("Transcription worker returned malformed payload.")
+    return cast(_WorkerMessage, raw_message)
+
+
+def _raise_worker_error(message: _WorkerMessage) -> Never:
+    """Raises one transcription-domain error from a worker payload."""
+    if (
+        isinstance(message, tuple)
+        and len(message) == 4
+        and message[0] == "err"
+        and isinstance(message[1], str)
+        and isinstance(message[2], str)
+        and isinstance(message[3], str)
+    ):
+        stage, error_type, error_message = message[1], message[2], message[3]
+        raise TranscriptionError(
+            f"Transcription worker {stage} failed with {error_type}: {error_message}"
+        )
+    raise TranscriptionError("Transcription worker returned unexpected payload shape.")
+
+
+def _terminate_worker_process(process: BaseProcess) -> None:
+    """Terminates a worker process with kill fallback."""
+    process.terminate()
+    process.join(timeout=_TERMINATE_GRACE_SECONDS)
+    if process.is_alive():
+        process.kill()
+        process.join(timeout=_KILL_GRACE_SECONDS)
+
+
+def _transcription_worker_entry(
+    payload: _TranscriptionProcessPayload,
+    connection: Connection,
+) -> None:
+    """Executes faster-whisper transcription inside one isolated worker process."""
+    stage = "setup"
+    try:
+        if payload.profile.backend_id != "faster_whisper":
+            raise RuntimeError(
+                f"Unsupported process-isolated backend: {payload.profile.backend_id!r}."
+            )
+        # Prevent ctranslate2 from importing torch/functorch in this worker.
+        sys.modules["torch"] = cast(ModuleType, None)
+        settings = get_settings()
+        runtime_request = _runtime_request_for_isolated_faster_whisper(
+            profile=payload.profile,
+            settings=settings,
+        )
+        adapter = resolve_transcription_backend_adapter(payload.profile.backend_id)
+        if adapter.setup_required(runtime_request=runtime_request, settings=settings):
+            adapter.prepare_assets(runtime_request=runtime_request, settings=settings)
+        connection.send(("phase", "setup_complete"))
+        stage = "model_load"
+        model = adapter.load_model(runtime_request=runtime_request, settings=settings)
+        connection.send(("phase", "model_loaded"))
+        stage = "transcription"
+        transcript_words = adapter.transcribe(
+            model=model,
+            runtime_request=runtime_request,
+            file_path=payload.file_path,
+            language=payload.language,
+            settings=settings,
+        )
+        serialized_words = [
+            (word.word, word.start_seconds, word.end_seconds)
+            for word in transcript_words
+        ]
+        connection.send(("ok", serialized_words))
+    except BaseException as err:
+        connection.send(("err", stage, type(err).__name__, str(err)))
+    finally:
+        connection.close()
 
 
 def extract_transcript(
@@ -208,9 +524,31 @@ def _extract_transcript(
     language: str,
     profile: TranscriptionProfile | None = None,
 ) -> list[TranscriptWord]:
-    """Internal transcript workflow with model loading and formatting."""
+    """Internal transcript workflow with backend-specific execution strategy."""
+    active_profile = resolve_transcription_profile(profile)
+    if _should_use_process_isolated_path(active_profile):
+        return _run_faster_whisper_process_isolated(
+            file_path=file_path,
+            language=language,
+            profile=active_profile,
+        )
+    return _extract_transcript_in_process(
+        file_path=file_path,
+        language=language,
+        profile=active_profile,
+    )
+
+
+def _extract_transcript_in_process(
+    *,
+    file_path: str,
+    language: str,
+    profile: TranscriptionProfile,
+) -> list[TranscriptWord]:
+    """Runs one in-process transcript workflow with phase-aware logging."""
     settings: AppConfig = get_settings()
-    active_profile: TranscriptionProfile = resolve_transcription_profile(profile)
+    active_profile = profile
+    model: object | None = None
 
     if _transcription_setup_required(
         active_profile=active_profile,
@@ -262,33 +600,64 @@ def _extract_transcript(
         phase_name=PHASE_TRANSCRIPTION,
     )
     try:
-        transcript_words: list[TranscriptWord] = (
-            __transcribe_file(model, language, file_path)
-            if profile is None
-            else _transcribe_file_with_profile(
+        try:
+            transcript_words = _transcribe_file_with_profile(
                 model,
                 language,
                 file_path,
                 active_profile,
             )
-        )
-    except Exception:
-        log_phase_failed(
+        except Exception:
+            log_phase_failed(
+                logger,
+                phase_name=PHASE_TRANSCRIPTION,
+                started_at=transcription_started_at,
+            )
+            raise
+        log_phase_completed(
             logger,
             phase_name=PHASE_TRANSCRIPTION,
             started_at=transcription_started_at,
         )
-        raise
-    log_phase_completed(
-        logger,
-        phase_name=PHASE_TRANSCRIPTION,
-        started_at=transcription_started_at,
-    )
+        if not transcript_words:
+            logger.info(msg="Transcript extraction succeeded but returned no words.")
+        logger.debug(msg="Transcript output formatted successfully.")
+        return transcript_words
+    finally:
+        _release_transcription_runtime_memory(model=model)
 
-    if not transcript_words:
-        logger.info(msg="Transcript extraction succeeded but returned no words.")
-    logger.debug(msg="Transcript output formatted successfully.")
-    return transcript_words
+
+def _release_transcription_runtime_memory(*, model: object | None) -> None:
+    """Releases best-effort Torch runtime memory after one in-process transcript run."""
+    del model
+    gc.collect()
+    torch_module = sys.modules.get("torch")
+    if not isinstance(torch_module, ModuleType):
+        return
+    mps_module = getattr(torch_module, "mps", None)
+    if isinstance(mps_module, ModuleType):
+        is_available = getattr(mps_module, "is_available", None)
+        empty_cache = getattr(mps_module, "empty_cache", None)
+        try:
+            if callable(is_available) and is_available() and callable(empty_cache):
+                empty_cache()
+        except Exception:
+            logger.debug(
+                "Ignored failure while emptying torch MPS cache after transcription.",
+                exc_info=True,
+            )
+    cuda_module = getattr(torch_module, "cuda", None)
+    if isinstance(cuda_module, ModuleType):
+        is_available = getattr(cuda_module, "is_available", None)
+        empty_cache = getattr(cuda_module, "empty_cache", None)
+        try:
+            if callable(is_available) and is_available() and callable(empty_cache):
+                empty_cache()
+        except Exception:
+            logger.debug(
+                "Ignored failure while emptying torch CUDA cache after transcription.",
+                exc_info=True,
+            )
 
 
 def __transcribe_file(
@@ -307,15 +676,17 @@ def _transcribe_file_with_profile(
     """Runs a Whisper transcription call using an explicit runtime profile."""
     settings: AppConfig = get_settings()
     active_profile: TranscriptionProfile = resolve_transcription_profile(profile)
+    runtime_request = _runtime_request_from_profile(active_profile, settings)
     _check_adapter_compatibility(
         active_profile=active_profile,
         settings=settings,
+        runtime_request=runtime_request,
     )
     adapter = resolve_transcription_backend_adapter(active_profile.backend_id)
     try:
         return adapter.transcribe(
             model=model,
-            runtime_request=_runtime_request_from_profile(active_profile),
+            runtime_request=runtime_request,
             file_path=file_path,
             language=language,
             settings=settings,

--- a/ser/utils/logger.py
+++ b/ser/utils/logger.py
@@ -5,25 +5,109 @@ from __future__ import annotations
 import io
 import logging
 import os
+import re
+import warnings
 from collections.abc import Iterator, Sequence
-from contextlib import contextmanager, redirect_stderr, redirect_stdout
+from contextlib import (
+    AbstractContextManager,
+    contextmanager,
+    nullcontext,
+    redirect_stderr,
+    redirect_stdout,
+)
 from dataclasses import dataclass
+from typing import Literal
 
 _LOG_FORMAT = "%(asctime)s - %(levelname)s - %(name)s - %(message)s"
 _LOGGING_CONFIGURED = False
 
 
+def _normalize_scope_value(value: str | None) -> str | None:
+    """Normalizes one scope value for policy matching."""
+    if value is None:
+        return None
+    normalized = value.strip().lower()
+    return normalized or None
+
+
+def _normalize_scope_values(values: frozenset[str]) -> frozenset[str]:
+    """Normalizes one frozenset of scope values for policy matching."""
+    return frozenset(
+        normalized
+        for normalized in (_normalize_scope_value(item) for item in values)
+        if normalized is not None
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class DependencyPolicyContext:
+    """Execution scope used to determine whether a dependency policy applies."""
+
+    backend_id: str | None = None
+    phase_name: str | None = None
+    op_tag: str | None = None
+
+    def __post_init__(self) -> None:
+        """Normalizes context values for robust matching."""
+        object.__setattr__(self, "backend_id", _normalize_scope_value(self.backend_id))
+        object.__setattr__(self, "phase_name", _normalize_scope_value(self.phase_name))
+        object.__setattr__(self, "op_tag", _normalize_scope_value(self.op_tag))
+
+
+@dataclass(frozen=True, slots=True)
+class WarningPolicy:
+    """Scoped warning policy applied during dependency execution contexts."""
+
+    policy_id: str
+    message_regex: str
+    module_regex: str
+    category: type[Warning]
+    action: Literal["default", "error", "ignore"] = "ignore"
+    backend_ids: frozenset[str] = frozenset()
+    phase_names: frozenset[str] = frozenset()
+    op_tags: frozenset[str] = frozenset()
+
+    def __post_init__(self) -> None:
+        """Validates and normalizes warning policy values."""
+        normalized_policy_id = self.policy_id.strip()
+        if not normalized_policy_id:
+            raise ValueError("WarningPolicy policy_id must be non-empty.")
+        if self.action not in {"default", "error", "ignore"}:
+            raise ValueError(f"Unsupported warning action {self.action!r}.")
+        if not self.message_regex.strip():
+            raise ValueError("WarningPolicy message_regex must be non-empty.")
+        if not self.module_regex.strip():
+            raise ValueError("WarningPolicy module_regex must be non-empty.")
+        re.compile(self.message_regex)
+        re.compile(self.module_regex)
+        if not issubclass(self.category, Warning):
+            raise TypeError("WarningPolicy category must be a Warning subclass.")
+        object.__setattr__(self, "policy_id", normalized_policy_id)
+        object.__setattr__(
+            self, "backend_ids", _normalize_scope_values(self.backend_ids)
+        )
+        object.__setattr__(
+            self, "phase_names", _normalize_scope_values(self.phase_names)
+        )
+        object.__setattr__(self, "op_tags", _normalize_scope_values(self.op_tags))
+
+
 @dataclass(frozen=True, slots=True)
 class DependencyLogPolicy:
-    """Scoped policy that targets noisy dependency log records."""
+    """Scoped policy that targets noisy dependency log records and warnings."""
 
     logger_prefixes: frozenset[str]
     root_path_markers: frozenset[str] = frozenset()
     demote_from_level: int = logging.INFO
     demote_to_level: int = logging.DEBUG
+    message_regex: str | None = None
+    backend_ids: frozenset[str] = frozenset()
+    phase_names: frozenset[str] = frozenset()
+    op_tags: frozenset[str] = frozenset()
+    warning_policies: tuple[WarningPolicy, ...] = ()
 
     def __post_init__(self) -> None:
-        """Normalizes dependency logger prefixes and root path markers."""
+        """Normalizes dependency logger prefixes, scope selectors, and warning rules."""
         normalized_prefixes = frozenset(
             prefix.strip().lower() for prefix in self.logger_prefixes if prefix.strip()
         )
@@ -32,14 +116,55 @@ class DependencyLogPolicy:
             for marker in self.root_path_markers
             if marker.strip()
         )
+        normalized_message_regex = self.message_regex
+        if normalized_message_regex is not None:
+            stripped_regex = normalized_message_regex.strip()
+            normalized_message_regex = stripped_regex or None
+            if normalized_message_regex is not None:
+                re.compile(normalized_message_regex)
         object.__setattr__(self, "logger_prefixes", normalized_prefixes)
         object.__setattr__(self, "root_path_markers", normalized_markers)
+        object.__setattr__(self, "message_regex", normalized_message_regex)
+        object.__setattr__(
+            self, "backend_ids", _normalize_scope_values(self.backend_ids)
+        )
+        object.__setattr__(
+            self, "phase_names", _normalize_scope_values(self.phase_names)
+        )
+        object.__setattr__(self, "op_tags", _normalize_scope_values(self.op_tags))
+        object.__setattr__(self, "warning_policies", tuple(self.warning_policies))
+
+
+def _policy_matches_context(
+    *,
+    backend_ids: frozenset[str],
+    phase_names: frozenset[str],
+    op_tags: frozenset[str],
+    context: DependencyPolicyContext | None,
+) -> bool:
+    """Returns whether scoped policy selectors match the active context."""
+    if not backend_ids and not phase_names and not op_tags:
+        return True
+    if context is None:
+        return False
+    if backend_ids and context.backend_id not in backend_ids:
+        return False
+    if phase_names and context.phase_name not in phase_names:
+        return False
+    if op_tags and context.op_tag not in op_tags:
+        return False
+    return True
 
 
 def _record_matches_policy(
     record: logging.LogRecord, policy: DependencyLogPolicy
 ) -> bool:
     """Checks whether a log record matches one dependency policy."""
+    if policy.message_regex is not None and not re.search(
+        policy.message_regex,
+        record.getMessage(),
+    ):
+        return False
     logger_name = record.name.strip().lower()
     for prefix in policy.logger_prefixes:
         if logger_name == prefix or logger_name.startswith(f"{prefix}."):
@@ -91,17 +216,45 @@ class DependencyLogFilter(logging.Filter):
         return True
 
 
+def _active_warning_policies(
+    *,
+    policy: DependencyLogPolicy,
+    context: DependencyPolicyContext | None,
+) -> tuple[WarningPolicy, ...]:
+    """Returns warning policies that apply to the active execution context."""
+    return tuple(
+        warning_policy
+        for warning_policy in policy.warning_policies
+        if _policy_matches_context(
+            backend_ids=warning_policy.backend_ids,
+            phase_names=warning_policy.phase_names,
+            op_tags=warning_policy.op_tags,
+            context=context,
+        )
+    )
+
+
 @contextmanager
 def scoped_dependency_log_policy(
     *,
     policy: DependencyLogPolicy,
+    context: DependencyPolicyContext | None = None,
     keep_demoted: bool = True,
     handlers: Sequence[logging.Handler] | None = None,
     capture_std_streams: bool = False,
     suppressed_output_logger: logging.Logger | None = None,
     suppressed_output_level: int = logging.DEBUG,
 ) -> Iterator[None]:
-    """Applies one dependency logging policy for the current code path scope."""
+    """Applies one dependency policy for the current code path scope."""
+    if not _policy_matches_context(
+        backend_ids=policy.backend_ids,
+        phase_names=policy.phase_names,
+        op_tags=policy.op_tags,
+        context=context,
+    ):
+        yield
+        return
+
     active_handlers = (
         tuple(handlers) if handlers is not None else tuple(logging.getLogger().handlers)
     )
@@ -115,14 +268,25 @@ def scoped_dependency_log_policy(
 
     stdout_buffer: io.StringIO | None = None
     stderr_buffer: io.StringIO | None = None
+    warning_policies = _active_warning_policies(policy=policy, context=context)
+    warning_context: AbstractContextManager[object]
+    warning_context = warnings.catch_warnings() if warning_policies else nullcontext()
     try:
-        if capture_std_streams:
-            stdout_buffer = io.StringIO()
-            stderr_buffer = io.StringIO()
-            with redirect_stdout(stdout_buffer), redirect_stderr(stderr_buffer):
-                yield
-            return
-        yield
+        with warning_context:
+            for warning_policy in warning_policies:
+                warnings.filterwarnings(
+                    warning_policy.action,
+                    message=warning_policy.message_regex,
+                    category=warning_policy.category,
+                    module=warning_policy.module_regex,
+                )
+            if capture_std_streams:
+                stdout_buffer = io.StringIO()
+                stderr_buffer = io.StringIO()
+                with redirect_stdout(stdout_buffer), redirect_stderr(stderr_buffer):
+                    yield
+                return
+            yield
     finally:
         for handler in active_handlers:
             handler.removeFilter(dependency_filter)

--- a/ser/utils/transcription_compat.py
+++ b/ser/utils/transcription_compat.py
@@ -1,0 +1,123 @@
+"""Compatibility helpers for transcription backend runtime selection."""
+
+from __future__ import annotations
+
+import importlib.util
+import platform
+import sys
+from functools import lru_cache
+from pathlib import Path
+
+FASTER_WHISPER_OPENMP_CONFLICT_ISSUE_CODE = "faster_whisper_openmp_runtime_conflict"
+STABLE_WHISPER_SPARSE_MPS_INCOMPATIBLE_ISSUE_CODE = (
+    "stable_whisper_sparse_mps_incompatible"
+)
+
+_STABLE_WHISPER_SUPPORTED_MODELS = frozenset(
+    {
+        "tiny.en",
+        "tiny",
+        "base.en",
+        "base",
+        "small.en",
+        "small",
+        "medium.en",
+        "medium",
+        "large-v1",
+        "large-v2",
+        "large-v3",
+        "large",
+        "large-v3-turbo",
+        "turbo",
+    }
+)
+
+_STABLE_WHISPER_MODEL_ALIASES: dict[str, str] = {
+    "openai/whisper-large-v1": "large-v1",
+    "openai/whisper-large-v2": "large-v2",
+    "openai/whisper-large-v3": "large-v3",
+    "openai/whisper-large-v3-turbo": "turbo",
+}
+
+
+def has_known_faster_whisper_openmp_runtime_conflict() -> bool:
+    """Returns whether known faster-whisper OpenMP collision risk is present."""
+    if sys.platform != "darwin":
+        return False
+    machine = platform.machine().lower()
+    if machine not in {"x86_64", "amd64"}:
+        return False
+    if (
+        "faster_whisper" in sys.modules
+        and getattr(sys.modules["faster_whisper"], "__file__", None) is None
+    ):
+        return False
+    if importlib.util.find_spec("faster_whisper") is None:
+        return False
+    ctranslate2_root = _module_root("ctranslate2")
+    torch_root = _module_root("torch")
+    if ctranslate2_root is None or torch_root is None:
+        return False
+    ctranslate2_openmp = ctranslate2_root / ".dylibs" / "libiomp5.dylib"
+    torch_openmp_candidates = (
+        torch_root.parent / "functorch" / ".dylibs" / "libiomp5.dylib",
+        torch_root / ".dylibs" / "libiomp5.dylib",
+    )
+    return ctranslate2_openmp.is_file() and any(
+        candidate.is_file() for candidate in torch_openmp_candidates
+    )
+
+
+@lru_cache(maxsize=1)
+def has_known_stable_whisper_sparse_mps_incompatibility() -> bool:
+    """Returns whether current torch MPS runtime cannot handle sparse allocations."""
+    try:
+        import torch
+    except ModuleNotFoundError:
+        return False
+    backends = getattr(torch, "backends", None)
+    mps_backend = getattr(backends, "mps", None)
+    is_available = getattr(mps_backend, "is_available", None)
+    is_built = getattr(mps_backend, "is_built", None)
+    if not callable(is_available) or not callable(is_built):
+        return False
+    if not is_available() or not is_built():
+        return False
+    try:
+        sample_sparse = torch.ones((1, 1), dtype=torch.float32).to_sparse()
+        _ = sample_sparse.to(device="mps")
+    except NotImplementedError as err:
+        message = str(err).lower()
+        return (
+            "sparsemps" in message
+            or "aten::empty.memory_format" in message
+            or "sparse mps" in message
+        )
+    except Exception:
+        return False
+    return False
+
+
+def resolve_stable_whisper_fallback_model_name(model_name: str) -> str:
+    """Maps one requested model name to a stable-whisper compatible fallback."""
+    normalized = model_name.strip()
+    if not normalized:
+        return "turbo"
+    if normalized in _STABLE_WHISPER_SUPPORTED_MODELS:
+        return normalized
+    if normalized in _STABLE_WHISPER_MODEL_ALIASES:
+        return _STABLE_WHISPER_MODEL_ALIASES[normalized]
+    if normalized.startswith("distil-"):
+        return "turbo"
+    return "turbo"
+
+
+def _module_root(module_name: str) -> Path | None:
+    """Returns package root for one module spec if available."""
+    try:
+        spec = importlib.util.find_spec(module_name)
+    except ValueError:
+        return None
+    if spec is None or spec.origin is None:
+        return None
+    return Path(spec.origin).resolve().parent

--- a/tests/test_hf_whisper_backend.py
+++ b/tests/test_hf_whisper_backend.py
@@ -53,6 +53,7 @@ class _FakeEncoder:
 
     def __init__(self, hidden_size: int) -> None:
         self.hidden_size = hidden_size
+        self.config = _FakeModelConfig(hidden_size=hidden_size)
         self.call_sizes: list[int] = []
 
     def __call__(self, **kwargs: object) -> _FakeEncoderOutput:
@@ -88,6 +89,20 @@ class _FakeModel:
         self.config = _FakeModelConfig(hidden_size=hidden_size)
         self.model = self
         self.encoder = _FakeEncoder(hidden_size=hidden_size)
+
+    def eval(self) -> None:
+        """No-op eval mode for protocol compatibility."""
+
+
+class _FakeEncoderOnlyModel:
+    """Deterministic encoder-only model stub with callable forward contract."""
+
+    def __init__(self, hidden_size: int) -> None:
+        self.config = _FakeModelConfig(hidden_size=hidden_size)
+        self._encoder = _FakeEncoder(hidden_size=hidden_size)
+
+    def __call__(self, **kwargs: object) -> _FakeEncoderOutput:
+        return self._encoder(**kwargs)
 
     def eval(self) -> None:
         """No-op eval mode for protocol compatibility."""
@@ -173,6 +188,131 @@ def test_whisper_backend_pool_is_deterministic_for_overlap_windows() -> None:
         pooled,
         np.asarray([[2.0, 3.0], [4.0, 5.0]], dtype=np.float64),
     )
+
+
+def test_whisper_backend_accepts_callable_encoder_only_model() -> None:
+    """Encoder-only callable models should be supported by encoder resolution."""
+    backend = WhisperBackend(
+        feature_extractor=_FakeFeatureExtractor(),
+        model=_FakeEncoderOnlyModel(hidden_size=3),
+    )
+
+    encoded = backend.encode_sequence(np.arange(8, dtype=np.float32), sample_rate=4)
+
+    assert encoded.embeddings.shape[1] == 3
+    assert np.all(np.diff(encoded.frame_start_seconds) >= 0.0)
+
+
+def test_whisper_backend_prefers_encoder_only_loader(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Runtime loader should select AutoModel backbone before seq2seq fallback."""
+    calls = {"backbone": 0, "seq2seq": 0}
+
+    class _FeatureExtractorLoader:
+        @staticmethod
+        def from_pretrained(model_id: str, **kwargs: object) -> _FakeFeatureExtractor:
+            del model_id, kwargs
+            return _FakeFeatureExtractor()
+
+    class _BackboneLoader:
+        @staticmethod
+        def from_pretrained(model_id: str, **kwargs: object) -> _FakeModel:
+            del model_id, kwargs
+            calls["backbone"] += 1
+            return _FakeModel(hidden_size=9)
+
+    class _Seq2SeqLoader:
+        @staticmethod
+        def from_pretrained(model_id: str, **kwargs: object) -> _FakeModel:
+            del model_id, kwargs
+            calls["seq2seq"] += 1
+            return _FakeModel(hidden_size=11)
+
+    class _TransformersModule:
+        AutoFeatureExtractor = _FeatureExtractorLoader
+        AutoModel = _BackboneLoader
+        AutoModelForSpeechSeq2Seq = _Seq2SeqLoader
+
+    def fake_import_module(module_name: str) -> object:
+        if module_name == "transformers":
+            return _TransformersModule()
+        raise AssertionError(f"Unexpected import requested: {module_name!r}")
+
+    monkeypatch.setattr(
+        hf_whisper_module.importlib, "import_module", fake_import_module
+    )
+    monkeypatch.setattr(
+        hf_whisper_module.WhisperBackend,
+        "_ensure_dependencies_available",
+        lambda self: None,
+    )
+    monkeypatch.setattr(
+        hf_whisper_module,
+        "maybe_resolve_torch_runtime",
+        lambda *, device, dtype: None,
+    )
+
+    backend = WhisperBackend(model_id="unit-test/whisper")
+    assert backend.feature_dim == 9
+    assert calls["backbone"] == 1
+    assert calls["seq2seq"] == 0
+
+
+def test_whisper_backend_falls_back_to_seq2seq_when_backbone_load_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Runtime loader should fallback to seq2seq when AutoModel init fails."""
+    calls = {"backbone": 0, "seq2seq": 0}
+
+    class _FeatureExtractorLoader:
+        @staticmethod
+        def from_pretrained(model_id: str, **kwargs: object) -> _FakeFeatureExtractor:
+            del model_id, kwargs
+            return _FakeFeatureExtractor()
+
+    class _BackboneLoader:
+        @staticmethod
+        def from_pretrained(model_id: str, **kwargs: object) -> _FakeModel:
+            del model_id, kwargs
+            calls["backbone"] += 1
+            raise RuntimeError("backbone loader unavailable")
+
+    class _Seq2SeqLoader:
+        @staticmethod
+        def from_pretrained(model_id: str, **kwargs: object) -> _FakeModel:
+            del model_id, kwargs
+            calls["seq2seq"] += 1
+            return _FakeModel(hidden_size=7)
+
+    class _TransformersModule:
+        AutoFeatureExtractor = _FeatureExtractorLoader
+        AutoModel = _BackboneLoader
+        AutoModelForSpeechSeq2Seq = _Seq2SeqLoader
+
+    def fake_import_module(module_name: str) -> object:
+        if module_name == "transformers":
+            return _TransformersModule()
+        raise AssertionError(f"Unexpected import requested: {module_name!r}")
+
+    monkeypatch.setattr(
+        hf_whisper_module.importlib, "import_module", fake_import_module
+    )
+    monkeypatch.setattr(
+        hf_whisper_module.WhisperBackend,
+        "_ensure_dependencies_available",
+        lambda self: None,
+    )
+    monkeypatch.setattr(
+        hf_whisper_module,
+        "maybe_resolve_torch_runtime",
+        lambda *, device, dtype: None,
+    )
+
+    backend = WhisperBackend(model_id="unit-test/whisper")
+    assert backend.feature_dim == 7
+    assert calls["backbone"] == 1
+    assert calls["seq2seq"] == 1
 
 
 def test_whisper_backend_missing_dependency_error_is_actionable(

--- a/tests/test_stable_whisper_mps_compat.py
+++ b/tests/test_stable_whisper_mps_compat.py
@@ -1,0 +1,262 @@
+"""Unit tests for stable-whisper MPS compatibility helpers."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+import torch
+
+from ser.transcript.backends import stable_whisper_mps_compat as mps_compat
+
+
+class _FakeModel:
+    """Minimal model-like object for MPS compatibility move tests."""
+
+    def __init__(self) -> None:
+        indices = torch.tensor([[0], [0]], dtype=torch.int64)
+        values = torch.tensor([True], dtype=torch.bool)
+        self.alignment_heads = torch.sparse_coo_tensor(
+            indices,
+            values,
+            size=(1, 1),
+        )
+        self.buffer_updates: list[tuple[bool, str]] = []
+        self.to_calls: list[str] = []
+
+    def register_buffer(
+        self,
+        name: str,
+        tensor: torch.Tensor,
+        persistent: bool = False,
+    ) -> None:
+        assert name == "alignment_heads"
+        assert persistent is False
+        self.alignment_heads = tensor
+        self.buffer_updates.append((bool(tensor.is_sparse), tensor.device.type))
+
+    def to(self, *, device: str) -> _FakeModel:
+        self.to_calls.append(device)
+        return self
+
+
+class _FailingMoveModel(_FakeModel):
+    """Model-like object that fails during MPS move after mutating device state."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.device_type = "cpu"
+
+    def to(self, *, device: str) -> _FailingMoveModel:
+        self.to_calls.append(device)
+        self.device_type = device
+        if device == "mps":
+            raise RuntimeError("MPS backend out of memory")
+        return self
+
+
+class _FakeHookHandle:
+    """Minimal torch-style hook handle used in timing compatibility tests."""
+
+    def __init__(self, hooks: list[Any], hook: Any) -> None:
+        self._hooks = hooks
+        self._hook = hook
+
+    def remove(self) -> None:
+        if self._hook in self._hooks:
+            self._hooks.remove(self._hook)
+
+
+class _FakeCrossAttention:
+    """Cross-attention stub that invokes registered forward hooks."""
+
+    def __init__(self) -> None:
+        self.hooks: list[Any] = []
+
+    def register_forward_hook(self, hook: Any) -> _FakeHookHandle:
+        self.hooks.append(hook)
+        return _FakeHookHandle(self.hooks, hook)
+
+    def emit(self) -> None:
+        qk = torch.randn((1, 2, 3, 4), dtype=torch.float32, requires_grad=True)
+        outputs = (torch.zeros((1,), dtype=torch.float32), qk)
+        for hook in list(self.hooks):
+            hook(self, (), outputs)
+
+
+class _FakeDecoder:
+    """Decoder stub exposing blocks and producing one logits tensor."""
+
+    def __init__(self, cross_attn: _FakeCrossAttention) -> None:
+        self.blocks = [SimpleNamespace(cross_attn=cross_attn)]
+        self._cross_attn = cross_attn
+
+    def __call__(
+        self, tokens: torch.Tensor, _audio_features: torch.Tensor
+    ) -> torch.Tensor:
+        self._cross_attn.emit()
+        sequence_len = int(tokens.shape[1])
+        return torch.randn((1, sequence_len, 8), dtype=torch.float32)
+
+
+class _FakeStableWhisperModel:
+    """Stable-whisper model stub for _compute_qks offload tests."""
+
+    def __init__(self, cross_attn: _FakeCrossAttention) -> None:
+        self.dims = SimpleNamespace(n_text_layer=1)
+        self.decoder = _FakeDecoder(cross_attn)
+
+    def encoder(self, mel: torch.Tensor) -> torch.Tensor:
+        return mel.mean(dim=-1, keepdim=True)
+
+
+def test_move_model_to_mps_with_alignment_placeholder_restores_sparse_cpu_buffer() -> (
+    None
+):
+    """Sparse alignment buffer should be restored on CPU after MPS move."""
+    model = _FakeModel()
+
+    moved_model = mps_compat.move_model_to_mps_with_alignment_placeholder(model)
+
+    assert moved_model is model
+    assert model.to_calls == ["mps"]
+    assert model.buffer_updates[0] == (False, "cpu")
+    assert model.buffer_updates[1] == (True, "cpu")
+    assert bool(model.alignment_heads.is_sparse) is True
+    assert model.alignment_heads.device.type == "cpu"
+
+
+def test_move_model_to_mps_with_alignment_placeholder_rolls_back_to_cpu_on_failure() -> (
+    None
+):
+    """Failed MPS move should restore sparse buffer and force model rollback to CPU."""
+    model = _FailingMoveModel()
+
+    with pytest.raises(RuntimeError, match="MPS backend out of memory"):
+        mps_compat.move_model_to_mps_with_alignment_placeholder(model)
+
+    assert model.to_calls == ["mps", "cpu"]
+    assert model.device_type == "cpu"
+    assert bool(model.alignment_heads.is_sparse) is True
+    assert model.alignment_heads.device.type == "cpu"
+
+
+def test_mps_timing_compatibility_context_patches_and_restores_aliases(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Context should patch DTW/std_mean/_compute_qks aliases and restore on exit."""
+
+    def _original_compute_qks(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    @contextmanager
+    def _disable_sdpa() -> Any:
+        yield
+
+    fake_timing = SimpleNamespace(
+        dtw=lambda _x: "timing_original",
+        _compute_qks=_original_compute_qks,
+    )
+    fake_compat = SimpleNamespace(
+        dtw=lambda _x: "compat_original",
+        disable_sdpa=_disable_sdpa,
+    )
+    fake_whisper_timing = SimpleNamespace(dtw_cpu=lambda x: ("cpu", x))
+
+    def _fake_import_module(name: str) -> object:
+        if name == "stable_whisper.timing":
+            return fake_timing
+        if name == "stable_whisper.whisper_compatibility":
+            return fake_compat
+        if name == "whisper.timing":
+            return fake_whisper_timing
+        raise ModuleNotFoundError(name)
+
+    monkeypatch.setattr(mps_compat.importlib, "import_module", _fake_import_module)
+    original_std_mean = torch.std_mean
+    original_compute_qks = fake_timing._compute_qks
+
+    with mps_compat.stable_whisper_mps_timing_compatibility_context():
+        assert fake_timing.dtw is not None
+        assert fake_timing.dtw is fake_compat.dtw
+        assert torch.std_mean is not original_std_mean
+        assert fake_timing._compute_qks is not original_compute_qks
+        dtw_result = cast(object, fake_timing.dtw(torch.tensor([1.0])))
+        assert isinstance(dtw_result, tuple)
+        assert dtw_result[0] == "cpu"
+
+    assert fake_timing.dtw(torch.tensor([1.0])) == "timing_original"
+    assert fake_compat.dtw(torch.tensor([1.0])) == "compat_original"
+    assert torch.std_mean is original_std_mean
+    assert fake_timing._compute_qks is original_compute_qks
+
+
+def test_mps_timing_compatibility_context_offloads_compute_qks_to_cpu(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Patched _compute_qks should cache detached QKs on CPU and remove hooks."""
+    original_calls: list[str] = []
+
+    def _original_compute_qks(
+        *,
+        model: object,
+        tokenizer: object,
+        text_tokens: object,
+        mel: object,
+        tokens: object,
+        cache: object,
+    ) -> None:
+        del model, tokenizer, text_tokens, mel, tokens, cache
+        original_calls.append("called")
+
+    @contextmanager
+    def _disable_sdpa() -> Any:
+        yield
+
+    fake_cross_attn = _FakeCrossAttention()
+    fake_model = _FakeStableWhisperModel(fake_cross_attn)
+    fake_tokenizer = SimpleNamespace(sot_sequence=[0, 1], eot=7)
+    fake_timing = SimpleNamespace(
+        dtw=lambda _x: "timing_original",
+        _compute_qks=_original_compute_qks,
+    )
+    fake_compat = SimpleNamespace(
+        dtw=lambda _x: "compat_original",
+        disable_sdpa=_disable_sdpa,
+    )
+    fake_whisper_timing = SimpleNamespace(dtw_cpu=lambda x: ("cpu", x))
+
+    def _fake_import_module(name: str) -> object:
+        if name == "stable_whisper.timing":
+            return fake_timing
+        if name == "stable_whisper.whisper_compatibility":
+            return fake_compat
+        if name == "whisper.timing":
+            return fake_whisper_timing
+        raise ModuleNotFoundError(name)
+
+    monkeypatch.setattr(mps_compat.importlib, "import_module", _fake_import_module)
+    cache: dict[str, object] = {"audio_features": None}
+    mel = torch.ones((80, 6), dtype=torch.float32)
+    tokens = torch.tensor([0, 1, 2, 3], dtype=torch.int64)
+    text_tokens = [2, 3]
+
+    with mps_compat.stable_whisper_mps_timing_compatibility_context():
+        fake_timing._compute_qks(
+            model=fake_model,
+            tokenizer=fake_tokenizer,
+            text_tokens=text_tokens,
+            mel=mel,
+            tokens=tokens,
+            cache=cache,
+        )
+
+    assert original_calls == []
+    assert isinstance(cache["qks"], list)
+    cached_qk = cast(torch.Tensor, cast(list[object], cache["qks"])[0])
+    assert cached_qk.device.type == "cpu"
+    assert cached_qk.requires_grad is False
+    assert len(cast(list[float], cache["text_token_probs"])) == len(text_tokens)
+    assert fake_cross_attn.hooks == []

--- a/tests/test_transcript_extractor.py
+++ b/tests/test_transcript_extractor.py
@@ -1,6 +1,7 @@
 """Behavior tests for transcript extraction error handling."""
 
 import logging
+import os
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -10,6 +11,7 @@ import pytest
 
 from ser.domain import TranscriptWord
 from ser.transcript import transcript_extractor as te
+from ser.transcript.backends import faster_whisper as faster_whisper_adapter
 
 if TYPE_CHECKING:
     from stable_whisper.result import WhisperResult
@@ -117,7 +119,7 @@ def test_load_whisper_model_routes_downloads_to_model_cache_root(
 
     assert loaded is fake_model
     assert captured["download_root"] == str(download_root)
-    assert te.os.environ["TORCH_HOME"] == str(torch_cache_root)
+    assert os.environ["TORCH_HOME"] == str(torch_cache_root)
     assert download_root.is_dir()
     assert torch_cache_root.is_dir()
 
@@ -375,7 +377,7 @@ def test_faster_whisper_setup_required_when_cache_missing(
         raise RuntimeError("cache miss")
 
     monkeypatch.setattr(
-        te.importlib,
+        faster_whisper_adapter.importlib,
         "import_module",
         lambda name: (
             SimpleNamespace(download_model=_fake_download_model)
@@ -423,7 +425,7 @@ def test_faster_whisper_prepare_transcription_assets_downloads(
         return str(tmp_path / "snapshot")
 
     monkeypatch.setattr(
-        te.importlib,
+        faster_whisper_adapter.importlib,
         "import_module",
         lambda name: (
             SimpleNamespace(download_model=_fake_download_model)

--- a/tests/test_transcription_admission_overrides.py
+++ b/tests/test_transcription_admission_overrides.py
@@ -1,0 +1,244 @@
+"""Tests for calibration-driven MPS admission overrides."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+
+from ser.config import AppConfig
+from ser.transcript.backends.base import BackendRuntimeRequest
+from ser.transcript.mps_admission import MpsAdmissionDecision
+from ser.transcript.mps_admission_overrides import (
+    apply_calibrated_mps_admission_override,
+)
+
+
+def _settings(
+    *,
+    report_path: Path,
+    min_confidence: str = "high",
+    max_age_hours: float = 168.0,
+    enabled: bool = True,
+) -> AppConfig:
+    """Builds minimal settings object for override-resolution tests."""
+    return cast(
+        AppConfig,
+        SimpleNamespace(
+            transcription=SimpleNamespace(
+                backend_id="stable_whisper",
+                mps_admission_calibration_overrides_enabled=enabled,
+                mps_admission_calibration_min_confidence=min_confidence,
+                mps_admission_calibration_report_max_age_hours=max_age_hours,
+                mps_admission_calibration_report_path=report_path,
+            ),
+            models=SimpleNamespace(folder=report_path.parent),
+        ),
+    )
+
+
+def _write_report(
+    *,
+    path: Path,
+    created_at: datetime,
+    recommendation: str,
+    confidence: str,
+    model_name: str,
+) -> None:
+    """Writes one runtime-calibration report fixture."""
+    payload = {
+        "created_at_utc": created_at.isoformat(),
+        "profiles": [
+            {
+                "profile": "accurate",
+                "backend_id": "stable_whisper",
+                "model_name": model_name,
+                "recommendation": recommendation,
+                "confidence": confidence,
+                "reason": "test fixture",
+            }
+        ],
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _runtime_request(model_name: str) -> BackendRuntimeRequest:
+    """Builds one stable-whisper runtime request fixture."""
+    return BackendRuntimeRequest(
+        model_name=model_name,
+        use_demucs=False,
+        use_vad=True,
+        device_spec="mps",
+        device_type="mps",
+        precision_candidates=("float16", "float32"),
+        memory_tier="low",
+    )
+
+
+def test_calibrated_override_prefer_cpu_forces_admission_denial(tmp_path: Path) -> None:
+    """High-confidence prefer_cpu recommendation should deny MPS admission."""
+    report_path = tmp_path / "calibration.json"
+    _write_report(
+        path=report_path,
+        created_at=datetime.now(tz=UTC),
+        recommendation="prefer_cpu",
+        confidence="high",
+        model_name="large",
+    )
+    settings = _settings(report_path=report_path)
+    heuristic = MpsAdmissionDecision(
+        allow_mps=True,
+        reason_code="mps_headroom_sufficient",
+        required_bytes=1,
+        available_bytes=2,
+        required_metric="headroom_budget",
+        available_metric="headroom",
+        confidence="high",
+    )
+
+    resolved = apply_calibrated_mps_admission_override(
+        settings=settings,
+        runtime_request=_runtime_request("large"),
+        phase="model_load",
+        heuristic_decision=heuristic,
+    )
+
+    assert resolved.allow_mps is False
+    assert resolved.reason_code == "calibration_prefer_cpu_model_load"
+
+
+def test_calibrated_override_prefer_mps_relaxes_low_confidence_deny(
+    tmp_path: Path,
+) -> None:
+    """prefer_mps should allow MPS when heuristic denial is low-confidence only."""
+    report_path = tmp_path / "calibration.json"
+    _write_report(
+        path=report_path,
+        created_at=datetime.now(tz=UTC),
+        recommendation="prefer_mps",
+        confidence="high",
+        model_name="turbo",
+    )
+    settings = _settings(report_path=report_path)
+    heuristic = MpsAdmissionDecision(
+        allow_mps=False,
+        reason_code="mps_headroom_estimate_below_required_budget",
+        required_bytes=100,
+        available_bytes=50,
+        required_metric="headroom_budget",
+        available_metric="headroom_estimate",
+        confidence="low",
+    )
+
+    resolved = apply_calibrated_mps_admission_override(
+        settings=settings,
+        runtime_request=_runtime_request("turbo"),
+        phase="transcribe",
+        heuristic_decision=heuristic,
+    )
+
+    assert resolved.allow_mps is True
+    assert resolved.reason_code == "calibration_prefer_mps_transcribe"
+
+
+def test_calibrated_override_does_not_relax_high_confidence_deny(
+    tmp_path: Path,
+) -> None:
+    """High-confidence heuristic denials should not be overridden to allow MPS."""
+    report_path = tmp_path / "calibration.json"
+    _write_report(
+        path=report_path,
+        created_at=datetime.now(tz=UTC),
+        recommendation="prefer_mps",
+        confidence="high",
+        model_name="large",
+    )
+    settings = _settings(report_path=report_path)
+    heuristic = MpsAdmissionDecision(
+        allow_mps=False,
+        reason_code="mps_headroom_below_required_budget",
+        required_bytes=100,
+        available_bytes=10,
+        required_metric="headroom_budget",
+        available_metric="headroom",
+        confidence="high",
+    )
+
+    resolved = apply_calibrated_mps_admission_override(
+        settings=settings,
+        runtime_request=_runtime_request("large"),
+        phase="transcribe",
+        heuristic_decision=heuristic,
+    )
+
+    assert resolved == heuristic
+
+
+def test_calibrated_override_ignores_stale_report(tmp_path: Path) -> None:
+    """Stale calibration reports should be ignored safely."""
+    report_path = tmp_path / "calibration.json"
+    _write_report(
+        path=report_path,
+        created_at=datetime.now(tz=UTC) - timedelta(days=30),
+        recommendation="prefer_cpu",
+        confidence="high",
+        model_name="large",
+    )
+    settings = _settings(
+        report_path=report_path,
+        max_age_hours=24.0,
+    )
+    heuristic = MpsAdmissionDecision(
+        allow_mps=True,
+        reason_code="mps_headroom_sufficient",
+        required_bytes=1,
+        available_bytes=2,
+        required_metric="headroom_budget",
+        available_metric="headroom",
+        confidence="high",
+    )
+
+    resolved = apply_calibrated_mps_admission_override(
+        settings=settings,
+        runtime_request=_runtime_request("large"),
+        phase="model_load",
+        heuristic_decision=heuristic,
+    )
+
+    assert resolved == heuristic
+
+
+def test_calibrated_override_respects_minimum_confidence(tmp_path: Path) -> None:
+    """Recommendations below configured confidence threshold should be ignored."""
+    report_path = tmp_path / "calibration.json"
+    _write_report(
+        path=report_path,
+        created_at=datetime.now(tz=UTC),
+        recommendation="prefer_cpu",
+        confidence="medium",
+        model_name="large",
+    )
+    settings = _settings(
+        report_path=report_path,
+        min_confidence="high",
+    )
+    heuristic = MpsAdmissionDecision(
+        allow_mps=True,
+        reason_code="mps_headroom_sufficient",
+        required_bytes=1,
+        available_bytes=2,
+        required_metric="headroom_budget",
+        available_metric="headroom",
+        confidence="high",
+    )
+
+    resolved = apply_calibrated_mps_admission_override(
+        settings=settings,
+        runtime_request=_runtime_request("large"),
+        phase="model_load",
+        heuristic_decision=heuristic,
+    )
+
+    assert resolved == heuristic

--- a/tests/test_transcription_backends.py
+++ b/tests/test_transcription_backends.py
@@ -1,0 +1,189 @@
+"""Unit tests for transcription backend adapter compatibility behavior."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+
+from ser.config import AppConfig
+from ser.transcript.backends.base import BackendRuntimeRequest
+from ser.transcript.backends.faster_whisper import FasterWhisperAdapter
+from ser.transcript.backends.stable_whisper import StableWhisperAdapter
+
+
+def test_stable_whisper_compatibility_report_is_noise_aware(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stable adapter should expose noise policy metadata without blocking."""
+    adapter = StableWhisperAdapter()
+    monkeypatch.setattr(adapter, "_is_module_available", lambda _name: True)
+    report = adapter.check_compatibility(
+        runtime_request=BackendRuntimeRequest(
+            model_name="large-v2",
+            use_demucs=True,
+            use_vad=True,
+        ),
+        settings=cast(AppConfig, SimpleNamespace()),
+    )
+
+    assert report.has_blocking_issues is False
+    assert report.policy_ids == (
+        "stable_whisper.invalid_escape_sequence",
+        "stable_whisper.fp16_cpu_fallback_warning",
+        "stable_whisper.demucs_deprecated_warning",
+    )
+    assert report.noise_issues
+
+
+def test_stable_whisper_compatibility_blocks_on_missing_dependency(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stable adapter should block when stable_whisper dependency is unavailable."""
+    adapter = StableWhisperAdapter()
+    monkeypatch.setattr(adapter, "_is_module_available", lambda _name: False)
+    report = adapter.check_compatibility(
+        runtime_request=BackendRuntimeRequest(
+            model_name="large-v2",
+            use_demucs=True,
+            use_vad=True,
+        ),
+        settings=cast(AppConfig, SimpleNamespace()),
+    )
+
+    assert report.has_blocking_issues is True
+    assert any(
+        issue.code == "missing_dependency_stable_whisper"
+        for issue in report.functional_issues
+    )
+
+
+def test_faster_whisper_demucs_issue_is_operational_not_blocking(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Faster adapter should report demucs limitation without blocking execution."""
+    adapter = FasterWhisperAdapter()
+    monkeypatch.setattr(adapter, "_is_module_available", lambda _name: True)
+    report = adapter.check_compatibility(
+        runtime_request=BackendRuntimeRequest(
+            model_name="distil-large-v3",
+            use_demucs=True,
+            use_vad=True,
+        ),
+        settings=cast(AppConfig, SimpleNamespace()),
+    )
+
+    assert report.has_blocking_issues is False
+    assert any(
+        issue.code == "faster_whisper_demucs_unsupported"
+        for issue in report.operational_issues
+    )
+    assert report.policy_ids == ("faster_whisper.info_demotion",)
+
+
+def test_stable_whisper_transcribe_prefers_denoiser_and_fp16_control(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stable adapter should pass modern denoiser API and disable fp16 on CPU."""
+    adapter = StableWhisperAdapter()
+    monkeypatch.setattr(adapter, "_normalize_result", lambda raw: raw)
+    monkeypatch.setattr(adapter, "_format_transcript", lambda _result: [])
+    captured: dict[str, object] = {}
+
+    class _FakeModel:
+        def transcribe(
+            self,
+            *,
+            audio: str,
+            language: str,
+            verbose: bool,
+            word_timestamps: bool,
+            no_speech_threshold: object,
+            vad: bool,
+            fp16: bool,
+            denoiser: str,
+        ) -> dict[str, object]:
+            captured["audio"] = audio
+            captured["language"] = language
+            captured["verbose"] = verbose
+            captured["word_timestamps"] = word_timestamps
+            captured["no_speech_threshold"] = no_speech_threshold
+            captured["vad"] = vad
+            captured["fp16"] = fp16
+            captured["denoiser"] = denoiser
+            return {"segments": []}
+
+    transcript = adapter.transcribe(
+        model=_FakeModel(),
+        runtime_request=BackendRuntimeRequest(
+            model_name="large-v2",
+            use_demucs=True,
+            use_vad=True,
+        ),
+        file_path="sample.wav",
+        language="en",
+        settings=cast(AppConfig, SimpleNamespace()),
+    )
+
+    assert transcript == []
+    assert captured["audio"] == "sample.wav"
+    assert captured["language"] == "en"
+    assert captured["verbose"] is False
+    assert captured["word_timestamps"] is True
+    assert captured["no_speech_threshold"] is None
+    assert captured["vad"] is True
+    assert captured["fp16"] is False
+    assert captured["denoiser"] == "demucs"
+
+
+def test_stable_whisper_transcribe_uses_legacy_demucs_when_denoiser_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stable adapter should fall back to legacy demucs argument for old signatures."""
+    adapter = StableWhisperAdapter()
+    monkeypatch.setattr(adapter, "_normalize_result", lambda raw: raw)
+    monkeypatch.setattr(adapter, "_format_transcript", lambda _result: [])
+    captured: dict[str, object] = {}
+
+    class _LegacyModel:
+        def transcribe(
+            self,
+            *,
+            audio: str,
+            language: str,
+            verbose: bool,
+            word_timestamps: bool,
+            no_speech_threshold: object,
+            vad: bool,
+            demucs: bool,
+        ) -> dict[str, object]:
+            captured["audio"] = audio
+            captured["language"] = language
+            captured["verbose"] = verbose
+            captured["word_timestamps"] = word_timestamps
+            captured["no_speech_threshold"] = no_speech_threshold
+            captured["vad"] = vad
+            captured["demucs"] = demucs
+            return {"segments": []}
+
+    transcript = adapter.transcribe(
+        model=_LegacyModel(),
+        runtime_request=BackendRuntimeRequest(
+            model_name="large-v2",
+            use_demucs=True,
+            use_vad=False,
+        ),
+        file_path="legacy.wav",
+        language="en",
+        settings=cast(AppConfig, SimpleNamespace()),
+    )
+
+    assert transcript == []
+    assert captured["audio"] == "legacy.wav"
+    assert captured["language"] == "en"
+    assert captured["verbose"] is False
+    assert captured["word_timestamps"] is True
+    assert captured["no_speech_threshold"] is None
+    assert captured["vad"] is False
+    assert captured["demucs"] is True

--- a/tests/test_transcription_backends.py
+++ b/tests/test_transcription_backends.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+import logging
+import sys
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
 from types import SimpleNamespace
 from typing import cast
 
@@ -11,6 +16,17 @@ from ser.config import AppConfig
 from ser.transcript.backends.base import BackendRuntimeRequest
 from ser.transcript.backends.faster_whisper import FasterWhisperAdapter
 from ser.transcript.backends.stable_whisper import StableWhisperAdapter
+from ser.utils.transcription_compat import FASTER_WHISPER_OPENMP_CONFLICT_ISSUE_CODE
+
+
+@pytest.fixture(autouse=True)
+def _disable_openmp_conflict_detection(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keeps faster-whisper compatibility assertions deterministic in unit tests."""
+    monkeypatch.setattr(
+        "ser.transcript.backends.faster_whisper."
+        "has_known_faster_whisper_openmp_runtime_conflict",
+        lambda: False,
+    )
 
 
 def test_stable_whisper_compatibility_report_is_noise_aware(
@@ -80,6 +96,59 @@ def test_faster_whisper_demucs_issue_is_operational_not_blocking(
         for issue in report.operational_issues
     )
     assert report.policy_ids == ("faster_whisper.info_demotion",)
+
+
+def test_faster_whisper_mps_runtime_is_operational_not_blocking(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Faster adapter should downgrade unsupported MPS runtime to operational issue."""
+    adapter = FasterWhisperAdapter()
+    monkeypatch.setattr(adapter, "_is_module_available", lambda _name: True)
+    report = adapter.check_compatibility(
+        runtime_request=BackendRuntimeRequest(
+            model_name="distil-large-v3",
+            use_demucs=False,
+            use_vad=True,
+            device_spec="mps",
+            device_type="mps",
+            precision_candidates=("float16", "float32"),
+            memory_tier="low",
+        ),
+        settings=cast(AppConfig, SimpleNamespace()),
+    )
+
+    assert report.has_blocking_issues is False
+    assert any(
+        issue.code == "faster_whisper_mps_unsupported"
+        for issue in report.operational_issues
+    )
+
+
+def test_faster_whisper_openmp_conflict_is_blocking(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Known OpenMP runtime collisions should block faster-whisper execution."""
+    monkeypatch.setattr(
+        "ser.transcript.backends.faster_whisper."
+        "has_known_faster_whisper_openmp_runtime_conflict",
+        lambda: True,
+    )
+    adapter = FasterWhisperAdapter()
+    monkeypatch.setattr(adapter, "_is_module_available", lambda _name: True)
+    report = adapter.check_compatibility(
+        runtime_request=BackendRuntimeRequest(
+            model_name="distil-large-v3",
+            use_demucs=False,
+            use_vad=True,
+        ),
+        settings=cast(AppConfig, SimpleNamespace()),
+    )
+
+    assert report.has_blocking_issues is True
+    assert any(
+        issue.code == FASTER_WHISPER_OPENMP_CONFLICT_ISSUE_CODE
+        for issue in report.functional_issues
+    )
 
 
 def test_stable_whisper_transcribe_prefers_denoiser_and_fp16_control(
@@ -187,3 +256,677 @@ def test_stable_whisper_transcribe_uses_legacy_demucs_when_denoiser_absent(
     assert captured["no_speech_threshold"] is None
     assert captured["vad"] is False
     assert captured["demucs"] is True
+
+
+def test_stable_whisper_transcribe_retries_with_fallback_precision(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stable adapter should retry with next precision on retryable failure."""
+    adapter = StableWhisperAdapter()
+    monkeypatch.setattr(adapter, "_normalize_result", lambda raw: raw)
+    monkeypatch.setattr(adapter, "_format_transcript", lambda _result: [])
+    fp16_flags: list[bool] = []
+
+    class _FakeModel:
+        def transcribe(
+            self,
+            *,
+            fp16: bool,
+            **_kwargs: object,
+        ) -> dict[str, object]:
+            fp16_flags.append(fp16)
+            if fp16:
+                raise NotImplementedError(
+                    "Could not run 'aten::empty.memory_format' with arguments "
+                    "from the 'SparseMPS' backend."
+                )
+            return {"segments": []}
+
+    transcript = adapter.transcribe(
+        model=_FakeModel(),
+        runtime_request=BackendRuntimeRequest(
+            model_name="large-v3",
+            use_demucs=False,
+            use_vad=True,
+            device_spec="mps",
+            device_type="mps",
+            precision_candidates=("float16", "float32"),
+            memory_tier="low",
+        ),
+        file_path="sample.wav",
+        language="en",
+        settings=cast(AppConfig, SimpleNamespace()),
+    )
+
+    assert transcript == []
+    assert fp16_flags == [True, False]
+
+
+def test_stable_whisper_transcribe_hard_mps_oom_shortcuts_to_cpu(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Pure MPS OOM on fp16 should skip MPS float32 retry and fail over to CPU."""
+    adapter = StableWhisperAdapter()
+    monkeypatch.setattr(adapter, "_normalize_result", lambda raw: raw)
+    monkeypatch.setattr(adapter, "_format_transcript", lambda _result: [])
+    calls: list[tuple[str, bool]] = []
+
+    class _FakeModel:
+        runtime_device = "mps"
+
+        def transcribe(self, *, fp16: bool, **_kwargs: object) -> dict[str, object]:
+            calls.append((self.runtime_device, fp16))
+            if self.runtime_device == "mps":
+                raise RuntimeError("MPS backend out of memory")
+            return {"segments": []}
+
+        def to(self, *, device: str) -> _FakeModel:
+            self.runtime_device = device
+            return self
+
+    caplog.set_level(logging.INFO)
+    transcript = adapter.transcribe(
+        model=_FakeModel(),
+        runtime_request=BackendRuntimeRequest(
+            model_name="large-v3",
+            use_demucs=False,
+            use_vad=True,
+            device_spec="mps",
+            device_type="mps",
+            precision_candidates=("float16", "float32"),
+            memory_tier="low",
+        ),
+        file_path="sample.wav",
+        language="en",
+        settings=cast(
+            AppConfig,
+            SimpleNamespace(
+                transcription=SimpleNamespace(
+                    mps_admission_control_enabled=False,
+                    mps_hard_oom_shortcut_enabled=True,
+                )
+            ),
+        ),
+    )
+
+    assert transcript == []
+    assert calls == [("mps", True), ("cpu", False)]
+    assert "switching directly to cpu" in caplog.text
+
+
+def test_stable_whisper_transcribe_hard_mps_oom_shortcut_can_be_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Disabling hard-OOM shortcut should preserve MPS precision fallback behavior."""
+    adapter = StableWhisperAdapter()
+    monkeypatch.setattr(adapter, "_normalize_result", lambda raw: raw)
+    monkeypatch.setattr(adapter, "_format_transcript", lambda _result: [])
+    calls: list[tuple[str, bool]] = []
+
+    class _FakeModel:
+        runtime_device = "mps"
+
+        def transcribe(self, *, fp16: bool, **_kwargs: object) -> dict[str, object]:
+            calls.append((self.runtime_device, fp16))
+            if self.runtime_device == "mps":
+                raise RuntimeError("MPS backend out of memory")
+            return {"segments": []}
+
+        def to(self, *, device: str) -> _FakeModel:
+            self.runtime_device = device
+            return self
+
+    transcript = adapter.transcribe(
+        model=_FakeModel(),
+        runtime_request=BackendRuntimeRequest(
+            model_name="large-v3",
+            use_demucs=False,
+            use_vad=True,
+            device_spec="mps",
+            device_type="mps",
+            precision_candidates=("float16", "float32"),
+            memory_tier="low",
+        ),
+        file_path="sample.wav",
+        language="en",
+        settings=cast(
+            AppConfig,
+            SimpleNamespace(
+                transcription=SimpleNamespace(
+                    mps_admission_control_enabled=False,
+                    mps_hard_oom_shortcut_enabled=False,
+                )
+            ),
+        ),
+    )
+
+    assert transcript == []
+    assert calls == [("mps", True), ("mps", False), ("cpu", False)]
+
+
+@pytest.mark.parametrize(
+    ("failure_type", "failure_message"),
+    [
+        (RuntimeError, "MPS backend out of memory"),
+        (
+            NotImplementedError,
+            "Could not run 'aten::empty.memory_format' with arguments from the 'SparseMPS' backend.",
+        ),
+    ],
+)
+def test_stable_whisper_load_model_retries_on_cpu_after_retryable_mps_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    failure_type: type[Exception],
+    failure_message: str,
+) -> None:
+    """Stable adapter should keep CPU model when MPS compatibility move fails."""
+    adapter = StableWhisperAdapter()
+    download_root = tmp_path / "model-cache" / "OpenAI" / "whisper"
+    torch_cache_root = tmp_path / "model-cache" / "torch"
+    settings = cast(
+        AppConfig,
+        SimpleNamespace(
+            models=SimpleNamespace(
+                whisper_download_root=download_root,
+                torch_cache_root=torch_cache_root,
+            )
+        ),
+    )
+    loaded_model = SimpleNamespace()
+    load_devices: list[str] = []
+
+    def _fake_load_model(
+        *,
+        name: str,
+        device: str,
+        dq: bool,
+        download_root: str,
+        in_memory: bool,
+    ) -> object:
+        del name
+        del dq
+        del download_root
+        del in_memory
+        load_devices.append(device)
+        return loaded_model
+
+    monkeypatch.setitem(
+        sys.modules,
+        "stable_whisper",
+        SimpleNamespace(load_model=_fake_load_model),
+    )
+    monkeypatch.setattr(
+        "ser.transcript.backends.stable_whisper."
+        "enable_stable_whisper_mps_compatibility",
+        lambda _model: (_ for _ in ()).throw(failure_type(failure_message)),
+    )
+
+    resolved_model = adapter.load_model(
+        runtime_request=BackendRuntimeRequest(
+            model_name="large-v3",
+            use_demucs=False,
+            use_vad=True,
+            device_spec="mps",
+            device_type="mps",
+            precision_candidates=("float16", "float32"),
+            memory_tier="low",
+        ),
+        settings=settings,
+    )
+
+    assert resolved_model is loaded_model
+    assert load_devices == ["cpu"]
+
+
+def test_stable_whisper_load_model_enables_mps_compatibility_on_success(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Stable adapter should enable MPS compatibility flow for MPS runtime requests."""
+    adapter = StableWhisperAdapter()
+    download_root = tmp_path / "model-cache" / "OpenAI" / "whisper"
+    torch_cache_root = tmp_path / "model-cache" / "torch"
+    settings = cast(
+        AppConfig,
+        SimpleNamespace(
+            models=SimpleNamespace(
+                whisper_download_root=download_root,
+                torch_cache_root=torch_cache_root,
+            ),
+            transcription=SimpleNamespace(
+                mps_admission_control_enabled=False,
+                mps_hard_oom_shortcut_enabled=True,
+            ),
+        ),
+    )
+    loaded_model = SimpleNamespace()
+    moved_model = object()
+    load_devices: list[str] = []
+
+    def _fake_load_model(
+        *,
+        name: str,
+        device: str,
+        dq: bool,
+        download_root: str,
+        in_memory: bool,
+    ) -> object:
+        del name
+        del dq
+        del download_root
+        del in_memory
+        load_devices.append(device)
+        return loaded_model
+
+    monkeypatch.setitem(
+        sys.modules,
+        "stable_whisper",
+        SimpleNamespace(load_model=_fake_load_model),
+    )
+    monkeypatch.setattr(
+        "ser.transcript.backends.stable_whisper."
+        "enable_stable_whisper_mps_compatibility",
+        lambda _model: moved_model,
+    )
+    monkeypatch.setattr(
+        "ser.transcript.backends.stable_whisper."
+        "has_known_stable_whisper_sparse_mps_incompatibility",
+        lambda: True,
+    )
+
+    resolved_model = adapter.load_model(
+        runtime_request=BackendRuntimeRequest(
+            model_name="large-v3",
+            use_demucs=False,
+            use_vad=True,
+            device_spec="mps",
+            device_type="mps",
+            precision_candidates=("float16", "float32"),
+            memory_tier="low",
+        ),
+        settings=settings,
+    )
+
+    assert resolved_model is moved_model
+    assert load_devices == ["cpu"]
+
+
+def test_stable_whisper_load_model_mps_admission_control_prefers_cpu(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """MPS admission control should keep model on CPU when headroom is insufficient."""
+    adapter = StableWhisperAdapter()
+    download_root = tmp_path / "model-cache" / "OpenAI" / "whisper"
+    torch_cache_root = tmp_path / "model-cache" / "torch"
+    settings = cast(
+        AppConfig,
+        SimpleNamespace(
+            models=SimpleNamespace(
+                whisper_download_root=download_root,
+                torch_cache_root=torch_cache_root,
+            ),
+            transcription=SimpleNamespace(
+                mps_admission_control_enabled=True,
+                mps_hard_oom_shortcut_enabled=True,
+                mps_admission_min_headroom_mb=64.0,
+                mps_admission_safety_margin_mb=64.0,
+            ),
+        ),
+    )
+    loaded_model = SimpleNamespace()
+    load_devices: list[str] = []
+    enable_calls: list[str] = []
+
+    def _fake_load_model(
+        *,
+        name: str,
+        device: str,
+        dq: bool,
+        download_root: str,
+        in_memory: bool,
+    ) -> object:
+        del name
+        del dq
+        del download_root
+        del in_memory
+        load_devices.append(device)
+        return loaded_model
+
+    monkeypatch.setitem(
+        sys.modules,
+        "stable_whisper",
+        SimpleNamespace(load_model=_fake_load_model),
+    )
+    monkeypatch.setattr(
+        "ser.transcript.backends.stable_whisper.decide_mps_admission_for_transcription",
+        lambda **_kwargs: SimpleNamespace(
+            allow_mps=False,
+            reason_code="mps_headroom_below_required_budget",
+            required_bytes=256 * 1024**2,
+            available_bytes=32 * 1024**2,
+            required_metric="headroom_budget",
+            available_metric="headroom_estimate",
+            confidence="high",
+        ),
+    )
+
+    def _record_enable_call(model: object) -> object:
+        enable_calls.append("called")
+        return model
+
+    monkeypatch.setattr(
+        "ser.transcript.backends.stable_whisper."
+        "enable_stable_whisper_mps_compatibility",
+        _record_enable_call,
+    )
+
+    caplog.set_level(logging.INFO)
+    resolved_model = adapter.load_model(
+        runtime_request=BackendRuntimeRequest(
+            model_name="large-v3",
+            use_demucs=False,
+            use_vad=True,
+            device_spec="mps",
+            device_type="mps",
+            precision_candidates=("float16", "float32"),
+            memory_tier="low",
+        ),
+        settings=settings,
+    )
+
+    assert resolved_model is loaded_model
+    assert load_devices == ["cpu"]
+    assert enable_calls == []
+    assert "MPS admission control switched model_load to cpu" in caplog.text
+
+
+def test_stable_whisper_transcribe_mps_admission_control_prefers_cpu(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Transcribe admission control should switch to CPU before first MPS attempt."""
+    adapter = StableWhisperAdapter()
+    monkeypatch.setattr(adapter, "_normalize_result", lambda raw: raw)
+    monkeypatch.setattr(adapter, "_format_transcript", lambda _result: [])
+    calls: list[tuple[str, bool]] = []
+
+    class _FakeModel:
+        runtime_device = "mps"
+
+        def transcribe(self, *, fp16: bool, **_kwargs: object) -> dict[str, object]:
+            calls.append((self.runtime_device, fp16))
+            return {"segments": []}
+
+        def to(self, *, device: str) -> _FakeModel:
+            self.runtime_device = device
+            return self
+
+    monkeypatch.setattr(
+        "ser.transcript.backends.stable_whisper.decide_mps_admission_for_transcription",
+        lambda **_kwargs: SimpleNamespace(
+            allow_mps=False,
+            reason_code="mps_headroom_below_required_budget",
+            required_bytes=256 * 1024**2,
+            available_bytes=32 * 1024**2,
+            required_metric="headroom_budget",
+            available_metric="headroom_estimate",
+            confidence="high",
+        ),
+    )
+
+    transcript = adapter.transcribe(
+        model=_FakeModel(),
+        runtime_request=BackendRuntimeRequest(
+            model_name="large-v3",
+            use_demucs=False,
+            use_vad=True,
+            device_spec="mps",
+            device_type="mps",
+            precision_candidates=("float16", "float32"),
+            memory_tier="low",
+        ),
+        file_path="sample.wav",
+        language="en",
+        settings=cast(
+            AppConfig,
+            SimpleNamespace(
+                transcription=SimpleNamespace(
+                    mps_admission_control_enabled=True,
+                    mps_hard_oom_shortcut_enabled=True,
+                    mps_admission_min_headroom_mb=64.0,
+                    mps_admission_safety_margin_mb=64.0,
+                )
+            ),
+        ),
+    )
+
+    assert transcript == []
+    assert calls == [("cpu", False)]
+
+
+def test_stable_whisper_transcribe_low_confidence_admission_denial_is_advisory(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Low-confidence admission denial should allow one MPS attempt before fallback."""
+    adapter = StableWhisperAdapter()
+    monkeypatch.setattr(adapter, "_normalize_result", lambda raw: raw)
+    monkeypatch.setattr(adapter, "_format_transcript", lambda _result: [])
+    calls: list[tuple[str, bool]] = []
+
+    class _FakeModel:
+        runtime_device = "mps"
+
+        def transcribe(self, *, fp16: bool, **_kwargs: object) -> dict[str, object]:
+            calls.append((self.runtime_device, fp16))
+            if self.runtime_device == "mps":
+                raise RuntimeError("MPS backend out of memory")
+            return {"segments": []}
+
+        def to(self, *, device: str) -> _FakeModel:
+            self.runtime_device = device
+            return self
+
+    monkeypatch.setattr(
+        "ser.transcript.backends.stable_whisper.decide_mps_admission_for_transcription",
+        lambda **_kwargs: SimpleNamespace(
+            allow_mps=False,
+            reason_code="mps_headroom_estimate_below_required_budget",
+            required_bytes=256 * 1024**2,
+            available_bytes=32 * 1024**2,
+            required_metric="headroom_budget",
+            available_metric="headroom_estimate",
+            confidence="low",
+        ),
+    )
+
+    caplog.set_level(logging.INFO)
+    transcript = adapter.transcribe(
+        model=_FakeModel(),
+        runtime_request=BackendRuntimeRequest(
+            model_name="turbo",
+            use_demucs=False,
+            use_vad=True,
+            device_spec="mps",
+            device_type="mps",
+            precision_candidates=("float16", "float32"),
+            memory_tier="low",
+        ),
+        file_path="sample.wav",
+        language="en",
+        settings=cast(
+            AppConfig,
+            SimpleNamespace(
+                transcription=SimpleNamespace(
+                    mps_admission_control_enabled=True,
+                    mps_hard_oom_shortcut_enabled=True,
+                )
+            ),
+        ),
+    )
+
+    assert transcript == []
+    assert calls == [("mps", True), ("cpu", False)]
+    assert "allowing one MPS attempt" in caplog.text
+
+
+def test_stable_whisper_transcribe_uses_mps_timing_compatibility_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stable adapter should run transcribe in MPS timing compatibility context."""
+    adapter = StableWhisperAdapter()
+    monkeypatch.setattr(adapter, "_normalize_result", lambda raw: raw)
+    monkeypatch.setattr(adapter, "_format_transcript", lambda _result: [])
+    context_events: list[str] = []
+
+    @contextmanager
+    def _fake_context() -> Iterator[None]:
+        context_events.append("enter")
+        try:
+            yield
+        finally:
+            context_events.append("exit")
+
+    monkeypatch.setattr(
+        "ser.transcript.backends.stable_whisper."
+        "is_stable_whisper_mps_compatibility_enabled",
+        lambda _model: True,
+    )
+    monkeypatch.setattr(
+        "ser.transcript.backends.stable_whisper."
+        "stable_whisper_mps_timing_compatibility_context",
+        _fake_context,
+    )
+
+    class _FakeModel:
+        def transcribe(self, **_kwargs: object) -> dict[str, object]:
+            context_events.append("call")
+            return {"segments": []}
+
+    transcript = adapter.transcribe(
+        model=_FakeModel(),
+        runtime_request=BackendRuntimeRequest(
+            model_name="large-v3",
+            use_demucs=False,
+            use_vad=True,
+            device_spec="mps",
+            device_type="mps",
+            precision_candidates=("float32",),
+            memory_tier="low",
+        ),
+        file_path="sample.wav",
+        language="en",
+        settings=cast(AppConfig, SimpleNamespace()),
+    )
+
+    assert transcript == []
+    assert context_events == ["enter", "call", "exit"]
+
+
+def test_stable_whisper_runtime_error_summary_is_single_line() -> None:
+    """Stable adapter retry logs should keep runtime errors concise and single-line."""
+    adapter = StableWhisperAdapter()
+    summary = adapter._summarize_runtime_error(
+        RuntimeError("line1\nline2 " + ("x" * 500))
+    )
+
+    assert "\n" not in summary
+    assert len(summary) <= 180
+
+
+def test_stable_whisper_accurate_mps_move_failure_uses_cpu_transcribe_directly(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """MPS compatibility-move failure should transcribe directly on CPU in accurate path."""
+    adapter = StableWhisperAdapter()
+    download_root = tmp_path / "model-cache" / "OpenAI" / "whisper"
+    torch_cache_root = tmp_path / "model-cache" / "torch"
+    settings = cast(
+        AppConfig,
+        SimpleNamespace(
+            models=SimpleNamespace(
+                whisper_download_root=download_root,
+                torch_cache_root=torch_cache_root,
+            )
+        ),
+    )
+    fp16_flags: list[bool] = []
+
+    class _FakeModel:
+        def transcribe(self, *, fp16: bool, **_kwargs: object) -> dict[str, object]:
+            fp16_flags.append(fp16)
+            return {"segments": []}
+
+        def to(self, *, device: str) -> _FakeModel:
+            del device
+            return self
+
+    fake_model = _FakeModel()
+
+    def _fake_load_model(
+        *,
+        name: str,
+        device: str,
+        dq: bool,
+        download_root: str,
+        in_memory: bool,
+    ) -> object:
+        del name
+        del device
+        del dq
+        del download_root
+        del in_memory
+        return fake_model
+
+    monkeypatch.setitem(
+        sys.modules,
+        "stable_whisper",
+        SimpleNamespace(load_model=_fake_load_model),
+    )
+    monkeypatch.setattr(
+        "ser.transcript.backends.stable_whisper."
+        "enable_stable_whisper_mps_compatibility",
+        lambda _model: (_ for _ in ()).throw(RuntimeError("MPS backend out of memory")),
+    )
+    monkeypatch.setattr(adapter, "_normalize_result", lambda raw: raw)
+    monkeypatch.setattr(adapter, "_format_transcript", lambda _result: [])
+
+    caplog.set_level(logging.WARNING)
+    loaded_model = adapter.load_model(
+        runtime_request=BackendRuntimeRequest(
+            model_name="large-v3",
+            use_demucs=False,
+            use_vad=True,
+            device_spec="mps",
+            device_type="mps",
+            precision_candidates=("float16", "float32"),
+            memory_tier="low",
+        ),
+        settings=settings,
+    )
+
+    transcript = adapter.transcribe(
+        model=loaded_model,
+        runtime_request=BackendRuntimeRequest(
+            model_name="large-v3",
+            use_demucs=False,
+            use_vad=True,
+            device_spec="mps",
+            device_type="mps",
+            precision_candidates=("float16", "float32"),
+            memory_tier="low",
+        ),
+        file_path="sample.wav",
+        language="en",
+        settings=settings,
+    )
+
+    assert transcript == []
+    assert fp16_flags == [False]
+    assert "retrying with fallback precision" not in caplog.text
+    assert "retrying on cpu runtime after mps failure" not in caplog.text

--- a/tests/test_transcription_compat.py
+++ b/tests/test_transcription_compat.py
@@ -1,0 +1,118 @@
+"""Unit tests for transcription compatibility helpers."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import ser.utils.transcription_compat as compat
+
+
+def test_resolve_stable_whisper_fallback_model_name_maps_distil_to_turbo() -> None:
+    """Distil model ids should map to a stable-whisper compatible fallback."""
+    assert (
+        compat.resolve_stable_whisper_fallback_model_name("distil-large-v3") == "turbo"
+    )
+
+
+def test_resolve_stable_whisper_fallback_model_name_keeps_supported_model() -> None:
+    """Already-supported stable-whisper model ids should pass through unchanged."""
+    assert compat.resolve_stable_whisper_fallback_model_name("large-v3") == "large-v3"
+
+
+def test_has_known_faster_whisper_openmp_runtime_conflict_detects_dual_libiomp(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Conflict detection should trigger when ctranslate2 and torch OpenMP runtimes coexist."""
+    ctranslate2_origin = tmp_path / "ctranslate2" / "__init__.py"
+    torch_origin = tmp_path / "torchpkg" / "torch" / "__init__.py"
+    faster_whisper_origin = tmp_path / "faster_whisper" / "__init__.py"
+    ctranslate2_openmp = tmp_path / "ctranslate2" / ".dylibs" / "libiomp5.dylib"
+    functorch_openmp = (
+        tmp_path / "torchpkg" / "functorch" / ".dylibs" / "libiomp5.dylib"
+    )
+    ctranslate2_openmp.parent.mkdir(parents=True, exist_ok=True)
+    functorch_openmp.parent.mkdir(parents=True, exist_ok=True)
+    ctranslate2_origin.parent.mkdir(parents=True, exist_ok=True)
+    torch_origin.parent.mkdir(parents=True, exist_ok=True)
+    faster_whisper_origin.parent.mkdir(parents=True, exist_ok=True)
+    ctranslate2_origin.write_text("", encoding="utf-8")
+    torch_origin.write_text("", encoding="utf-8")
+    faster_whisper_origin.write_text("", encoding="utf-8")
+    ctranslate2_openmp.write_text("", encoding="utf-8")
+    functorch_openmp.write_text("", encoding="utf-8")
+
+    def _fake_find_spec(name: str) -> object | None:
+        if name == "faster_whisper":
+            return SimpleNamespace(origin=str(faster_whisper_origin))
+        if name == "ctranslate2":
+            return SimpleNamespace(origin=str(ctranslate2_origin))
+        if name == "torch":
+            return SimpleNamespace(origin=str(torch_origin))
+        return None
+
+    monkeypatch.setattr(compat.sys, "platform", "darwin")
+    monkeypatch.setattr(compat.platform, "machine", lambda: "x86_64")
+    monkeypatch.setattr(compat.importlib.util, "find_spec", _fake_find_spec)
+    monkeypatch.delitem(compat.sys.modules, "faster_whisper", raising=False)
+
+    assert compat.has_known_faster_whisper_openmp_runtime_conflict() is True
+
+
+def test_stable_whisper_sparse_mps_incompatibility_detects_sparse_backend_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SparseMPS NotImplementedError should mark stable-whisper MPS as incompatible."""
+
+    class _FakeSparseTensor:
+        def to(self, *, device: str) -> object:
+            del device
+            raise NotImplementedError(
+                "Could not run 'aten::empty.memory_format' with arguments from the "
+                "'SparseMPS' backend."
+            )
+
+    class _FakeDenseTensor:
+        def to_sparse(self) -> _FakeSparseTensor:
+            return _FakeSparseTensor()
+
+    fake_torch = SimpleNamespace(
+        float32=object(),
+        backends=SimpleNamespace(
+            mps=SimpleNamespace(
+                is_available=lambda: True,
+                is_built=lambda: True,
+            )
+        ),
+        ones=lambda _shape, dtype=None: _FakeDenseTensor(),
+    )
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+    compat.has_known_stable_whisper_sparse_mps_incompatibility.cache_clear()
+
+    assert compat.has_known_stable_whisper_sparse_mps_incompatibility() is True
+
+    compat.has_known_stable_whisper_sparse_mps_incompatibility.cache_clear()
+
+
+def test_stable_whisper_sparse_mps_incompatibility_returns_false_when_mps_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """MPS-unavailable environments should not report sparse-MPS incompatibility."""
+    fake_torch = SimpleNamespace(
+        backends=SimpleNamespace(
+            mps=SimpleNamespace(
+                is_available=lambda: False,
+                is_built=lambda: True,
+            )
+        ),
+    )
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+    compat.has_known_stable_whisper_sparse_mps_incompatibility.cache_clear()
+
+    assert compat.has_known_stable_whisper_sparse_mps_incompatibility() is False
+
+    compat.has_known_stable_whisper_sparse_mps_incompatibility.cache_clear()

--- a/tests/test_transcription_factory.py
+++ b/tests/test_transcription_factory.py
@@ -1,0 +1,36 @@
+"""Unit tests for transcription backend adapter factory behavior."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+
+def test_factory_resolves_faster_adapter_without_importing_stable_backend() -> None:
+    """Resolving faster adapter should not import stable backend or torch stack."""
+    module_names = (
+        "ser.transcript.backends.factory",
+        "ser.transcript.backends.stable_whisper",
+        "ser.transcript.backends.stable_whisper_mps_compat",
+    )
+    removed_modules = {
+        module_name: sys.modules.pop(module_name, None) for module_name in module_names
+    }
+    try:
+        factory = importlib.import_module("ser.transcript.backends.factory")
+        reloaded_factory = importlib.reload(factory)
+
+        assert "ser.transcript.backends.stable_whisper" not in sys.modules
+        assert "ser.transcript.backends.stable_whisper_mps_compat" not in sys.modules
+
+        adapter = reloaded_factory.resolve_transcription_backend_adapter(
+            "faster_whisper"
+        )
+
+        assert adapter.backend_id == "faster_whisper"
+        assert "ser.transcript.backends.stable_whisper" not in sys.modules
+        assert "ser.transcript.backends.stable_whisper_mps_compat" not in sys.modules
+    finally:
+        for module_name, module in removed_modules.items():
+            if module is not None:
+                sys.modules[module_name] = module

--- a/tests/test_transcription_mps_admission.py
+++ b/tests/test_transcription_mps_admission.py
@@ -1,0 +1,166 @@
+"""Tests for dynamic MPS admission control decisions."""
+
+from __future__ import annotations
+
+import pytest
+
+from ser.transcript import mps_admission
+
+
+def test_mps_admission_allows_when_pressure_snapshot_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unavailable pressure telemetry should keep MPS enabled conservatively."""
+    monkeypatch.setattr(
+        mps_admission,
+        "capture_mps_pressure_snapshot",
+        lambda: mps_admission.MpsPressureSnapshot(
+            is_available=False,
+            current_allocated_bytes=None,
+            driver_allocated_bytes=None,
+            recommended_max_bytes=None,
+            headroom_bytes=None,
+        ),
+    )
+
+    decision = mps_admission.decide_mps_admission_for_transcription(
+        model_name="turbo",
+        phase="transcribe",
+    )
+
+    assert decision.allow_mps is True
+    assert decision.reason_code == "mps_pressure_unavailable"
+
+
+def test_mps_admission_denies_when_headroom_is_below_required_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Insufficient MPS headroom should force CPU fallback for transcription."""
+    monkeypatch.setattr(
+        mps_admission,
+        "capture_mps_pressure_snapshot",
+        lambda: mps_admission.MpsPressureSnapshot(
+            is_available=True,
+            current_allocated_bytes=0,
+            driver_allocated_bytes=0,
+            recommended_max_bytes=0,
+            headroom_bytes=32 * 1024**2,
+        ),
+    )
+
+    decision = mps_admission.decide_mps_admission_for_transcription(
+        model_name="large",
+        phase="model_load",
+        min_headroom_mb=64.0,
+        safety_margin_mb=64.0,
+    )
+
+    assert decision.allow_mps is False
+    assert decision.reason_code == "mps_headroom_below_required_budget"
+    assert decision.available_bytes == 32 * 1024**2
+    assert decision.required_bytes is not None
+    assert decision.required_bytes > decision.available_bytes
+
+
+def test_mps_admission_allows_when_headroom_is_sufficient(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Sufficient MPS headroom should keep MPS runtime admitted."""
+    monkeypatch.setattr(
+        mps_admission,
+        "capture_mps_pressure_snapshot",
+        lambda: mps_admission.MpsPressureSnapshot(
+            is_available=True,
+            current_allocated_bytes=0,
+            driver_allocated_bytes=0,
+            recommended_max_bytes=0,
+            headroom_bytes=512 * 1024**2,
+        ),
+    )
+
+    decision = mps_admission.decide_mps_admission_for_transcription(
+        model_name="turbo",
+        phase="transcribe",
+        min_headroom_mb=32.0,
+        safety_margin_mb=16.0,
+    )
+
+    assert decision.allow_mps is True
+    assert decision.reason_code == "mps_headroom_sufficient"
+
+
+def test_mps_admission_uses_driver_guard_when_headroom_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Driver-allocation guard should deny MPS when nearing known pressure limits."""
+    monkeypatch.setattr(
+        mps_admission,
+        "capture_mps_pressure_snapshot",
+        lambda: mps_admission.MpsPressureSnapshot(
+            is_available=True,
+            current_allocated_bytes=None,
+            driver_allocated_bytes=int(3.30 * float(1024**3)),
+            recommended_max_bytes=None,
+            headroom_bytes=None,
+        ),
+    )
+
+    decision = mps_admission.decide_mps_admission_for_transcription(
+        model_name="turbo",
+        phase="model_load",
+    )
+
+    assert decision.allow_mps is False
+    assert decision.reason_code == "mps_headroom_estimate_below_required_budget"
+
+
+def test_mps_admission_denies_large_model_load_when_headroom_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Large model load should fail over to CPU when MPS headroom cannot be measured."""
+    monkeypatch.setattr(
+        mps_admission,
+        "capture_mps_pressure_snapshot",
+        lambda: mps_admission.MpsPressureSnapshot(
+            is_available=True,
+            current_allocated_bytes=None,
+            driver_allocated_bytes=None,
+            recommended_max_bytes=None,
+            headroom_bytes=None,
+        ),
+    )
+
+    decision = mps_admission.decide_mps_admission_for_transcription(
+        model_name="large",
+        phase="model_load",
+    )
+
+    assert decision.allow_mps is False
+    assert decision.reason_code == "mps_headroom_unknown_large_model"
+
+
+def test_mps_admission_model_load_budget_tracks_model_footprint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Large model-load admission should require near-footprint headroom budget."""
+    monkeypatch.setattr(
+        mps_admission,
+        "capture_mps_pressure_snapshot",
+        lambda: mps_admission.MpsPressureSnapshot(
+            is_available=True,
+            current_allocated_bytes=0,
+            driver_allocated_bytes=0,
+            recommended_max_bytes=int(4.00 * float(1024**3)),
+            headroom_bytes=int(4.00 * float(1024**3)),
+        ),
+    )
+
+    decision = mps_admission.decide_mps_admission_for_transcription(
+        model_name="large",
+        phase="model_load",
+        min_headroom_mb=64.0,
+        safety_margin_mb=64.0,
+    )
+
+    assert decision.required_bytes is not None
+    assert decision.required_bytes >= int(3.15 * float(1024**3))

--- a/tests/test_transcription_runtime_failures.py
+++ b/tests/test_transcription_runtime_failures.py
@@ -1,0 +1,49 @@
+"""Tests for runtime failure classification in transcription adapters."""
+
+from __future__ import annotations
+
+from ser.transcript.runtime_failures import (
+    FailureDisposition,
+    classify_stable_whisper_transcription_failure,
+)
+
+
+def test_classifier_marks_pure_mps_oom_on_fp16_for_direct_cpu_failover() -> None:
+    """Pure MPS OOM on fp16 should shortcut to CPU failover."""
+    classification = classify_stable_whisper_transcription_failure(
+        err=RuntimeError("MPS backend out of memory"),
+        runtime_device_type="mps",
+        precision="float16",
+    )
+
+    assert classification.disposition == FailureDisposition.FAILOVER_CPU_NOW
+    assert classification.reason_code == "mps_oom_hard_float16"
+    assert classification.is_retryable is True
+
+
+def test_classifier_preserves_retry_path_for_operator_gaps() -> None:
+    """SparseMPS/aten operator gaps should keep precision fallback behavior."""
+    classification = classify_stable_whisper_transcription_failure(
+        err=NotImplementedError(
+            "Could not run 'aten::empty.memory_format' with arguments "
+            "from the 'SparseMPS' backend."
+        ),
+        runtime_device_type="mps",
+        precision="float16",
+    )
+
+    assert classification.disposition == FailureDisposition.RETRY_NEXT_PRECISION
+    assert classification.is_retryable is True
+
+
+def test_classifier_fails_fast_for_non_retryable_errors() -> None:
+    """Non-retryable runtime failures should terminate without fallback retries."""
+    classification = classify_stable_whisper_transcription_failure(
+        err=RuntimeError("unexpected serialization corruption"),
+        runtime_device_type="cpu",
+        precision="float32",
+    )
+
+    assert classification.disposition == FailureDisposition.FAIL_FAST
+    assert classification.reason_code == "non_retryable_runtime_error"
+    assert classification.is_retryable is False

--- a/tests/test_transcription_runtime_policy.py
+++ b/tests/test_transcription_runtime_policy.py
@@ -1,0 +1,166 @@
+"""Tests for transcription runtime policy resolution."""
+
+from __future__ import annotations
+
+import pytest
+
+import ser.transcript.runtime_policy as runtime_policy
+from ser.utils.torch_inference import TorchRuntime
+
+
+def _runtime(*, device_spec: str, device_type: str) -> TorchRuntime:
+    """Builds one deterministic torch runtime stub."""
+    return TorchRuntime(
+        device=object(),
+        dtype=object(),
+        device_spec=device_spec,
+        device_type=device_type,
+        dtype_name="float32",
+    )
+
+
+def test_policy_resolves_explicit_cuda_float16() -> None:
+    """Explicit CUDA+float16 should pin precision without fallback candidates."""
+    policy = runtime_policy.resolve_transcription_runtime_policy(
+        backend_id="stable_whisper",
+        requested_device="cuda",
+        requested_dtype="float16",
+    )
+
+    assert policy.device_type in {"cpu", "cuda"}
+    if policy.device_type == "cuda":
+        assert policy.precision_candidates == ("float16",)
+    else:
+        assert policy.precision_candidates == ("float32",)
+
+
+def test_policy_prefers_fp16_then_fp32_on_low_memory_mps(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Low-memory MPS auto mode should prioritize fp16 for fit-first behavior."""
+    monkeypatch.setattr(
+        runtime_policy,
+        "maybe_resolve_torch_runtime",
+        lambda **_kwargs: _runtime(device_spec="mps", device_type="mps"),
+    )
+    monkeypatch.setattr(
+        runtime_policy,
+        "_resolve_mps_memory_tier",
+        lambda **_kwargs: "low",
+    )
+
+    policy = runtime_policy.resolve_transcription_runtime_policy(
+        backend_id="stable_whisper",
+        requested_device="auto",
+        requested_dtype="auto",
+    )
+
+    assert policy.device_spec == "mps"
+    assert policy.device_type == "mps"
+    assert policy.memory_tier == "low"
+    assert policy.precision_candidates == ("float16", "float32")
+
+
+def test_policy_keeps_fp16_then_fp32_on_high_memory_mps(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """High-memory MPS keeps fit-first order; memory tier is informational."""
+    monkeypatch.setattr(
+        runtime_policy,
+        "maybe_resolve_torch_runtime",
+        lambda **_kwargs: _runtime(device_spec="mps", device_type="mps"),
+    )
+    monkeypatch.setattr(
+        runtime_policy,
+        "_resolve_mps_memory_tier",
+        lambda **_kwargs: "high",
+    )
+
+    policy = runtime_policy.resolve_transcription_runtime_policy(
+        backend_id="stable_whisper",
+        requested_device="auto",
+        requested_dtype="auto",
+    )
+
+    assert policy.device_spec == "mps"
+    assert policy.device_type == "mps"
+    assert policy.memory_tier == "high"
+    assert policy.precision_candidates == ("float16", "float32")
+    assert "mps_memory_tier_high_informational_only" in policy.reason
+
+
+def test_policy_filters_bfloat16_for_stable_whisper(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stable-whisper should drop bfloat16 from candidate list by capability."""
+    monkeypatch.setattr(
+        runtime_policy,
+        "maybe_resolve_torch_runtime",
+        lambda **_kwargs: _runtime(device_spec="cuda:0", device_type="cuda"),
+    )
+
+    policy = runtime_policy.resolve_transcription_runtime_policy(
+        backend_id="stable_whisper",
+        requested_device="cuda:0",
+        requested_dtype="bfloat16",
+    )
+
+    assert policy.device_spec == "cuda:0"
+    assert policy.device_type == "cuda"
+    assert policy.precision_candidates == ("float16", "float32")
+    assert "precision_candidates_filtered_by_backend_capabilities" in policy.reason
+
+
+def test_policy_falls_back_to_cpu_for_unsupported_backend_device(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Backends lacking MPS support should resolve to CPU without hard failure."""
+    monkeypatch.setattr(
+        runtime_policy,
+        "maybe_resolve_torch_runtime",
+        lambda **_kwargs: _runtime(device_spec="mps", device_type="mps"),
+    )
+    monkeypatch.setattr(
+        runtime_policy,
+        "_resolve_mps_memory_tier",
+        lambda **_kwargs: "low",
+    )
+
+    policy = runtime_policy.resolve_transcription_runtime_policy(
+        backend_id="faster_whisper",
+        requested_device="auto",
+        requested_dtype="auto",
+    )
+
+    assert policy.device_spec == "cpu"
+    assert policy.device_type == "cpu"
+    assert policy.memory_tier == "not_applicable"
+    assert policy.precision_candidates == ("float32",)
+    assert "backend_faster_whisper_does_not_support_device_mps" in policy.reason
+
+
+def test_policy_passes_configured_mps_threshold_to_memory_tier_resolver(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Policy should route configured threshold through memory-tier resolution."""
+    monkeypatch.setattr(
+        runtime_policy,
+        "maybe_resolve_torch_runtime",
+        lambda **_kwargs: _runtime(device_spec="mps", device_type="mps"),
+    )
+    captured: dict[str, float] = {}
+
+    def _fake_memory_tier(*, low_memory_threshold_gb: float) -> str:
+        captured["threshold"] = low_memory_threshold_gb
+        return "high"
+
+    monkeypatch.setattr(runtime_policy, "_resolve_mps_memory_tier", _fake_memory_tier)
+
+    _ = runtime_policy.resolve_transcription_runtime_policy(
+        backend_id="stable_whisper",
+        requested_device="mps",
+        requested_dtype="auto",
+        mps_low_memory_threshold_gb=28.5,
+    )
+
+    assert captured["threshold"] == pytest.approx(28.5)


### PR DESCRIPTION
## Summary

This PR improves transcription runtime robustness across MPS/CUDA/CPU paths, adds configurable admission/fallback controls, and isolates faster-whisper execution to reduce runtime conflict risk.

## What changed

- Added new runtime/transcription config flags for MPS admission behavior, thresholds, calibration controls, and torch MPS fallback env sync.
- Extended backend runtime request metadata with device, precision candidates, and memory tier.
- Added proactive torch cache cleanup before/after transcription and before retry paths.
- Updated faster-whisper compatibility checks and runtime loading behavior for OpenMP and MPS constraints.
- Reworked stable-whisper load/transcribe flow with:
    - MPS admission decisioning
    - precision retry strategy
    - hard OOM shortcut option
    - CPU failover handling
    - compatibility/timing contexts
    - improved runtime error summarization/logging
- Added process-isolated faster-whisper execution in transcript extraction via spawned worker and structured phase/error messaging.
- Updated typecheck docs/Make target to pin Pyright to Python 3.12.

## Tests

- Added/expanded unit coverage in:
    - test_config_feature_flags.py
    - test_runtime_pipeline.py
    - test_transcript_extractor.py
    - test_transcription_backends.py
- Coverage now explicitly validates new admission/fallback policies, process isolation flow, and runtime cache cleanup behavior.