### PR TITLE
Add dataset workflow and backend runtime policy; harden medium inference and fix faster_whisper process cleanup

### DIFF
--- a/ser/__main__.py
+++ b/ser/__main__.py
@@ -38,7 +38,6 @@ from ser.runtime.phase_timing import format_duration
 from ser.utils.logger import configure_logging, get_logger
 
 if TYPE_CHECKING:
-    from ser.domain import EmotionSegment, TimelineEntry, TranscriptWord
     from ser.runtime.pipeline import RuntimePipeline
 
 logger: logging.Logger = get_logger("ser")
@@ -476,10 +475,11 @@ def main() -> None:
     use_profile_pipeline: bool = _profile_pipeline_enabled(active_settings)
     required_restricted_backends: tuple[str, ...] = ()
     if isinstance(active_settings, AppConfig):
+        profile_resolution_enabled = use_profile_pipeline or bool(args.file)
         required_restricted_backends = (
             _required_restricted_backends_for_current_profile(
                 active_settings,
-                use_profile_pipeline=use_profile_pipeline,
+                use_profile_pipeline=profile_resolution_enabled,
             )
         )
         if args.accept_all_restricted_backends:
@@ -494,7 +494,7 @@ def main() -> None:
         if args.accept_restricted_backends:
             persisted = _persist_required_restricted_backends(
                 active_settings,
-                use_profile_pipeline=use_profile_pipeline,
+                use_profile_pipeline=profile_resolution_enabled,
                 consent_source="cli_flag_accept_restricted",
             )
             if persisted:
@@ -624,28 +624,25 @@ def main() -> None:
     workflow_profile = (
         resolve_profile_name(active_settings)
         if isinstance(active_settings, AppConfig)
-        else "legacy"
+        else "fast"
     )
     logger.info("SER workflow started (profile=%s).", workflow_profile)
     start_time = time.perf_counter()
     try:
-        if use_profile_pipeline:
-            from ser.runtime import InferenceRequest
+        from ser.runtime import InferenceRequest
 
-            execution: InferenceExecution = _build_runtime_pipeline(
-                cast(AppConfig, active_settings)
-            ).run_inference(
-                InferenceRequest(
-                    file_path=args.file,
-                    language=args.language,
-                    save_transcript=args.save_transcript,
-                    include_transcript=not args.no_transcript,
-                )
+        execution: InferenceExecution = _build_runtime_pipeline(
+            cast(AppConfig, active_settings)
+        ).run_inference(
+            InferenceRequest(
+                file_path=args.file,
+                language=args.language,
+                save_transcript=args.save_transcript,
+                include_transcript=not args.no_transcript,
             )
-            if execution.timeline_csv_path is not None:
-                logger.info(msg=f"Timeline saved to {execution.timeline_csv_path}")
-        else:
-            _run_legacy_inference_workflow(args)
+        )
+        if execution.timeline_csv_path is not None:
+            logger.info(msg=f"Timeline saved to {execution.timeline_csv_path}")
     except UnsupportedProfileError as err:
         logger.error("%s", err)
         sys.exit(2)
@@ -688,29 +685,6 @@ def main() -> None:
         "SER workflow completed in %s.",
         format_duration(time.perf_counter() - start_time),
     )
-
-
-def _run_legacy_inference_workflow(args: argparse.Namespace) -> None:
-    from ser.models.emotion_model import predict_emotions
-    from ser.transcript import extract_transcript
-    from ser.utils.timeline_utils import (
-        build_timeline,
-        print_timeline,
-        save_timeline_to_csv,
-    )
-
-    emotions: list[EmotionSegment] = predict_emotions(args.file)
-    transcript: list[TranscriptWord]
-    if args.no_transcript:
-        transcript = []
-    else:
-        transcript = extract_transcript(args.file, args.language)
-    timeline: list[TimelineEntry] = build_timeline(transcript, emotions)
-    print_timeline(timeline)
-
-    if args.save_transcript:
-        csv_file_name: str = save_timeline_to_csv(timeline, args.file)
-        logger.info(msg=f"Timeline saved to {csv_file_name}")
 
 
 if __name__ == "__main__":

--- a/ser/data/adapters/__init__.py
+++ b/ser/data/adapters/__init__.py
@@ -2,4 +2,38 @@
 
 from __future__ import annotations
 
-__all__ = []
+from .biic_podcast import (
+    BIIC_PODCAST_CORPUS_ID,
+    build_biic_podcast_manifest_jsonl,
+    build_biic_podcast_utterances,
+)
+from .crema_d import (
+    CREMA_D_CORPUS_ID,
+    build_crema_d_manifest_jsonl,
+    build_crema_d_utterances,
+)
+from .msp_podcast import (
+    MSP_PODCAST_CORPUS_ID,
+    build_msp_podcast_manifest_jsonl,
+    build_msp_podcast_utterances,
+)
+from .ravdess import (
+    RAVDESS_CORPUS_ID,
+    build_ravdess_manifest_jsonl,
+    build_ravdess_utterances,
+)
+
+__all__ = [
+    "BIIC_PODCAST_CORPUS_ID",
+    "CREMA_D_CORPUS_ID",
+    "MSP_PODCAST_CORPUS_ID",
+    "RAVDESS_CORPUS_ID",
+    "build_biic_podcast_manifest_jsonl",
+    "build_biic_podcast_utterances",
+    "build_crema_d_manifest_jsonl",
+    "build_crema_d_utterances",
+    "build_msp_podcast_manifest_jsonl",
+    "build_msp_podcast_utterances",
+    "build_ravdess_manifest_jsonl",
+    "build_ravdess_utterances",
+]

--- a/ser/data/adapters/biic_podcast.py
+++ b/ser/data/adapters/biic_podcast.py
@@ -1,0 +1,246 @@
+"""BIIC-Podcast adapter for building manifest-compatible utterances."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Any
+
+from ser.data.manifest import SplitName, Utterance
+from ser.data.manifest_jsonl import write_manifest_jsonl
+from ser.data.ontology import LabelOntology, remap_label
+from ser.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+BIIC_PODCAST_CORPUS_ID = "biic-podcast"
+BIIC_PODCAST_DATASET_POLICY_ID = "academic_only"
+BIIC_PODCAST_DATASET_LICENSE_ID = "biic-academic-license"
+BIIC_PODCAST_SOURCE_URL = "https://biic.ee.nthu.edu.tw/"
+
+
+_EMO_CLASS_MAP: dict[str, str] = {
+    "0": "angry",
+    "1": "sad",
+    "2": "happy",
+    "3": "surprised",
+    "4": "fearful",
+    "5": "disgust",
+    "6": "contempt",
+    "7": "neutral",
+}
+
+
+def _normalize_split(value: str | None) -> SplitName | None:
+    if value is None:
+        return None
+    normalized = value.strip().lower()
+    if not normalized:
+        return None
+    if normalized in {"train", "training"}:
+        return "train"
+    if normalized in {"dev", "valid", "validation", "development"}:
+        return "dev"
+    if normalized in {"test", "evaluation", "eval"}:
+        return "test"
+    return None
+
+
+def _read_optional_float(row: dict[str, Any], *keys: str) -> float | None:
+    for key in keys:
+        raw = row.get(key)
+        if isinstance(raw, str):
+            text = raw.strip()
+            if not text:
+                continue
+            try:
+                return float(text)
+            except ValueError:
+                continue
+    return None
+
+
+def _build_sample_id(
+    *,
+    file_name: str,
+    start_seconds: float | None,
+    duration_seconds: float | None,
+) -> str:
+    normalized = file_name.replace("\\", "/")
+    base = f"{BIIC_PODCAST_CORPUS_ID}:{normalized}"
+    if start_seconds is None or duration_seconds is None:
+        return base
+    return f"{base}@{start_seconds:.3f}+{duration_seconds:.3f}"
+
+
+def build_biic_podcast_utterances(
+    *,
+    dataset_root: Path,
+    labels_csv_path: Path,
+    audio_base_dir: Path | None,
+    ontology: LabelOntology,
+    default_language: str,
+    max_failed_file_ratio: float,
+) -> list[Utterance] | None:
+    """Builds utterances from BIIC-Podcast label CSV.
+
+    The corpus is often distributed under access-controlled terms. This adapter
+    expects a CSV/TSV with at least FileName and EmoClass.
+    """
+
+    if not labels_csv_path.is_file():
+        logger.warning("BIIC-Podcast labels CSV not found: %s", labels_csv_path)
+        return None
+    base_dir = audio_base_dir if audio_base_dir is not None else dataset_root
+    utterances: list[Utterance] = []
+    parse_errors: list[str] = []
+    with labels_csv_path.open("r", encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle)
+        for index, row in enumerate(reader):
+            file_name = (row.get("FileName") or row.get("filename") or "").strip()
+            if not file_name:
+                parse_errors.append(f"Row {index}: missing FileName")
+                continue
+            raw_class = (row.get("EmoClass") or row.get("emotion") or "").strip()
+            if not raw_class:
+                parse_errors.append(f"Row {index}: missing EmoClass for {file_name}")
+                continue
+            mapped_raw = _EMO_CLASS_MAP.get(raw_class, raw_class)
+            mapped_label = remap_label(
+                raw_label=mapped_raw,
+                mapping={
+                    "anger": "angry",
+                    "angry": "angry",
+                    "sad": "sad",
+                    "happy": "happy",
+                    "surprise": "surprised",
+                    "surprised": "surprised",
+                    "fear": "fearful",
+                    "fearful": "fearful",
+                    "disgust": "disgust",
+                    "neutral": "neutral",
+                    "contempt": "contempt",
+                },
+                ontology=ontology,
+            )
+            if mapped_label is None:
+                continue
+
+            split = _normalize_split(row.get("Split_Set") or row.get("split"))
+            start_seconds = _read_optional_float(
+                row,
+                "start_seconds",
+                "Start",
+                "start",
+                "start_time",
+                "StartTime",
+            )
+            duration_seconds = _read_optional_float(
+                row,
+                "duration_seconds",
+                "Duration",
+                "duration",
+            )
+            end_seconds = _read_optional_float(
+                row,
+                "end_seconds",
+                "End",
+                "end",
+                "end_time",
+                "EndTime",
+            )
+            if (
+                duration_seconds is None
+                and start_seconds is not None
+                and end_seconds is not None
+            ):
+                duration = end_seconds - start_seconds
+                duration_seconds = duration if duration > 0.0 else None
+
+            language = (
+                row.get("Language") or row.get("language") or ""
+            ).strip() or default_language
+            speaker_raw = (
+                row.get("Speaker") or row.get("Speaker_ID") or row.get("speaker") or ""
+            ).strip()
+            speaker_id = (
+                f"{BIIC_PODCAST_CORPUS_ID}:{speaker_raw}" if speaker_raw else None
+            )
+            audio_path = (base_dir / file_name).expanduser()
+            sample_id = _build_sample_id(
+                file_name=file_name,
+                start_seconds=start_seconds,
+                duration_seconds=duration_seconds,
+            )
+            utterances.append(
+                Utterance(
+                    schema_version=1,
+                    sample_id=sample_id,
+                    corpus=BIIC_PODCAST_CORPUS_ID,
+                    audio_path=audio_path,
+                    label=mapped_label,
+                    raw_label=mapped_raw,
+                    speaker_id=speaker_id,
+                    language=language,
+                    split=split,
+                    start_seconds=start_seconds,
+                    duration_seconds=duration_seconds,
+                    dataset_policy_id=BIIC_PODCAST_DATASET_POLICY_ID,
+                    dataset_license_id=BIIC_PODCAST_DATASET_LICENSE_ID,
+                    source_url=BIIC_PODCAST_SOURCE_URL,
+                )
+            )
+
+    if parse_errors:
+        logger.warning(
+            "Skipped %s rows while parsing BIIC-Podcast labels.",
+            len(parse_errors),
+        )
+        for error in parse_errors[:5]:
+            logger.warning("%s", error)
+
+    total_rows = len(utterances) + len(parse_errors)
+    if total_rows > 0:
+        failure_ratio = float(len(parse_errors)) / float(total_rows)
+        if failure_ratio > max_failed_file_ratio:
+            raise RuntimeError(
+                "Aborting data load: "
+                f"{failure_ratio * 100.0:.1f}% label-row failures exceeded configured "
+                "limit "
+                f"{max_failed_file_ratio * 100.0:.1f}%."
+            )
+
+    if not utterances:
+        logger.warning("No labeled audio samples matched configured emotions.")
+        return None
+    labels = [utterance.label for utterance in utterances]
+    if len(set(labels)) < 2:
+        logger.warning("At least two emotion classes are required to train the model.")
+        return None
+    return utterances
+
+
+def build_biic_podcast_manifest_jsonl(
+    *,
+    dataset_root: Path,
+    labels_csv_path: Path,
+    audio_base_dir: Path | None,
+    ontology: LabelOntology,
+    default_language: str,
+    max_failed_file_ratio: float,
+    output_path: Path,
+) -> list[Utterance] | None:
+    """Builds utterances and persists a BIIC-Podcast JSONL manifest."""
+
+    utterances = build_biic_podcast_utterances(
+        dataset_root=dataset_root,
+        labels_csv_path=labels_csv_path,
+        audio_base_dir=audio_base_dir,
+        ontology=ontology,
+        default_language=default_language,
+        max_failed_file_ratio=max_failed_file_ratio,
+    )
+    if utterances is None:
+        return None
+    write_manifest_jsonl(output_path, utterances, base_dir=dataset_root)
+    return utterances

--- a/ser/data/adapters/msp_podcast.py
+++ b/ser/data/adapters/msp_podcast.py
@@ -1,0 +1,259 @@
+"""MSP-Podcast adapter for building manifest-compatible utterances."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Any
+
+from ser.data.manifest import SplitName, Utterance
+from ser.data.manifest_jsonl import write_manifest_jsonl
+from ser.data.ontology import LabelOntology, remap_label
+from ser.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+MSP_PODCAST_CORPUS_ID = "msp-podcast"
+MSP_PODCAST_DATASET_POLICY_ID = "academic_only"
+MSP_PODCAST_DATASET_LICENSE_ID = "msp-academic-license"
+MSP_PODCAST_SOURCE_URL = "https://lab-msp.com/MSP/MSP-Podcast.html"
+
+
+_EMO_CLASS_MAP: dict[str, str] = {
+    # Categorical mapping used by MSP-Podcast challenge baselines.
+    "0": "angry",
+    "1": "sad",
+    "2": "happy",
+    "3": "surprised",
+    "4": "fearful",
+    "5": "disgust",
+    "6": "contempt",
+    "7": "neutral",
+}
+
+
+def _normalize_split(value: str | None) -> SplitName | None:
+    if value is None:
+        return None
+    normalized = value.strip().lower()
+    if not normalized:
+        return None
+    if normalized in {"train", "training"}:
+        return "train"
+    if normalized in {"dev", "valid", "validation", "development"}:
+        return "dev"
+    if normalized in {"test", "evaluation", "eval"}:
+        return "test"
+    # Some MSP-Podcast releases use Train/Development/Test1...; keep unknown as None.
+    return None
+
+
+def _read_optional_float(row: dict[str, Any], *keys: str) -> float | None:
+    for key in keys:
+        raw = row.get(key)
+        if isinstance(raw, str):
+            text = raw.strip()
+            if not text:
+                continue
+            try:
+                return float(text)
+            except ValueError:
+                continue
+    return None
+
+
+def _build_sample_id(
+    *,
+    file_name: str,
+    start_seconds: float | None,
+    duration_seconds: float | None,
+) -> str:
+    normalized = file_name.replace("\\", "/")
+    base = f"{MSP_PODCAST_CORPUS_ID}:{normalized}"
+    if start_seconds is None or duration_seconds is None:
+        return base
+    return f"{base}@{start_seconds:.3f}+{duration_seconds:.3f}"
+
+
+def build_msp_podcast_utterances(
+    *,
+    dataset_root: Path,
+    labels_csv_path: Path,
+    audio_base_dir: Path | None,
+    ontology: LabelOntology,
+    default_language: str,
+    max_failed_file_ratio: float,
+) -> list[Utterance] | None:
+    """Builds utterances from MSP-Podcast categorical label CSV.
+
+    The adapter is intentionally permissive about field names to support common
+    MSP-Podcast releases.
+
+    Required columns (typical):
+      - FileName
+      - EmoClass
+      - Split_Set (optional)
+
+    Optional columns:
+      - Speaker / Speaker_ID
+      - Language
+      - Start/End or Start/Duration
+    """
+
+    if not labels_csv_path.is_file():
+        logger.warning("MSP-Podcast labels CSV not found: %s", labels_csv_path)
+        return None
+
+    base_dir = audio_base_dir if audio_base_dir is not None else dataset_root
+    utterances: list[Utterance] = []
+    parse_errors: list[str] = []
+    with labels_csv_path.open("r", encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle)
+        for index, row in enumerate(reader):
+            file_name = (row.get("FileName") or row.get("filename") or "").strip()
+            if not file_name:
+                parse_errors.append(f"Row {index}: missing FileName")
+                continue
+            raw_class = (row.get("EmoClass") or row.get("emotion") or "").strip()
+            if not raw_class:
+                parse_errors.append(f"Row {index}: missing EmoClass for {file_name}")
+                continue
+            mapped_raw = _EMO_CLASS_MAP.get(raw_class, raw_class)
+            mapped_label = remap_label(
+                raw_label=mapped_raw,
+                mapping={
+                    "anger": "angry",
+                    "angry": "angry",
+                    "sad": "sad",
+                    "happy": "happy",
+                    "surprise": "surprised",
+                    "surprised": "surprised",
+                    "fear": "fearful",
+                    "fearful": "fearful",
+                    "disgust": "disgust",
+                    "neutral": "neutral",
+                    "contempt": "contempt",
+                },
+                ontology=ontology,
+            )
+            if mapped_label is None:
+                continue
+
+            split = _normalize_split(row.get("Split_Set") or row.get("split"))
+            start_seconds = _read_optional_float(
+                row,
+                "start_seconds",
+                "Start",
+                "start",
+                "start_time",
+                "StartTime",
+            )
+            duration_seconds = _read_optional_float(
+                row,
+                "duration_seconds",
+                "Duration",
+                "duration",
+            )
+            end_seconds = _read_optional_float(
+                row,
+                "end_seconds",
+                "End",
+                "end",
+                "end_time",
+                "EndTime",
+            )
+            if (
+                duration_seconds is None
+                and start_seconds is not None
+                and end_seconds is not None
+            ):
+                duration = end_seconds - start_seconds
+                duration_seconds = duration if duration > 0.0 else None
+
+            language = (
+                row.get("Language") or row.get("language") or ""
+            ).strip() or default_language
+            speaker_raw = (
+                row.get("Speaker") or row.get("Speaker_ID") or row.get("speaker") or ""
+            ).strip()
+            speaker_id = (
+                f"{MSP_PODCAST_CORPUS_ID}:{speaker_raw}" if speaker_raw else None
+            )
+            audio_path = (base_dir / file_name).expanduser()
+            sample_id = _build_sample_id(
+                file_name=file_name,
+                start_seconds=start_seconds,
+                duration_seconds=duration_seconds,
+            )
+            utterances.append(
+                Utterance(
+                    schema_version=1,
+                    sample_id=sample_id,
+                    corpus=MSP_PODCAST_CORPUS_ID,
+                    audio_path=audio_path,
+                    label=mapped_label,
+                    raw_label=mapped_raw,
+                    speaker_id=speaker_id,
+                    language=language,
+                    split=split,
+                    start_seconds=start_seconds,
+                    duration_seconds=duration_seconds,
+                    dataset_policy_id=MSP_PODCAST_DATASET_POLICY_ID,
+                    dataset_license_id=MSP_PODCAST_DATASET_LICENSE_ID,
+                    source_url=MSP_PODCAST_SOURCE_URL,
+                )
+            )
+
+    if parse_errors:
+        logger.warning(
+            "Skipped %s rows while parsing MSP-Podcast labels.",
+            len(parse_errors),
+        )
+        for error in parse_errors[:5]:
+            logger.warning("%s", error)
+
+    total_rows = len(utterances) + len(parse_errors)
+    if total_rows > 0:
+        failure_ratio = float(len(parse_errors)) / float(total_rows)
+        if failure_ratio > max_failed_file_ratio:
+            raise RuntimeError(
+                "Aborting data load: "
+                f"{failure_ratio * 100.0:.1f}% label-row failures exceeded configured "
+                "limit "
+                f"{max_failed_file_ratio * 100.0:.1f}%."
+            )
+
+    if not utterances:
+        logger.warning("No labeled audio samples matched configured emotions.")
+        return None
+    labels = [utterance.label for utterance in utterances]
+    if len(set(labels)) < 2:
+        logger.warning("At least two emotion classes are required to train the model.")
+        return None
+    return utterances
+
+
+def build_msp_podcast_manifest_jsonl(
+    *,
+    dataset_root: Path,
+    labels_csv_path: Path,
+    audio_base_dir: Path | None,
+    ontology: LabelOntology,
+    default_language: str,
+    max_failed_file_ratio: float,
+    output_path: Path,
+) -> list[Utterance] | None:
+    """Builds utterances and persists an MSP-Podcast JSONL manifest."""
+
+    utterances = build_msp_podcast_utterances(
+        dataset_root=dataset_root,
+        labels_csv_path=labels_csv_path,
+        audio_base_dir=audio_base_dir,
+        ontology=ontology,
+        default_language=default_language,
+        max_failed_file_ratio=max_failed_file_ratio,
+    )
+    if utterances is None:
+        return None
+    write_manifest_jsonl(output_path, utterances, base_dir=dataset_root)
+    return utterances

--- a/ser/data/cli.py
+++ b/ser/data/cli.py
@@ -1,0 +1,252 @@
+"""CLI helpers for dataset consent and dataset preparation."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from ser.config import get_settings
+from ser.data.data_loader import _resolve_label_ontology
+from ser.data.dataset_consents import (
+    DatasetConsentError,
+    is_policy_restricted,
+    load_persisted_dataset_consents,
+    persist_dataset_consents,
+)
+from ser.data.dataset_prepare import (
+    download_dataset,
+    prepare_dataset_manifest,
+    resolve_dataset_descriptor,
+)
+
+
+def _is_interactive() -> bool:
+    return sys.stdin.isatty() and sys.stderr.isatty()
+
+
+def _prompt_acceptance(*, message: str) -> bool:
+    print(message)
+    print("Type 'accept' to continue: ", end="", flush=True)
+    try:
+        response = input().strip().lower()
+    except EOFError:
+        return False
+    return response == "accept"
+
+
+def _ensure_descriptor_consents(
+    *,
+    dataset_id: str,
+    policy_id: str,
+    license_id: str,
+    accept_license_flag: bool,
+) -> None:
+    settings = get_settings()
+    persisted = load_persisted_dataset_consents(settings=settings)
+    normalized_policy = policy_id.strip().lower()
+    normalized_license = license_id.strip().lower()
+    missing_policies: list[str] = []
+    missing_licenses: list[str] = []
+    if (
+        is_policy_restricted(normalized_policy)
+        and normalized_policy not in persisted.policy_consents
+    ):
+        missing_policies.append(normalized_policy)
+    if (
+        is_policy_restricted(normalized_policy)
+        and normalized_license
+        and normalized_license not in persisted.license_consents
+    ):
+        missing_licenses.append(normalized_license)
+    if not missing_policies and not missing_licenses:
+        return
+
+    interactive = _is_interactive()
+    if not accept_license_flag and not interactive:
+        raise DatasetConsentError(
+            "Non-interactive run requires explicit acknowledgement. "
+            "Re-run with `--accept-license`, or persist via `ser configure ... --persist`."
+        )
+
+    if not accept_license_flag:
+        policy_text = ", ".join(missing_policies) if missing_policies else "(none)"
+        license_text = ", ".join(missing_licenses) if missing_licenses else "(none)"
+        accepted = _prompt_acceptance(
+            message=(
+                f"Dataset '{dataset_id}' requires acknowledgement.\n"
+                f"Missing policy consent(s): {policy_text}\n"
+                f"Missing license consent(s): {license_text}\n"
+                "Your acknowledgement will be persisted locally."
+            )
+        )
+        if not accepted:
+            raise DatasetConsentError(
+                "Dataset acknowledgement declined. "
+                "Re-run with `--accept-license` or persist consents via `ser configure`."
+            )
+
+    persist_dataset_consents(
+        settings=settings,
+        accept_policy_ids=missing_policies,
+        accept_license_ids=missing_licenses,
+        source=f"ser data download --dataset {dataset_id}",
+    )
+
+
+def run_configure_command(argv: list[str]) -> int:
+    """Runs `ser configure ...` command."""
+
+    parser = argparse.ArgumentParser(prog="ser configure")
+    parser.add_argument(
+        "--accept-dataset-policy",
+        nargs="+",
+        default=[],
+        help="Dataset policy IDs to acknowledge (e.g., academic_only share_alike).",
+    )
+    parser.add_argument(
+        "--accept-dataset-license",
+        nargs="+",
+        default=[],
+        help="Dataset license IDs to acknowledge (e.g., odbl-1.0 cc-by-nc-sa-4.0).",
+    )
+    parser.add_argument(
+        "--persist",
+        action="store_true",
+        help="Persist acknowledgements to a local config file.",
+    )
+    parser.add_argument(
+        "--show",
+        action="store_true",
+        help="Show currently persisted dataset consents.",
+    )
+    args = parser.parse_args(argv)
+
+    settings = get_settings()
+    if args.show or (
+        not args.accept_dataset_policy and not args.accept_dataset_license
+    ):
+        consents = load_persisted_dataset_consents(settings=settings)
+        policies = ", ".join(sorted(consents.policy_consents)) or "(none)"
+        licenses = ", ".join(sorted(consents.license_consents)) or "(none)"
+        print(f"Persisted dataset policy consents: {policies}")
+        print(f"Persisted dataset license consents: {licenses}")
+        return 0
+
+    if not args.persist:
+        print("Refusing to modify local config without --persist.")
+        return 2
+
+    persist_dataset_consents(
+        settings=settings,
+        accept_policy_ids=list(args.accept_dataset_policy),
+        accept_license_ids=list(args.accept_dataset_license),
+        source="ser configure",
+    )
+    return 0
+
+
+def run_data_command(argv: list[str]) -> int:
+    """Runs `ser data ...` command."""
+
+    parser = argparse.ArgumentParser(prog="ser data")
+    subparsers = parser.add_subparsers(dest="subcommand", required=True)
+    download_parser = subparsers.add_parser(
+        "download", help="Download/prepare datasets"
+    )
+    download_parser.add_argument(
+        "--dataset",
+        required=True,
+        help="Dataset id (ravdess, crema-d, msp-podcast, biic-podcast)",
+    )
+    download_parser.add_argument(
+        "--dataset-root",
+        type=Path,
+        default=None,
+        help="Dataset install root. Defaults to SER data_root/datasets/<dataset>.",
+    )
+    download_parser.add_argument(
+        "--manifest-path",
+        type=Path,
+        default=None,
+        help="Manifest output path. Defaults to SER data_root/manifests/<dataset>.jsonl.",
+    )
+    download_parser.add_argument(
+        "--labels-csv-path",
+        type=Path,
+        default=None,
+        help="Label/index CSV needed by segment-based corpora (MSP/BIIC).",
+    )
+    download_parser.add_argument(
+        "--audio-base-dir",
+        type=Path,
+        default=None,
+        help="Base directory used to resolve FileName entries in label CSV.",
+    )
+    download_parser.add_argument(
+        "--skip-download",
+        action="store_true",
+        help="Skip download step (useful when the dataset is already present).",
+    )
+    download_parser.add_argument(
+        "--accept-license",
+        action="store_true",
+        help="Acknowledge the dataset's policy/license and persist locally.",
+    )
+
+    args = parser.parse_args(argv)
+    if args.subcommand != "download":
+        raise RuntimeError(f"Unhandled ser data subcommand: {args.subcommand}")
+
+    settings = get_settings()
+    descriptor = resolve_dataset_descriptor(args.dataset)
+    dataset_root = (
+        args.dataset_root.expanduser()
+        if args.dataset_root is not None
+        else (settings.models.folder.parent / "datasets" / descriptor.dataset_id)
+    )
+    manifest_path = (
+        args.manifest_path.expanduser()
+        if args.manifest_path is not None
+        else (
+            settings.models.folder.parent
+            / "manifests"
+            / f"{descriptor.dataset_id}.jsonl"
+        )
+    )
+    labels_csv_path = (
+        args.labels_csv_path.expanduser() if args.labels_csv_path else None
+    )
+    audio_base_dir = args.audio_base_dir.expanduser() if args.audio_base_dir else None
+
+    _ensure_descriptor_consents(
+        dataset_id=descriptor.dataset_id,
+        policy_id=descriptor.policy_id,
+        license_id=descriptor.license_id,
+        accept_license_flag=args.accept_license,
+    )
+    if not args.skip_download:
+        download_dataset(
+            settings=settings,
+            dataset_id=descriptor.dataset_id,
+            dataset_root=dataset_root,
+        )
+
+    ontology = _resolve_label_ontology(settings)
+    built = prepare_dataset_manifest(
+        settings=settings,
+        dataset_id=descriptor.dataset_id,
+        dataset_root=dataset_root,
+        ontology=ontology,
+        manifest_path=manifest_path,
+        labels_csv_path=labels_csv_path,
+        audio_base_dir=audio_base_dir,
+        default_language=settings.default_language,
+    )
+    if not built:
+        print("No manifest written (dataset missing or no usable samples).")
+        return 2
+    print("Wrote manifest(s):")
+    for path in built:
+        print(f"- {path}")
+    return 0

--- a/ser/data/dataset_consents.py
+++ b/ser/data/dataset_consents.py
@@ -1,0 +1,182 @@
+"""Dataset policy/license consent enforcement.
+
+This project supports training on multiple datasets with potentially restrictive
+policies (e.g., academic-only) and/or licenses.
+
+Expected behavior:
+  - Without prior consent: training must refuse and explain how to consent.
+  - With consent: training proceeds.
+
+Consent is persisted locally under the SER data root.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+from ser.config import AppConfig
+from ser.data.manifest import Utterance
+
+_CONSENT_STORE_ENV = "SER_DATASET_CONSENTS_FILE"
+_CONSENT_SCHEMA_VERSION = 1
+_CONSENT_FILE_NAME = "dataset_consents.json"
+_RESTRICTED_POLICY_IDS = frozenset({"academic_only", "share_alike", "noncommercial"})
+
+
+class DatasetConsentError(RuntimeError):
+    """Raised when required dataset policy/license consents are missing."""
+
+
+@dataclass(frozen=True)
+class PersistedDatasetConsents:
+    policy_consents: dict[str, str]
+    license_consents: dict[str, str]
+
+
+def _consents_path(settings: AppConfig) -> Path:
+    explicit_path = os.getenv(_CONSENT_STORE_ENV, "").strip()
+    if explicit_path:
+        return Path(explicit_path).expanduser()
+    return settings.models.folder.parent / ".ser" / _CONSENT_FILE_NAME
+
+
+def is_policy_restricted(policy_id: str | None) -> bool:
+    """Whether a dataset policy requires explicit acknowledgement."""
+
+    normalized = (policy_id or "").strip().lower()
+    return normalized in _RESTRICTED_POLICY_IDS
+
+
+def load_persisted_dataset_consents(*, settings: AppConfig) -> PersistedDatasetConsents:
+    path = _consents_path(settings)
+    if not path.is_file():
+        return PersistedDatasetConsents(policy_consents={}, license_consents={})
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as err:
+        raise RuntimeError(
+            f"Dataset consent store at {path} is unreadable: {err}"
+        ) from err
+    if not isinstance(raw, dict):
+        raise RuntimeError(f"Dataset consent store at {path} must be a JSON object.")
+
+    schema_version = raw.get("schema_version")
+    if schema_version is not None and schema_version != _CONSENT_SCHEMA_VERSION:
+        raise RuntimeError(
+            "Dataset consent store schema mismatch. "
+            f"Expected {_CONSENT_SCHEMA_VERSION}, got {schema_version!r}."
+        )
+    policy_consents = raw.get("policy_consents", {})
+    license_consents = raw.get("license_consents", {})
+    if not isinstance(policy_consents, dict):
+        policy_consents = {}
+    if not isinstance(license_consents, dict):
+        license_consents = {}
+    return PersistedDatasetConsents(
+        policy_consents={str(k): str(v) for k, v in policy_consents.items()},
+        license_consents={str(k): str(v) for k, v in license_consents.items()},
+    )
+
+
+def persist_dataset_consents(
+    *,
+    settings: AppConfig,
+    accept_policy_ids: list[str] | None = None,
+    accept_license_ids: list[str] | None = None,
+    source: str,
+) -> None:
+    """Persist dataset policy/license acknowledgements locally."""
+
+    accept_policy_ids = accept_policy_ids or []
+    accept_license_ids = accept_license_ids or []
+    existing = load_persisted_dataset_consents(settings=settings)
+    policy_consents = dict(existing.policy_consents)
+    license_consents = dict(existing.license_consents)
+
+    for policy_id in accept_policy_ids:
+        normalized = policy_id.strip().lower()
+        if normalized:
+            policy_consents[normalized] = source
+    for license_id in accept_license_ids:
+        normalized = license_id.strip().lower()
+        if normalized:
+            license_consents[normalized] = source
+
+    path = _consents_path(settings)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema_version": _CONSENT_SCHEMA_VERSION,
+        "policy_consents": dict(sorted(policy_consents.items())),
+        "license_consents": dict(sorted(license_consents.items())),
+    }
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    serialized = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    try:
+        with tmp_path.open("w", encoding="utf-8") as handle:
+            handle.write(serialized)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_path, path)
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink(missing_ok=True)
+
+
+def compute_missing_dataset_consents(
+    *,
+    settings: AppConfig,
+    utterances: list[Utterance],
+) -> tuple[set[str], set[str]]:
+    """Returns missing (policy_ids, license_ids) needed for training."""
+
+    persisted = load_persisted_dataset_consents(settings=settings)
+    required_policies: set[str] = set()
+    required_licenses: set[str] = set()
+    for utterance in utterances:
+        policy_id = (utterance.dataset_policy_id or "").strip().lower()
+        if not policy_id:
+            continue
+        if not is_policy_restricted(policy_id):
+            continue
+        required_policies.add(policy_id)
+        license_id = (utterance.dataset_license_id or "").strip().lower()
+        if license_id:
+            required_licenses.add(license_id)
+
+    missing_policies = required_policies - set(persisted.policy_consents)
+    missing_licenses = required_licenses - set(persisted.license_consents)
+    return missing_policies, missing_licenses
+
+
+def ensure_dataset_consents(
+    *, settings: AppConfig, utterances: list[Utterance]
+) -> None:
+    """Raises if the training set requires policy/license acknowledgements."""
+
+    missing_policies, missing_licenses = compute_missing_dataset_consents(
+        settings=settings,
+        utterances=utterances,
+    )
+    if not missing_policies and not missing_licenses:
+        return
+
+    parts: list[str] = [
+        "Missing dataset acknowledgements.",
+        "To proceed, persist consent(s) locally via:",
+    ]
+    if missing_policies:
+        parts.append(
+            "  ser configure --accept-dataset-policy "
+            + " ".join(sorted(missing_policies))
+            + " --persist"
+        )
+    if missing_licenses:
+        parts.append(
+            "  ser configure --accept-dataset-license "
+            + " ".join(sorted(missing_licenses))
+            + " --persist"
+        )
+    raise DatasetConsentError("\n".join(parts))

--- a/ser/data/dataset_prepare.py
+++ b/ser/data/dataset_prepare.py
@@ -1,0 +1,304 @@
+"""Dataset download/prepare helpers.
+
+This module provides:
+  - Best-effort dataset download/install commands.
+  - Manifest building (JSONL) for supported corpora.
+  - Registry updates so training can auto-discover manifests.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+from ser.config import AppConfig
+from ser.data.adapters.biic_podcast import build_biic_podcast_manifest_jsonl
+from ser.data.adapters.crema_d import build_crema_d_manifest_jsonl
+from ser.data.adapters.msp_podcast import build_msp_podcast_manifest_jsonl
+from ser.data.adapters.ravdess import build_ravdess_manifest_jsonl
+from ser.data.dataset_registry import (
+    DatasetRegistryEntry,
+    upsert_dataset_registry_entry,
+)
+from ser.data.ontology import LabelOntology
+from ser.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class DatasetDescriptor:
+    """Static metadata for a supported dataset."""
+
+    dataset_id: str
+    display_name: str
+    policy_id: str
+    license_id: str
+    source_url: str
+    requires_manual_download: bool
+
+
+SUPPORTED_DATASETS: dict[str, DatasetDescriptor] = {
+    "ravdess": DatasetDescriptor(
+        dataset_id="ravdess",
+        display_name="RAVDESS",
+        policy_id="noncommercial",
+        license_id="cc-by-nc-sa-4.0",
+        source_url="https://zenodo.org/records/1188976",
+        requires_manual_download=True,
+    ),
+    "crema-d": DatasetDescriptor(
+        dataset_id="crema-d",
+        display_name="CREMA-D",
+        policy_id="share_alike",
+        license_id="odbl-1.0",
+        source_url="https://github.com/CheyneyComputerScience/CREMA-D",
+        requires_manual_download=False,
+    ),
+    "msp-podcast": DatasetDescriptor(
+        dataset_id="msp-podcast",
+        display_name="MSP-Podcast",
+        policy_id="academic_only",
+        license_id="msp-academic-license",
+        source_url="https://lab-msp.com/MSP/MSP-Podcast.html",
+        requires_manual_download=True,
+    ),
+    "biic-podcast": DatasetDescriptor(
+        dataset_id="biic-podcast",
+        display_name="BIIC-Podcast",
+        policy_id="academic_only",
+        license_id="biic-academic-license",
+        source_url="https://biic.ee.nthu.edu.tw/",
+        requires_manual_download=True,
+    ),
+}
+
+
+def resolve_dataset_descriptor(dataset_id: str) -> DatasetDescriptor:
+    """Resolves a supported dataset descriptor."""
+
+    normalized = dataset_id.strip().lower()
+    if not normalized or normalized not in SUPPORTED_DATASETS:
+        raise ValueError(
+            f"Unsupported dataset {dataset_id!r}. Supported: {', '.join(sorted(SUPPORTED_DATASETS))}."
+        )
+    return SUPPORTED_DATASETS[normalized]
+
+
+def default_dataset_root(settings: AppConfig, dataset_id: str) -> Path:
+    """Default dataset directory under the SER data root."""
+
+    resolved = resolve_dataset_descriptor(dataset_id)
+    return settings.models.folder.parent / "datasets" / resolved.dataset_id
+
+
+def default_manifest_path(settings: AppConfig, dataset_id: str) -> Path:
+    """Default manifest path under the SER data root."""
+
+    resolved = resolve_dataset_descriptor(dataset_id)
+    return settings.models.folder.parent / "manifests" / f"{resolved.dataset_id}.jsonl"
+
+
+def download_dataset(
+    *,
+    settings: AppConfig,
+    dataset_id: str,
+    dataset_root: Path,
+) -> None:
+    """Best-effort dataset download.
+
+    Some corpora require manual access requests; this function will not bypass
+    those requirements.
+    """
+
+    descriptor = resolve_dataset_descriptor(dataset_id)
+    dataset_root.mkdir(parents=True, exist_ok=True)
+
+    if descriptor.dataset_id == "crema-d":
+        if any(dataset_root.iterdir()):
+            logger.info("CREMA-D target directory is not empty; skipping download.")
+            return
+        git_bin = shutil.which("git")
+        if git_bin is None:
+            raise RuntimeError(
+                "git is required to download CREMA-D (git-lfs recommended)."
+            )
+        logger.info("Cloning CREMA-D into %s", dataset_root)
+        subprocess.run(
+            [
+                git_bin,
+                "clone",
+                "--depth",
+                "1",
+                descriptor.source_url,
+                str(dataset_root),
+            ],
+            check=True,
+        )
+        git_lfs = shutil.which("git-lfs")
+        if git_lfs is not None:
+            logger.info("Running git-lfs pull for CREMA-D")
+            subprocess.run([git_lfs, "pull"], check=False, cwd=str(dataset_root))
+        return
+
+    instructions = [
+        f"Dataset {descriptor.display_name} requires manual access/download.",
+        f"Source: {descriptor.source_url}",
+        f"Expected install directory: {dataset_root}",
+    ]
+    if descriptor.dataset_id == "msp-podcast":
+        instructions.append(
+            "MSP-Podcast is distributed under an academic access agreement. "
+            "Follow the instructions on the MSP site to request and download the corpus."
+        )
+    if descriptor.dataset_id == "biic-podcast":
+        instructions.append(
+            "BIIC-Podcast access is typically granted by request (often academic-only). "
+            "Obtain the corpus from the BIIC group and place it under the install directory."
+        )
+    logger.warning("\n".join(instructions))
+
+
+def prepare_dataset_manifest(
+    *,
+    settings: AppConfig,
+    dataset_id: str,
+    dataset_root: Path,
+    ontology: LabelOntology,
+    manifest_path: Path,
+    labels_csv_path: Path | None = None,
+    audio_base_dir: Path | None = None,
+    default_language: str | None = None,
+) -> list[Path]:
+    """Builds a dataset manifest and updates the registry.
+
+    Returns:
+        A list of manifest paths written.
+    """
+
+    descriptor = resolve_dataset_descriptor(dataset_id)
+    language = default_language or settings.default_language
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+
+    options: dict[str, str] = {}
+    if labels_csv_path is not None:
+        options["labels_csv_path"] = str(labels_csv_path)
+    if audio_base_dir is not None:
+        options["audio_base_dir"] = str(audio_base_dir)
+    if default_language is not None:
+        options["default_language"] = default_language
+
+    built: list[Path] = []
+    if descriptor.dataset_id == "ravdess":
+        utterances = build_ravdess_manifest_jsonl(
+            dataset_root=dataset_root,
+            dataset_glob_pattern=str(
+                dataset_root
+                / settings.dataset.subfolder_prefix
+                / settings.dataset.extension
+            ),
+            emotion_code_map=dict(settings.emotions),
+            default_language=language,
+            ontology=ontology,
+            max_failed_file_ratio=settings.data_loader.max_failed_file_ratio,
+            output_path=manifest_path,
+        )
+        if utterances is None:
+            return []
+        built.append(manifest_path)
+    elif descriptor.dataset_id == "crema-d":
+        crema_map = {
+            "ANG": "angry",
+            "DIS": "disgust",
+            "FEA": "fearful",
+            "HAP": "happy",
+            "NEU": "neutral",
+            "SAD": "sad",
+        }
+        pattern = (
+            "AudioWAV/**/*.wav" if (dataset_root / "AudioWAV").exists() else "**/*.wav"
+        )
+        utterances = build_crema_d_manifest_jsonl(
+            dataset_root=dataset_root,
+            dataset_glob_pattern=pattern,
+            emotion_code_map=crema_map,
+            default_language=language,
+            ontology=ontology,
+            max_failed_file_ratio=settings.data_loader.max_failed_file_ratio,
+            output_path=manifest_path,
+        )
+        if utterances is None:
+            return []
+        built.append(manifest_path)
+    elif descriptor.dataset_id == "msp-podcast":
+        if labels_csv_path is None:
+            raise ValueError(
+                "MSP-Podcast manifest build requires --labels-csv-path pointing to labels_consensus.csv."
+            )
+        utterances = build_msp_podcast_manifest_jsonl(
+            dataset_root=dataset_root,
+            labels_csv_path=labels_csv_path,
+            audio_base_dir=audio_base_dir,
+            ontology=ontology,
+            default_language=language,
+            max_failed_file_ratio=settings.data_loader.max_failed_file_ratio,
+            output_path=manifest_path,
+        )
+        if utterances is None:
+            return []
+        built.append(manifest_path)
+    elif descriptor.dataset_id == "biic-podcast":
+        if labels_csv_path is None:
+            raise ValueError(
+                "BIIC-Podcast manifest build requires --labels-csv-path for the corpus label index."
+            )
+        utterances = build_biic_podcast_manifest_jsonl(
+            dataset_root=dataset_root,
+            labels_csv_path=labels_csv_path,
+            audio_base_dir=audio_base_dir,
+            ontology=ontology,
+            default_language=language,
+            max_failed_file_ratio=settings.data_loader.max_failed_file_ratio,
+            output_path=manifest_path,
+        )
+        if utterances is None:
+            return []
+        built.append(manifest_path)
+    else:
+        raise ValueError(f"Unsupported dataset {descriptor.dataset_id!r}.")
+
+    upsert_dataset_registry_entry(
+        settings=settings,
+        dataset_id=descriptor.dataset_id,
+        dataset_root=dataset_root,
+        manifest_path=manifest_path,
+        options=options,
+    )
+    return built
+
+
+def prepare_from_registry_entry(
+    *,
+    settings: AppConfig,
+    entry: DatasetRegistryEntry,
+    ontology: LabelOntology,
+) -> list[Path]:
+    """Ensures a registered dataset has a manifest on disk."""
+
+    if entry.manifest_path.is_file():
+        return [entry.manifest_path]
+    labels_csv = entry.options.get("labels_csv_path")
+    audio_base = entry.options.get("audio_base_dir")
+    default_language = entry.options.get("default_language")
+    return prepare_dataset_manifest(
+        settings=settings,
+        dataset_id=entry.dataset_id,
+        dataset_root=entry.dataset_root,
+        ontology=ontology,
+        manifest_path=entry.manifest_path,
+        labels_csv_path=Path(labels_csv).expanduser() if labels_csv else None,
+        audio_base_dir=Path(audio_base).expanduser() if audio_base else None,
+        default_language=default_language,
+    )

--- a/ser/data/dataset_registry.py
+++ b/ser/data/dataset_registry.py
@@ -1,0 +1,106 @@
+"""Local dataset registry.
+
+The registry is a simple JSON file that maps dataset ids to:
+  - dataset_root (where audio/labels live)
+  - manifest_path (where the JSONL manifest is/will be written)
+  - options (dataset-specific metadata needed to rebuild manifests)
+
+The goal is to make training discover manifests automatically without requiring
+manual `build-manifest` invocations.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+from ser.config import AppConfig
+
+
+@dataclass(frozen=True)
+class DatasetRegistryEntry:
+    dataset_id: str
+    dataset_root: Path
+    manifest_path: Path
+    options: dict[str, str]
+
+
+def _registry_path(settings: AppConfig) -> Path:
+    data_root = settings.models.folder.parent
+    return data_root / ".ser" / "dataset_registry.json"
+
+
+def load_dataset_registry(*, settings: AppConfig) -> dict[str, DatasetRegistryEntry]:
+    path = _registry_path(settings)
+    if not path.is_file():
+        return {}
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        return {}
+    registry: dict[str, DatasetRegistryEntry] = {}
+    for dataset_id, payload in raw.items():
+        if not isinstance(payload, dict):
+            continue
+        dataset_root = Path(str(payload.get("dataset_root", ""))).expanduser()
+        manifest_path = Path(str(payload.get("manifest_path", ""))).expanduser()
+        options = payload.get("options", {})
+        if not isinstance(options, dict):
+            options = {}
+        registry[str(dataset_id)] = DatasetRegistryEntry(
+            dataset_id=str(dataset_id),
+            dataset_root=dataset_root,
+            manifest_path=manifest_path,
+            options={str(k): str(v) for k, v in options.items()},
+        )
+    return registry
+
+
+def save_dataset_registry(
+    *, settings: AppConfig, registry: dict[str, DatasetRegistryEntry]
+) -> None:
+    path = _registry_path(settings)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload: dict[str, object] = {
+        dataset_id: {
+            "dataset_root": str(entry.dataset_root),
+            "manifest_path": str(entry.manifest_path),
+            "options": dict(entry.options),
+        }
+        for dataset_id, entry in registry.items()
+    }
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    tmp_path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    os.replace(tmp_path, path)
+
+
+def upsert_dataset_registry_entry(
+    *,
+    settings: AppConfig,
+    dataset_id: str,
+    dataset_root: Path,
+    manifest_path: Path,
+    options: dict[str, str] | None = None,
+) -> None:
+    registry = load_dataset_registry(settings=settings)
+    normalized = dataset_id.strip().lower()
+    registry[normalized] = DatasetRegistryEntry(
+        dataset_id=normalized,
+        dataset_root=dataset_root.expanduser(),
+        manifest_path=manifest_path.expanduser(),
+        options=dict(options or {}),
+    )
+    save_dataset_registry(settings=settings, registry=registry)
+
+
+def registered_manifest_paths(*, settings: AppConfig) -> tuple[Path, ...]:
+    registry = load_dataset_registry(settings=settings)
+    manifests = [
+        entry.manifest_path
+        for entry in registry.values()
+        if entry.manifest_path.is_file()
+    ]
+    return tuple(sorted(set(manifests)))

--- a/ser/profile_defs.yaml
+++ b/ser/profile_defs.yaml
@@ -49,6 +49,8 @@ profiles:
     model:
       env_var: SER_MEDIUM_MODEL_ID
       default_model_id: facebook/wav2vec2-xls-r-300m
+    feature_runtime_defaults:
+      torch_dtype: float32
     transcription_defaults:
       backend_id: stable_whisper
       model_name: turbo

--- a/ser/repr/runtime_policy.py
+++ b/ser/repr/runtime_policy.py
@@ -1,0 +1,179 @@
+"""Backend-aware runtime policy resolution for emotion feature extractors."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from ser.utils.torch_inference import TorchRuntime, maybe_resolve_torch_runtime
+
+type FeatureBackendId = Literal["handcrafted", "hf_xlsr", "hf_whisper", "emotion2vec"]
+
+_KNOWN_BACKEND_IDS: frozenset[str] = frozenset(
+    {"handcrafted", "hf_xlsr", "hf_whisper", "emotion2vec"}
+)
+_KNOWN_DTYPE_SELECTORS: frozenset[str] = frozenset(
+    {"auto", "float16", "float32", "bfloat16"}
+)
+
+
+@dataclass(frozen=True)
+class FeatureRuntimePolicy:
+    """Resolved runtime selectors for one feature-backend invocation."""
+
+    device: str
+    dtype: str
+    reason: str
+
+
+def resolve_feature_runtime_policy(
+    *,
+    backend_id: str,
+    requested_device: str,
+    requested_dtype: str,
+    backend_override_device: str | None = None,
+    backend_override_dtype: str | None = None,
+) -> FeatureRuntimePolicy:
+    """Resolves backend-safe runtime selectors for feature extraction.
+
+    The resolver applies backend capabilities first, then caller intent.
+    """
+    normalized_backend = backend_id.strip().lower()
+    normalized_device = _normalize_optional_device_selector(
+        backend_override_device
+    ) or _normalize_device_selector(requested_device)
+    normalized_dtype = _normalize_optional_dtype_selector(
+        backend_override_dtype
+    ) or _normalize_dtype_selector(requested_dtype)
+
+    if normalized_backend not in _KNOWN_BACKEND_IDS:
+        return FeatureRuntimePolicy(
+            device=normalized_device,
+            dtype=normalized_dtype,
+            reason="unknown_backend_passthrough",
+        )
+
+    if normalized_backend == "handcrafted":
+        return FeatureRuntimePolicy(
+            device="cpu",
+            dtype="float32",
+            reason="handcrafted_cpu_only",
+        )
+
+    if normalized_backend == "emotion2vec":
+        return _resolve_emotion2vec_policy(
+            requested_device=normalized_device,
+            requested_dtype=normalized_dtype,
+        )
+
+    if normalized_backend == "hf_xlsr":
+        return _resolve_xlsr_policy(
+            requested_device=normalized_device,
+            requested_dtype=normalized_dtype,
+        )
+
+    return FeatureRuntimePolicy(
+        device=normalized_device,
+        dtype=normalized_dtype,
+        reason="torch_backend_requested_selectors",
+    )
+
+
+def _resolve_xlsr_policy(
+    *,
+    requested_device: str,
+    requested_dtype: str,
+) -> FeatureRuntimePolicy:
+    """Resolves safe runtime selectors for XLS-R feature extraction."""
+    runtime = _probe_runtime(requested_device)
+    if runtime is None:
+        return FeatureRuntimePolicy(
+            device="cpu",
+            dtype="float32",
+            reason="torch_runtime_unavailable",
+        )
+    if runtime.device_type == "mps":
+        return FeatureRuntimePolicy(
+            device="cpu",
+            dtype="float32",
+            reason="hf_xlsr_mps_stability_guard",
+        )
+    return FeatureRuntimePolicy(
+        device=requested_device,
+        dtype=requested_dtype,
+        reason="hf_xlsr_requested_selectors",
+    )
+
+
+def _resolve_emotion2vec_policy(
+    *,
+    requested_device: str,
+    requested_dtype: str,
+) -> FeatureRuntimePolicy:
+    """Resolves runtime selectors for Emotion2Vec/FunASR backend."""
+    runtime = _probe_runtime(requested_device)
+    if runtime is None:
+        return FeatureRuntimePolicy(
+            device="cpu",
+            dtype="float32",
+            reason="torch_runtime_unavailable",
+        )
+    if runtime.device_type == "cuda":
+        return FeatureRuntimePolicy(
+            device=runtime.device_spec,
+            dtype=requested_dtype,
+            reason="emotion2vec_cuda_enabled",
+        )
+    return FeatureRuntimePolicy(
+        device="cpu",
+        dtype="float32",
+        reason="emotion2vec_cpu_default",
+    )
+
+
+def _probe_runtime(requested_device: str) -> TorchRuntime | None:
+    """Best-effort runtime probe for one device selector."""
+    try:
+        return maybe_resolve_torch_runtime(device=requested_device, dtype="float32")
+    except RuntimeError:
+        return None
+
+
+def _normalize_device_selector(value: str) -> str:
+    """Normalizes one runtime device selector."""
+    normalized = value.strip().lower()
+    if normalized in {"auto", "cpu", "mps", "cuda"}:
+        return normalized
+    if normalized.startswith("cuda:"):
+        return normalized
+    return "auto"
+
+
+def _normalize_dtype_selector(value: str) -> str:
+    """Normalizes one runtime dtype selector."""
+    normalized = value.strip().lower()
+    if normalized in _KNOWN_DTYPE_SELECTORS:
+        return normalized
+    return "auto"
+
+
+def _normalize_optional_device_selector(value: str | None) -> str | None:
+    """Normalizes an optional runtime device selector override."""
+    if not isinstance(value, str) or not value.strip():
+        return None
+    normalized = value.strip().lower()
+    if normalized in {"auto", "cpu", "mps", "cuda"}:
+        return normalized
+    if normalized.startswith("cuda:"):
+        return normalized
+    return None
+
+
+def _normalize_optional_dtype_selector(value: str | None) -> str | None:
+    """Normalizes an optional runtime dtype selector override."""
+    if not isinstance(value, str) or not value.strip():
+        return None
+    normalized = value.strip().lower()
+    if normalized in _KNOWN_DTYPE_SELECTORS:
+        return normalized
+    return None

--- a/ser/runtime/accurate_research_inference.py
+++ b/ser/runtime/accurate_research_inference.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from ser.config import AppConfig
 from ser.models.emotion_model import LoadedModel, resolve_accurate_research_model_id
 from ser.repr import Emotion2VecBackend, FeatureBackend
+from ser.repr.runtime_policy import resolve_feature_runtime_policy
 from ser.runtime.accurate_inference import run_accurate_inference
 from ser.runtime.contracts import InferenceRequest
 from ser.runtime.schema import InferenceResult
@@ -21,15 +22,27 @@ def run_accurate_research_inference(
 ) -> InferenceResult:
     """Runs accurate-research inference with emotion2vec metadata compatibility checks."""
     accurate_research_model_id = resolve_accurate_research_model_id(settings)
-    active_backend: FeatureBackend = (
-        backend
-        if backend is not None
-        else Emotion2VecBackend(
+    if backend is not None:
+        active_backend: FeatureBackend = backend
+    else:
+        backend_override = settings.feature_runtime_policy.for_backend("emotion2vec")
+        runtime_policy = resolve_feature_runtime_policy(
+            backend_id="emotion2vec",
+            requested_device=settings.torch_runtime.device,
+            requested_dtype=settings.torch_runtime.dtype,
+            backend_override_device=(
+                backend_override.device if backend_override is not None else None
+            ),
+            backend_override_dtype=(
+                backend_override.dtype if backend_override is not None else None
+            ),
+        )
+        active_backend = Emotion2VecBackend(
             model_id=accurate_research_model_id,
+            device=runtime_policy.device,
             modelscope_cache_root=settings.models.modelscope_cache_root,
             huggingface_cache_root=settings.models.huggingface_cache_root,
         )
-    )
     return run_accurate_inference(
         request=request,
         settings=settings,

--- a/ser/runtime/contracts.py
+++ b/ser/runtime/contracts.py
@@ -17,6 +17,7 @@ class InferenceRequest:
     file_path: str
     language: str
     save_transcript: bool = False
+    include_transcript: bool = True
 
 
 @dataclass(frozen=True)

--- a/ser/runtime/pipeline.py
+++ b/ser/runtime/pipeline.py
@@ -144,10 +144,12 @@ class RuntimePipeline:
         else:
             emotions = self.predict_emotions(request.file_path)
 
-        _release_torch_runtime_memory_before_transcription()
-        transcript: list[TranscriptWord] = self.extract_transcript(
-            request.file_path, request.language
-        )
+        transcript: list[TranscriptWord]
+        if request.include_transcript:
+            _release_torch_runtime_memory_before_transcription()
+            transcript = self.extract_transcript(request.file_path, request.language)
+        else:
+            transcript = []
 
         timeline_build_started_at = log_phase_started(
             logger,

--- a/ser/train/__init__.py
+++ b/ser/train/__init__.py
@@ -6,10 +6,11 @@ from .eval import (
     grouped_train_test_split,
     speaker_independent_cv,
 )
-from .metrics import compute_ser_metrics
+from .metrics import compute_grouped_ser_metrics_by_sample, compute_ser_metrics
 
 __all__ = [
     "GroupedSplit",
+    "compute_grouped_ser_metrics_by_sample",
     "compute_ser_metrics",
     "extract_ravdess_speaker_id",
     "grouped_train_test_split",

--- a/ser/train/metrics.py
+++ b/ser/train/metrics.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from typing import Any
 
 from sklearn.metrics import confusion_matrix, f1_score, recall_score
 
@@ -71,4 +72,93 @@ def compute_ser_metrics(
         "macro_f1": macro_f1,
         "per_class_recall": per_class_recall,
         "confusion_matrix": confusion.tolist(),
+    }
+
+
+def compute_grouped_ser_metrics_by_sample(
+    *,
+    y_true: Sequence[str],
+    y_pred: Sequence[str],
+    sample_ids: Sequence[str],
+    group_ids: Sequence[str],
+    min_support: int,
+) -> dict[str, Any]:
+    """Compute group metrics with minimum support, aggregated per sample.
+
+    The inputs are window-level predictions/labels. The function aggregates
+    per-sample via majority vote on ``sample_ids``, then computes SER metrics
+    per group id (e.g., corpus or language).
+    """
+
+    if not (len(y_true) == len(y_pred) == len(sample_ids) == len(group_ids)):
+        raise ValueError("y_true/y_pred/sample_ids/group_ids must have equal length")
+    if min_support < 1:
+        raise ValueError("min_support must be >= 1")
+    if not y_true:
+        return {
+            "unit": "samples",
+            "min_support": min_support,
+            "included": {},
+            "excluded": {},
+        }
+
+    per_sample_true: dict[str, list[str]] = {}
+    per_sample_pred: dict[str, list[str]] = {}
+    per_sample_group: dict[str, list[str]] = {}
+    for true_label, pred_label, sample_id, group_id in zip(
+        y_true,
+        y_pred,
+        sample_ids,
+        group_ids,
+        strict=True,
+    ):
+        per_sample_true.setdefault(str(sample_id), []).append(str(true_label))
+        per_sample_pred.setdefault(str(sample_id), []).append(str(pred_label))
+        per_sample_group.setdefault(str(sample_id), []).append(str(group_id))
+
+    def _mode(values: list[str]) -> str:
+        counts: dict[str, int] = {}
+        for value in values:
+            counts[value] = counts.get(value, 0) + 1
+        # Deterministic tie-break.
+        return sorted(counts.items(), key=lambda item: (-item[1], item[0]))[0][0]
+
+    sample_true: list[str] = []
+    sample_pred: list[str] = []
+    sample_group: list[str] = []
+    for sample_id in sorted(per_sample_true):
+        sample_true.append(_mode(per_sample_true[sample_id]))
+        sample_pred.append(_mode(per_sample_pred[sample_id]))
+        sample_group.append(_mode(per_sample_group[sample_id]))
+
+    grouped_true: dict[str, list[str]] = {}
+    grouped_pred: dict[str, list[str]] = {}
+    for true_label, pred_label, group_id in zip(
+        sample_true,
+        sample_pred,
+        sample_group,
+        strict=True,
+    ):
+        grouped_true.setdefault(group_id, []).append(true_label)
+        grouped_pred.setdefault(group_id, []).append(pred_label)
+
+    included: dict[str, Any] = {}
+    excluded: dict[str, Any] = {}
+    for group_id in sorted(grouped_true):
+        support = len(grouped_true[group_id])
+        if support < min_support:
+            excluded[group_id] = {"support": support}
+            continue
+        included[group_id] = {
+            "support": support,
+            "metrics": compute_ser_metrics(
+                y_true=grouped_true[group_id],
+                y_pred=grouped_pred[group_id],
+            ),
+        }
+    return {
+        "unit": "samples",
+        "min_support": min_support,
+        "included": included,
+        "excluded": excluded,
     }

--- a/ser/transcript/transcript_extractor.py
+++ b/ser/transcript/transcript_extractor.py
@@ -410,10 +410,9 @@ def _run_faster_whisper_process_isolated(
         raise
     finally:
         parent_conn.close()
+        process.join(timeout=_TERMINATE_GRACE_SECONDS)
         if process.is_alive():
             _terminate_worker_process(process)
-        else:
-            process.join(timeout=_TERMINATE_GRACE_SECONDS)
         process.close()
 
 

--- a/ser/utils/__init__.py
+++ b/ser/utils/__init__.py
@@ -13,7 +13,12 @@ if TYPE_CHECKING:
     from ser.domain import EmotionSegment, TimelineEntry, TranscriptWord
 
 
-def read_audio_file(file_path: str) -> tuple[np.ndarray, int]:
+def read_audio_file(
+    file_path: str,
+    *,
+    start_seconds: float | None = None,
+    duration_seconds: float | None = None,
+) -> tuple[np.ndarray, int]:
     """Reads and normalizes an audio file.
 
     Args:
@@ -24,7 +29,11 @@ def read_audio_file(file_path: str) -> tuple[np.ndarray, int]:
     """
     from .audio_utils import read_audio_file as _read_audio_file
 
-    return _read_audio_file(file_path)
+    return _read_audio_file(
+        file_path,
+        start_seconds=start_seconds,
+        duration_seconds=duration_seconds,
+    )
 
 
 def build_timeline(

--- a/tests/test_audio_utils.py
+++ b/tests/test_audio_utils.py
@@ -78,3 +78,54 @@ def test_read_audio_file_uses_soundfile_fallback(
 
     assert sample_rate == 16000
     assert audio.tolist() == pytest.approx([0.5, 1.0])
+
+
+def test_read_audio_file_rejects_invalid_segment_bounds(tmp_path: Path) -> None:
+    """Segment arguments should be validated before decode attempts."""
+    audio_path = tmp_path / "sample.wav"
+    audio_path.write_bytes(b"fake-audio")
+
+    with pytest.raises(ValueError, match="start_seconds"):
+        au.read_audio_file(str(audio_path), start_seconds=-0.1)
+    with pytest.raises(ValueError, match="duration_seconds"):
+        au.read_audio_file(str(audio_path), duration_seconds=0.0)
+
+
+def test_read_audio_file_segment_uses_librosa_offset_duration(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Segment reads should pass offset/duration to librosa."""
+    audio_path = tmp_path / "sample.wav"
+    audio_path.write_bytes(b"fake-audio")
+    captured: dict[str, object] = {}
+
+    def _fake_librosa_load(
+        path: str, *, sr: None, offset: float, duration: float
+    ) -> tuple[np.ndarray, int]:
+        captured["path"] = path
+        captured["sr"] = sr
+        captured["offset"] = offset
+        captured["duration"] = duration
+        return np.asarray([0.2, 0.4], dtype=np.float32), 22050
+
+    monkeypatch.setattr(au.librosa, "load", _fake_librosa_load)
+    monkeypatch.setattr(
+        au,
+        "get_settings",
+        lambda: SimpleNamespace(
+            audio_read=SimpleNamespace(max_retries=1, retry_delay_seconds=0.0)
+        ),
+    )
+
+    audio, sample_rate = au.read_audio_file(
+        str(audio_path),
+        start_seconds=1.5,
+        duration_seconds=0.75,
+    )
+
+    assert sample_rate == 22050
+    assert audio.tolist() == pytest.approx([0.5, 1.0])
+    assert captured["path"] == str(audio_path)
+    assert captured["sr"] is None
+    assert captured["offset"] == pytest.approx(1.5)
+    assert captured["duration"] == pytest.approx(0.75)

--- a/tests/test_config_feature_flags.py
+++ b/tests/test_config_feature_flags.py
@@ -76,6 +76,11 @@ def test_runtime_flags_and_schema_defaults() -> None:
     assert settings.torch_runtime.device == "auto"
     assert settings.torch_runtime.dtype == "auto"
     assert settings.torch_runtime.enable_mps_fallback is False
+    xlsr_override = settings.feature_runtime_policy.for_backend("hf_xlsr")
+    assert xlsr_override is not None
+    assert xlsr_override.device is None
+    assert xlsr_override.dtype == "float32"
+    assert settings.feature_runtime_policy.for_backend("hf_whisper") is None
     assert os.getenv("PYTORCH_ENABLE_MPS_FALLBACK") == "0"
     assert settings.models.medium_model_id == "facebook/wav2vec2-xls-r-300m"
     assert settings.models.accurate_model_id == "openai/whisper-large-v3"
@@ -244,6 +249,11 @@ def test_runtime_flags_and_schema_env_overrides(
     assert settings.torch_runtime.device == "cuda:0"
     assert settings.torch_runtime.dtype == "bfloat16"
     assert settings.torch_runtime.enable_mps_fallback is True
+    xlsr_override = settings.feature_runtime_policy.for_backend("hf_xlsr")
+    assert xlsr_override is not None
+    assert xlsr_override.device is None
+    assert xlsr_override.dtype == "float32"
+    assert settings.feature_runtime_policy.for_backend("hf_whisper") is None
     assert os.getenv("PYTORCH_ENABLE_MPS_FALLBACK") == "1"
     assert settings.dataset.manifest_paths == (
         Path("unit-test/manifest_a.jsonl"),

--- a/tests/test_data_cli.py
+++ b/tests/test_data_cli.py
@@ -1,0 +1,131 @@
+"""Tests for dataset CLI helper commands."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+
+from ser.config import AppConfig
+from ser.data import cli as data_cli
+from ser.data.dataset_consents import PersistedDatasetConsents
+from ser.data.dataset_prepare import DatasetDescriptor
+
+
+def _settings(tmp_path: Path) -> AppConfig:
+    return cast(
+        AppConfig,
+        SimpleNamespace(
+            models=SimpleNamespace(folder=tmp_path / "data" / "models"),
+            default_language="en",
+        ),
+    )
+
+
+def test_run_configure_command_show(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    """Configure --show should print persisted dataset consents."""
+    monkeypatch.setattr(data_cli, "get_settings", lambda: _settings(tmp_path))
+    monkeypatch.setattr(
+        data_cli,
+        "load_persisted_dataset_consents",
+        lambda settings: PersistedDatasetConsents(
+            policy_consents={"academic_only": "unit_test"},
+            license_consents={"msp-academic-license": "unit_test"},
+        ),
+    )
+
+    code = data_cli.run_configure_command(["--show"])
+
+    captured = capsys.readouterr()
+    assert code == 0
+    assert "academic_only" in captured.out
+    assert "msp-academic-license" in captured.out
+
+
+def test_run_configure_command_requires_persist(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Mutating configure commands should require --persist."""
+    monkeypatch.setattr(data_cli, "get_settings", lambda: _settings(tmp_path))
+
+    code = data_cli.run_configure_command(["--accept-dataset-policy", "academic_only"])
+
+    assert code == 2
+
+
+def test_run_data_download_command_prepares_manifest(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    """Data download command should resolve descriptor and invoke manifest preparation."""
+    settings = _settings(tmp_path)
+    descriptor = DatasetDescriptor(
+        dataset_id="ravdess",
+        display_name="RAVDESS",
+        policy_id="noncommercial",
+        license_id="cc-by-nc-sa-4.0",
+        source_url="https://example.invalid/ravdess",
+        requires_manual_download=True,
+    )
+    captured: dict[str, object] = {}
+    manifest_path = tmp_path / "manifests" / "ravdess.jsonl"
+
+    monkeypatch.setattr(data_cli, "get_settings", lambda: settings)
+    monkeypatch.setattr(
+        data_cli,
+        "resolve_dataset_descriptor",
+        lambda dataset_id: descriptor,
+    )
+    monkeypatch.setattr(
+        data_cli,
+        "_ensure_descriptor_consents",
+        lambda **kwargs: captured.__setitem__("consent_kwargs", kwargs),
+    )
+    monkeypatch.setattr(
+        data_cli,
+        "_resolve_label_ontology",
+        lambda _settings: "ontology-stub",
+    )
+
+    def _capture_prepare_kwargs(**kwargs: object) -> list[Path]:
+        captured["prepare_kwargs"] = kwargs
+        return [manifest_path]
+
+    monkeypatch.setattr(
+        data_cli,
+        "prepare_dataset_manifest",
+        _capture_prepare_kwargs,
+    )
+    monkeypatch.setattr(
+        data_cli,
+        "download_dataset",
+        lambda **kwargs: captured.__setitem__("download_kwargs", kwargs),
+    )
+
+    code = data_cli.run_data_command(
+        ["download", "--dataset", "ravdess", "--accept-license"]
+    )
+
+    output = capsys.readouterr().out
+    assert code == 0
+    assert "Wrote manifest(s):" in output
+    consent_kwargs = captured["consent_kwargs"]
+    assert isinstance(consent_kwargs, dict)
+    assert consent_kwargs["dataset_id"] == "ravdess"
+    assert consent_kwargs["accept_license_flag"] is True
+    prepare_kwargs = captured["prepare_kwargs"]
+    assert isinstance(prepare_kwargs, dict)
+    assert prepare_kwargs["dataset_id"] == "ravdess"
+    assert prepare_kwargs["ontology"] == "ontology-stub"
+    assert (
+        prepare_kwargs["manifest_path"]
+        == settings.models.folder.parent / "manifests" / "ravdess.jsonl"
+    )

--- a/tests/test_dataset_adapters_biic_podcast.py
+++ b/tests/test_dataset_adapters_biic_podcast.py
@@ -1,0 +1,50 @@
+"""Tests for BIIC-Podcast dataset adapter."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ser.data.adapters.biic_podcast import (
+    BIIC_PODCAST_CORPUS_ID,
+    BIIC_PODCAST_DATASET_LICENSE_ID,
+    BIIC_PODCAST_DATASET_POLICY_ID,
+    build_biic_podcast_utterances,
+)
+from ser.data.ontology import LabelOntology
+
+
+def _ontology() -> LabelOntology:
+    return LabelOntology(
+        ontology_id="default_v1",
+        allowed_labels=frozenset({"happy", "sad"}),
+    )
+
+
+def test_build_biic_podcast_utterances_parses_csv_and_metadata(tmp_path: Path) -> None:
+    """BIIC adapter should parse label CSV and emit enriched utterances."""
+    labels_csv = tmp_path / "labels.csv"
+    labels_csv.write_text(
+        "FileName,EmoClass,Split_Set,Speaker,Start,Duration\n"
+        "a.wav,2,Train,spk1,0.5,1.0\n"
+        "b.wav,1,Test,spk2,1.0,1.5\n",
+        encoding="utf-8",
+    )
+
+    utterances = build_biic_podcast_utterances(
+        dataset_root=tmp_path,
+        labels_csv_path=labels_csv,
+        audio_base_dir=tmp_path,
+        ontology=_ontology(),
+        default_language="en",
+        max_failed_file_ratio=0.5,
+    )
+
+    assert utterances is not None
+    assert len(utterances) == 2
+    assert {item.corpus for item in utterances} == {BIIC_PODCAST_CORPUS_ID}
+    assert {item.dataset_policy_id for item in utterances} == {
+        BIIC_PODCAST_DATASET_POLICY_ID
+    }
+    assert {item.dataset_license_id for item in utterances} == {
+        BIIC_PODCAST_DATASET_LICENSE_ID
+    }

--- a/tests/test_dataset_adapters_crema_d.py
+++ b/tests/test_dataset_adapters_crema_d.py
@@ -1,0 +1,47 @@
+"""Tests for CREMA-D dataset adapter."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ser.data.adapters.crema_d import (
+    CREMA_D_CORPUS_ID,
+    CREMA_D_DATASET_LICENSE_ID,
+    CREMA_D_DATASET_POLICY_ID,
+    build_crema_d_utterances,
+)
+from ser.data.ontology import LabelOntology
+
+
+def _ontology() -> LabelOntology:
+    return LabelOntology(
+        ontology_id="default_v1",
+        allowed_labels=frozenset({"happy", "sad", "angry"}),
+    )
+
+
+def test_build_crema_d_utterances_maps_codes_and_metadata(tmp_path: Path) -> None:
+    """CREMA-D adapter should parse filename code and attach metadata."""
+    audio_root = tmp_path / "AudioWAV"
+    audio_root.mkdir(parents=True, exist_ok=True)
+    (audio_root / "1001_IEO_HAP_LO.wav").write_bytes(b"fake")
+    (audio_root / "1002_IEO_SAD_LO.wav").write_bytes(b"fake")
+
+    utterances = build_crema_d_utterances(
+        dataset_root=tmp_path,
+        dataset_glob_pattern="AudioWAV/**/*.wav",
+        emotion_code_map={"HAP": "happy", "SAD": "sad"},
+        default_language="en",
+        ontology=_ontology(),
+        max_failed_file_ratio=0.5,
+    )
+
+    assert utterances is not None
+    assert len(utterances) == 2
+    assert {item.corpus for item in utterances} == {CREMA_D_CORPUS_ID}
+    assert {item.dataset_policy_id for item in utterances} == {
+        CREMA_D_DATASET_POLICY_ID
+    }
+    assert {item.dataset_license_id for item in utterances} == {
+        CREMA_D_DATASET_LICENSE_ID
+    }

--- a/tests/test_dataset_adapters_msp_podcast.py
+++ b/tests/test_dataset_adapters_msp_podcast.py
@@ -1,0 +1,50 @@
+"""Tests for MSP-Podcast dataset adapter."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ser.data.adapters.msp_podcast import (
+    MSP_PODCAST_CORPUS_ID,
+    MSP_PODCAST_DATASET_LICENSE_ID,
+    MSP_PODCAST_DATASET_POLICY_ID,
+    build_msp_podcast_utterances,
+)
+from ser.data.ontology import LabelOntology
+
+
+def _ontology() -> LabelOntology:
+    return LabelOntology(
+        ontology_id="default_v1",
+        allowed_labels=frozenset({"happy", "sad"}),
+    )
+
+
+def test_build_msp_podcast_utterances_parses_csv_and_metadata(tmp_path: Path) -> None:
+    """MSP adapter should parse label CSV and emit enriched utterances."""
+    labels_csv = tmp_path / "labels.csv"
+    labels_csv.write_text(
+        "FileName,EmoClass,Split_Set,Speaker,Start,Duration\n"
+        "a.wav,2,Train,spk1,0.5,1.0\n"
+        "b.wav,1,Test,spk2,1.0,1.5\n",
+        encoding="utf-8",
+    )
+
+    utterances = build_msp_podcast_utterances(
+        dataset_root=tmp_path,
+        labels_csv_path=labels_csv,
+        audio_base_dir=tmp_path,
+        ontology=_ontology(),
+        default_language="en",
+        max_failed_file_ratio=0.5,
+    )
+
+    assert utterances is not None
+    assert len(utterances) == 2
+    assert {item.corpus for item in utterances} == {MSP_PODCAST_CORPUS_ID}
+    assert {item.dataset_policy_id for item in utterances} == {
+        MSP_PODCAST_DATASET_POLICY_ID
+    }
+    assert {item.dataset_license_id for item in utterances} == {
+        MSP_PODCAST_DATASET_LICENSE_ID
+    }

--- a/tests/test_dataset_adapters_ravdess.py
+++ b/tests/test_dataset_adapters_ravdess.py
@@ -1,0 +1,47 @@
+"""Tests for RAVDESS dataset adapter manifest records."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ser.data.adapters.ravdess import (
+    RAVDESS_CORPUS_ID,
+    RAVDESS_DATASET_LICENSE_ID,
+    RAVDESS_DATASET_POLICY_ID,
+    build_ravdess_utterances,
+)
+from ser.data.ontology import LabelOntology
+
+
+def _ontology() -> LabelOntology:
+    return LabelOntology(
+        ontology_id="default_v1",
+        allowed_labels=frozenset({"happy", "sad"}),
+    )
+
+
+def test_build_ravdess_utterances_sets_policy_and_license(tmp_path: Path) -> None:
+    """Adapter should emit dataset policy/license metadata on each utterance."""
+    actor_dir = tmp_path / "Actor_01"
+    actor_dir.mkdir(parents=True, exist_ok=True)
+    (actor_dir / "03-01-03-01-01-01-01.wav").write_bytes(b"fake")
+    (actor_dir / "03-01-04-01-01-01-01.wav").write_bytes(b"fake")
+
+    utterances = build_ravdess_utterances(
+        dataset_root=tmp_path,
+        dataset_glob_pattern=str(tmp_path / "Actor_*" / "*.wav"),
+        emotion_code_map={"03": "happy", "04": "sad"},
+        default_language="en",
+        ontology=_ontology(),
+        max_failed_file_ratio=0.5,
+    )
+
+    assert utterances is not None
+    assert len(utterances) == 2
+    assert {item.corpus for item in utterances} == {RAVDESS_CORPUS_ID}
+    assert {item.dataset_policy_id for item in utterances} == {
+        RAVDESS_DATASET_POLICY_ID
+    }
+    assert {item.dataset_license_id for item in utterances} == {
+        RAVDESS_DATASET_LICENSE_ID
+    }

--- a/tests/test_dataset_consents.py
+++ b/tests/test_dataset_consents.py
@@ -1,0 +1,120 @@
+"""Tests for dataset policy/license consent persistence and gating."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+
+from ser.config import AppConfig
+from ser.data.dataset_consents import (
+    DatasetConsentError,
+    compute_missing_dataset_consents,
+    ensure_dataset_consents,
+    is_policy_restricted,
+    load_persisted_dataset_consents,
+    persist_dataset_consents,
+)
+from ser.data.manifest import MANIFEST_SCHEMA_VERSION, Utterance
+
+
+def _settings(tmp_path: Path) -> AppConfig:
+    return cast(
+        AppConfig,
+        SimpleNamespace(models=SimpleNamespace(folder=tmp_path / "data" / "models")),
+    )
+
+
+def _utterance(
+    *,
+    sample_id: str,
+    label: str,
+    policy_id: str | None,
+    license_id: str | None,
+) -> Utterance:
+    return Utterance(
+        schema_version=MANIFEST_SCHEMA_VERSION,
+        sample_id=sample_id,
+        corpus="ravdess",
+        audio_path=Path(f"{sample_id}.wav"),
+        label=label,
+        speaker_id="ravdess:1",
+        dataset_policy_id=policy_id,
+        dataset_license_id=license_id,
+    )
+
+
+def test_is_policy_restricted_behaviour() -> None:
+    """Restricted policy resolver should include current policy ids only."""
+    assert is_policy_restricted("academic_only") is True
+    assert is_policy_restricted("share_alike") is True
+    assert is_policy_restricted("noncommercial") is True
+    assert is_policy_restricted("unknown") is False
+    assert is_policy_restricted(None) is False
+
+
+def test_persist_and_load_dataset_consents(tmp_path: Path) -> None:
+    """Persisted consents should round-trip deterministically."""
+    settings = _settings(tmp_path)
+
+    persist_dataset_consents(
+        settings=settings,
+        accept_policy_ids=["academic_only"],
+        accept_license_ids=["msp-academic-license"],
+        source="unit_test",
+    )
+    loaded = load_persisted_dataset_consents(settings=settings)
+
+    assert loaded.policy_consents == {"academic_only": "unit_test"}
+    assert loaded.license_consents == {"msp-academic-license": "unit_test"}
+
+
+def test_compute_missing_dataset_consents_ignores_unspecified_policy(
+    tmp_path: Path,
+) -> None:
+    """Legacy records without policy id should remain non-blocking by default."""
+    settings = _settings(tmp_path)
+    utterances = [
+        _utterance(
+            sample_id="legacy-0",
+            label="happy",
+            policy_id=None,
+            license_id=None,
+        ),
+        _utterance(
+            sample_id="modern-0",
+            label="sad",
+            policy_id="academic_only",
+            license_id="msp-academic-license",
+        ),
+    ]
+
+    missing_policies, missing_licenses = compute_missing_dataset_consents(
+        settings=settings,
+        utterances=utterances,
+    )
+
+    assert missing_policies == {"academic_only"}
+    assert missing_licenses == {"msp-academic-license"}
+
+
+def test_ensure_dataset_consents_raises_for_missing_persisted_consent(
+    tmp_path: Path,
+) -> None:
+    """Training gate should raise actionable error when required consents are missing."""
+    settings = _settings(tmp_path)
+    utterances = [
+        _utterance(
+            sample_id="restricted-0",
+            label="happy",
+            policy_id="noncommercial",
+            license_id="cc-by-nc-sa-4.0",
+        )
+    ]
+
+    with pytest.raises(
+        DatasetConsentError, match="ser configure --accept-dataset-policy"
+    ):
+        ensure_dataset_consents(settings=settings, utterances=utterances)

--- a/tests/test_dataset_prepare.py
+++ b/tests/test_dataset_prepare.py
@@ -1,0 +1,148 @@
+"""Tests for dataset descriptor resolution and manifest preparation orchestration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+
+from ser.config import AppConfig
+from ser.data import dataset_prepare as dp
+from ser.data.dataset_registry import DatasetRegistryEntry
+from ser.data.manifest import MANIFEST_SCHEMA_VERSION, Utterance
+from ser.data.ontology import LabelOntology
+
+
+def _settings(tmp_path: Path) -> AppConfig:
+    return cast(
+        AppConfig,
+        SimpleNamespace(
+            models=SimpleNamespace(folder=tmp_path / "data" / "models"),
+            dataset=SimpleNamespace(subfolder_prefix="Actor_*", extension="*.wav"),
+            emotions={"03": "happy", "04": "sad"},
+            data_loader=SimpleNamespace(max_failed_file_ratio=0.1),
+            default_language="en",
+        ),
+    )
+
+
+def _ontology() -> LabelOntology:
+    return LabelOntology(
+        ontology_id="default_v1",
+        allowed_labels=frozenset({"happy", "sad"}),
+    )
+
+
+def _utterance(sample_id: str, audio_path: Path, label: str) -> Utterance:
+    return Utterance(
+        schema_version=MANIFEST_SCHEMA_VERSION,
+        sample_id=sample_id,
+        corpus="ravdess",
+        audio_path=audio_path,
+        label=label,
+        speaker_id="ravdess:1",
+    )
+
+
+def test_resolve_dataset_descriptor_rejects_unknown_id() -> None:
+    """Unsupported dataset ids should fail with an explicit error."""
+    with pytest.raises(ValueError, match="Unsupported dataset"):
+        dp.resolve_dataset_descriptor("unknown-dataset")
+
+
+def test_prepare_dataset_manifest_for_ravdess_updates_registry(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """RAVDESS preparation should build manifest and upsert registry entry."""
+    settings = _settings(tmp_path)
+    dataset_root = tmp_path / "datasets" / "ravdess"
+    manifest_path = tmp_path / "manifests" / "ravdess.jsonl"
+    captured: dict[str, object] = {}
+
+    def _build_manifest(**kwargs: object) -> list[Utterance]:
+        captured["build_kwargs"] = kwargs
+        return [
+            _utterance("ravdess:a.wav", dataset_root / "a.wav", "happy"),
+            _utterance("ravdess:b.wav", dataset_root / "b.wav", "sad"),
+        ]
+
+    monkeypatch.setattr(dp, "build_ravdess_manifest_jsonl", _build_manifest)
+
+    def _capture_registry_kwargs(**kwargs: object) -> None:
+        captured["registry_kwargs"] = kwargs
+
+    monkeypatch.setattr(
+        dp,
+        "upsert_dataset_registry_entry",
+        _capture_registry_kwargs,
+    )
+
+    built = dp.prepare_dataset_manifest(
+        settings=settings,
+        dataset_id="ravdess",
+        dataset_root=dataset_root,
+        ontology=_ontology(),
+        manifest_path=manifest_path,
+        default_language="en",
+    )
+
+    assert built == [manifest_path]
+    build_kwargs = captured["build_kwargs"]
+    assert isinstance(build_kwargs, dict)
+    assert build_kwargs["dataset_root"] == dataset_root
+    assert build_kwargs["output_path"] == manifest_path
+    registry_kwargs = captured["registry_kwargs"]
+    assert isinstance(registry_kwargs, dict)
+    assert registry_kwargs["dataset_id"] == "ravdess"
+    assert registry_kwargs["dataset_root"] == dataset_root
+    assert registry_kwargs["manifest_path"] == manifest_path
+
+
+def test_prepare_from_registry_entry_passes_optional_paths(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Registry rebuild should pass labels/audio/default_language options through."""
+    settings = _settings(tmp_path)
+    dataset_root = tmp_path / "datasets" / "msp-podcast"
+    manifest_path = tmp_path / "manifests" / "msp.jsonl"
+    entry = DatasetRegistryEntry(
+        dataset_id="msp-podcast",
+        dataset_root=dataset_root,
+        manifest_path=manifest_path,
+        options={
+            "labels_csv_path": str(tmp_path / "labels.csv"),
+            "audio_base_dir": str(tmp_path / "audio"),
+            "default_language": "en",
+        },
+    )
+    captured: dict[str, object] = {}
+
+    def _prepare_dataset_manifest(**kwargs: object) -> list[Path]:
+        captured["kwargs"] = kwargs
+        return [manifest_path]
+
+    monkeypatch.setattr(
+        dp,
+        "prepare_dataset_manifest",
+        _prepare_dataset_manifest,
+    )
+
+    built = dp.prepare_from_registry_entry(
+        settings=settings,
+        entry=entry,
+        ontology=_ontology(),
+    )
+
+    assert built == [manifest_path]
+    kwargs = captured["kwargs"]
+    assert isinstance(kwargs, dict)
+    assert kwargs["dataset_id"] == "msp-podcast"
+    assert kwargs["dataset_root"] == dataset_root
+    assert kwargs["manifest_path"] == manifest_path
+    assert kwargs["labels_csv_path"] == tmp_path / "labels.csv"
+    assert kwargs["audio_base_dir"] == tmp_path / "audio"
+    assert kwargs["default_language"] == "en"

--- a/tests/test_dataset_registry.py
+++ b/tests/test_dataset_registry.py
@@ -1,0 +1,74 @@
+"""Tests for dataset registry persistence and lookup."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+
+from ser.config import AppConfig
+from ser.data.dataset_registry import (
+    DatasetRegistryEntry,
+    load_dataset_registry,
+    registered_manifest_paths,
+    save_dataset_registry,
+    upsert_dataset_registry_entry,
+)
+
+
+def _settings(tmp_path: Path) -> AppConfig:
+    return cast(
+        AppConfig,
+        SimpleNamespace(models=SimpleNamespace(folder=tmp_path / "data" / "models")),
+    )
+
+
+def test_registry_round_trip(tmp_path: Path) -> None:
+    """Registry save/load should preserve normalized entries."""
+    settings = _settings(tmp_path)
+    registry = {
+        "ravdess": DatasetRegistryEntry(
+            dataset_id="ravdess",
+            dataset_root=tmp_path / "datasets" / "ravdess",
+            manifest_path=tmp_path / "manifests" / "ravdess.jsonl",
+            options={"default_language": "en"},
+        )
+    }
+
+    save_dataset_registry(settings=settings, registry=registry)
+    loaded = load_dataset_registry(settings=settings)
+
+    assert "ravdess" in loaded
+    assert loaded["ravdess"].dataset_id == "ravdess"
+    assert loaded["ravdess"].dataset_root == tmp_path / "datasets" / "ravdess"
+    assert loaded["ravdess"].manifest_path == tmp_path / "manifests" / "ravdess.jsonl"
+    assert loaded["ravdess"].options == {"default_language": "en"}
+
+
+def test_registry_upsert_and_registered_manifest_paths(tmp_path: Path) -> None:
+    """Upsert should persist entry and path helper should return existing manifests only."""
+    settings = _settings(tmp_path)
+    manifest_path = tmp_path / "manifests" / "ravdess.jsonl"
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text("", encoding="utf-8")
+    upsert_dataset_registry_entry(
+        settings=settings,
+        dataset_id="RAVDESS",
+        dataset_root=tmp_path / "datasets" / "ravdess",
+        manifest_path=manifest_path,
+        options={"labels_csv_path": "labels.csv"},
+    )
+    upsert_dataset_registry_entry(
+        settings=settings,
+        dataset_id="crema-d",
+        dataset_root=tmp_path / "datasets" / "crema-d",
+        manifest_path=tmp_path / "manifests" / "missing.jsonl",
+        options={},
+    )
+
+    loaded = load_dataset_registry(settings=settings)
+
+    assert set(loaded) == {"ravdess", "crema-d"}
+    assert loaded["ravdess"].dataset_id == "ravdess"
+    assert loaded["ravdess"].options == {"labels_csv_path": "labels.csv"}
+    assert registered_manifest_paths(settings=settings) == (manifest_path,)

--- a/tests/test_feature_runtime_policy.py
+++ b/tests/test_feature_runtime_policy.py
@@ -1,0 +1,150 @@
+"""Tests for backend-aware feature runtime selector policy."""
+
+from __future__ import annotations
+
+import pytest
+
+import ser.repr.runtime_policy as runtime_policy
+from ser.repr.runtime_policy import resolve_feature_runtime_policy
+from ser.utils.torch_inference import TorchRuntime
+
+
+def _runtime(*, device_spec: str, device_type: str) -> TorchRuntime:
+    """Builds one torch runtime stub for selector-policy tests."""
+    return TorchRuntime(
+        device=object(),
+        dtype=object(),
+        device_spec=device_spec,
+        device_type=device_type,
+        dtype_name="float32",
+    )
+
+
+def test_feature_runtime_policy_demotes_xlsr_mps_to_cpu(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """XLS-R should avoid MPS runtime by default for stability."""
+    monkeypatch.setattr(
+        runtime_policy,
+        "maybe_resolve_torch_runtime",
+        lambda *, device, dtype: _runtime(device_spec="mps", device_type="mps"),
+    )
+
+    resolved = resolve_feature_runtime_policy(
+        backend_id="hf_xlsr",
+        requested_device="auto",
+        requested_dtype="auto",
+    )
+
+    assert resolved.device == "cpu"
+    assert resolved.dtype == "float32"
+    assert resolved.reason == "hf_xlsr_mps_stability_guard"
+
+
+def test_feature_runtime_policy_preserves_whisper_requested_selectors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Whisper backend should keep caller-provided selectors."""
+    monkeypatch.setattr(
+        runtime_policy,
+        "maybe_resolve_torch_runtime",
+        lambda *, device, dtype: _runtime(device_spec="mps", device_type="mps"),
+    )
+
+    resolved = resolve_feature_runtime_policy(
+        backend_id="hf_whisper",
+        requested_device="auto",
+        requested_dtype="auto",
+    )
+
+    assert resolved.device == "auto"
+    assert resolved.dtype == "auto"
+    assert resolved.reason == "torch_backend_requested_selectors"
+
+
+def test_feature_runtime_policy_enables_emotion2vec_cuda_when_available(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Emotion2Vec should enable CUDA runtime only when probe resolves CUDA."""
+    monkeypatch.setattr(
+        runtime_policy,
+        "maybe_resolve_torch_runtime",
+        lambda *, device, dtype: _runtime(device_spec="cuda:1", device_type="cuda"),
+    )
+
+    resolved = resolve_feature_runtime_policy(
+        backend_id="emotion2vec",
+        requested_device="auto",
+        requested_dtype="auto",
+    )
+
+    assert resolved.device == "cuda:1"
+    assert resolved.dtype == "auto"
+    assert resolved.reason == "emotion2vec_cuda_enabled"
+
+
+def test_feature_runtime_policy_defaults_emotion2vec_to_cpu_without_cuda(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Emotion2Vec should remain CPU-only when runtime probe is non-CUDA."""
+    monkeypatch.setattr(
+        runtime_policy,
+        "maybe_resolve_torch_runtime",
+        lambda *, device, dtype: _runtime(device_spec="mps", device_type="mps"),
+    )
+
+    resolved = resolve_feature_runtime_policy(
+        backend_id="emotion2vec",
+        requested_device="auto",
+        requested_dtype="auto",
+    )
+
+    assert resolved.device == "cpu"
+    assert resolved.dtype == "float32"
+    assert resolved.reason == "emotion2vec_cpu_default"
+
+
+def test_feature_runtime_policy_applies_backend_override_for_whisper(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Backend-level overrides should replace requested selectors for Whisper."""
+    monkeypatch.setattr(
+        runtime_policy,
+        "maybe_resolve_torch_runtime",
+        lambda *, device, dtype: _runtime(device_spec="cuda:0", device_type="cuda"),
+    )
+
+    resolved = resolve_feature_runtime_policy(
+        backend_id="hf_whisper",
+        requested_device="auto",
+        requested_dtype="auto",
+        backend_override_device="cuda:0",
+        backend_override_dtype="float16",
+    )
+
+    assert resolved.device == "cuda:0"
+    assert resolved.dtype == "float16"
+    assert resolved.reason == "torch_backend_requested_selectors"
+
+
+def test_feature_runtime_policy_keeps_xlsr_mps_guard_with_overrides(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """XLS-R stability guard should still demote MPS even when overrides request MPS."""
+    monkeypatch.setattr(
+        runtime_policy,
+        "maybe_resolve_torch_runtime",
+        lambda *, device, dtype: _runtime(device_spec="mps", device_type="mps"),
+    )
+
+    resolved = resolve_feature_runtime_policy(
+        backend_id="hf_xlsr",
+        requested_device="cpu",
+        requested_dtype="float32",
+        backend_override_device="mps",
+        backend_override_dtype="float16",
+    )
+
+    assert resolved.device == "cpu"
+    assert resolved.dtype == "float32"
+    assert resolved.reason == "hf_xlsr_mps_stability_guard"


### PR DESCRIPTION
## Summary
It introduces a full dataset-preparation workflow, backend-aware runtime policy resolution, medium-profile resilience improvements, and a process cleanup fix for `faster_whisper` isolation.

## What Changed

1. Dataset workflow and governance
- Added top-level CLI dispatch for dataset operations: `ser configure` and `ser data download`.
- Added dataset consent/policy persistence and enforcement for training.
- Added dataset registry + manifest preparation flow, including auto-rebuild when registry manifests are missing.
- Added adapters and manifest builders for `ravdess`, `crema-d`, `msp-podcast`, and `biic-podcast`.
- Updated README with consent/manifest workflow and new env vars.

2. Runtime policy and inference hardening
- Added backend-scoped feature runtime policy (`device`/`dtype`) derived from profile definitions.
- Added profile schema support for `feature_runtime_defaults`; medium now defaults feature dtype to `float32`.
- Wired runtime policy resolution into medium/accurate/accurate-research backend construction and mismatch checks.
- Added medium transient-failure handling with one-time CPU `float32` retry on known MPS/half-float/non-finite failure signatures.
- Added `--no-transcript` behavior end-to-end via `InferenceRequest.include_transcript`.

3. Feature extraction, caching, and training/reporting
- Added segment-aware audio reads (`start_seconds`, `duration_seconds`) with validation.
- Extended embedding-cache key derivation to include segment bounds.
- Switched training feature builders to utterance-driven segment extraction.
- Added grouped sample-level metrics by corpus/language with minimum support control.

4. faster_whisper process cleanup fix
- In isolated transcript execution, always `join` first in `finally`, then terminate only if still alive.
- Prevents leaked process resources/semaphore warnings under fast worker exits.

## Testing
- Added/expanded tests across CLI, dataset workflow, registry/consents, adapters, runtime policy, medium fallback, audio/caching, metrics, runtime pipeline, and transcript extractor cleanup paths.