### PR TITLE
Add startup preflight + ser doctor & Add XPU support

### DIFF
--- a/.github/workflows/linux-selfhosted-gpu-validation.yml
+++ b/.github/workflows/linux-selfhosted-gpu-validation.yml
@@ -1,0 +1,339 @@
+name: Linux Self-Hosted GPU Validation
+
+on:
+  workflow_dispatch:
+    inputs:
+      python_version:
+        description: "Python version used for setup and validation."
+        required: true
+        default: "3.12"
+        type: string
+      run_cuda:
+        description: "Run CUDA hardware validation (self-hosted runner required)."
+        required: true
+        default: true
+        type: boolean
+      run_xpu:
+        description: "Run XPU hardware validation (self-hosted runner required)."
+        required: true
+        default: false
+        type: boolean
+      cuda_runner_labels_json:
+        description: "JSON array of runner labels for CUDA job."
+        required: true
+        default: '["self-hosted","linux","x64","cuda"]'
+        type: string
+      xpu_runner_labels_json:
+        description: "JSON array of runner labels for XPU job."
+        required: true
+        default: '["self-hosted","linux","x64","xpu"]'
+        type: string
+      accurate_model_id:
+        description: "Whisper model id used by accurate profile smoke."
+        required: true
+        default: "openai/whisper-tiny"
+        type: string
+      run_accurate_research:
+        description: "Run accurate-research profile smoke."
+        required: true
+        default: false
+        type: boolean
+      accurate_research_model_id:
+        description: "Model id used by accurate-research profile smoke."
+        required: true
+        default: "iic/emotion2vec_plus_large"
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  validate-selection:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ensure at least one hardware lane is enabled
+        run: |
+          if [[ "${{ inputs.run_cuda }}" != "true" && "${{ inputs.run_xpu }}" != "true" ]]; then
+            echo "At least one of run_cuda or run_xpu must be true." >&2
+            exit 1
+          fi
+
+  cuda-selfhosted-profile-smoke:
+    if: ${{ inputs.run_cuda }}
+    needs: [validate-selection]
+    runs-on: ${{ fromJSON(inputs.cuda_runner_labels_json) }}
+    timeout-minutes: 300
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure runtime directories
+        run: |
+          echo "SER_MAX_WORKERS=1" >> "$GITHUB_ENV"
+          echo "SER_MODELS_DIR=$RUNNER_TEMP/ser-models" >> "$GITHUB_ENV"
+          echo "SER_DATA_DIR=$RUNNER_TEMP/ser-data" >> "$GITHUB_ENV"
+          echo "SER_CACHE_DIR=$RUNNER_TEMP/ser-cache" >> "$GITHUB_ENV"
+          echo "SER_TRANSCRIPTS_DIR=$RUNNER_TEMP/ser-transcripts" >> "$GITHUB_ENV"
+          mkdir -p \
+            "$RUNNER_TEMP/ser-models" \
+            "$RUNNER_TEMP/ser-data" \
+            "$RUNNER_TEMP/ser-cache" \
+            "$RUNNER_TEMP/ser-transcripts"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python_version }}
+
+      - name: Install uv
+        run: python -m pip install --upgrade pip uv
+
+      - name: Verify ffmpeg availability on runner
+        run: |
+          if ! command -v ffmpeg >/dev/null 2>&1; then
+            echo "ffmpeg is required on self-hosted CUDA runners." >&2
+            exit 1
+          fi
+          ffmpeg -version
+
+      - name: Cache uv
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/uv
+          key: uv-${{ runner.os }}-selfhosted-cuda-py${{ inputs.python_version }}-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            uv-${{ runner.os }}-selfhosted-cuda-py${{ inputs.python_version }}-
+
+      - name: Sync all dependency groups
+        run: uv sync --frozen --python ${{ inputs.python_version }} --all-extras
+
+      - name: Verify CUDA runtime availability
+        run: |
+          uv run --python ${{ inputs.python_version }} python - <<'PY'
+          import importlib
+
+          torch = importlib.import_module("torch")
+          cuda = getattr(torch, "cuda", None)
+          is_available = getattr(cuda, "is_available", None)
+          available = bool(is_available()) if callable(is_available) else False
+          if not available:
+              raise SystemExit("CUDA runtime unavailable on selected self-hosted runner.")
+          device_count = getattr(cuda, "device_count", lambda: "unknown")
+          print(f"cuda_available={available}, cuda_device_count={device_count()}")
+          PY
+
+      - name: Build synthetic RAVDESS smoke dataset
+        run: python ./scripts/build_synthetic_ravdess_dataset.py
+
+      - name: Run CUDA-focused policy/runtime tests
+        run: >
+          uv run --python ${{ inputs.python_version }} --extra dev pytest -q
+          tests/test_torch_inference.py
+          tests/test_feature_runtime_policy.py
+          tests/test_transcription_runtime_policy.py
+          tests/test_transcript_extractor.py
+
+      - name: Medium profile train and predict (CUDA lane)
+        run: |
+          SER_TORCH_DEVICE=cuda \
+          SER_TORCH_DTYPE=float16 \
+          SER_MODEL_FILE_NAME=ser_model_medium_cuda.pkl \
+          SER_TRAINING_REPORT_FILE_NAME=training_report_medium_cuda.json \
+          uv run --python ${{ inputs.python_version }} --extra medium ser --train --profile medium
+
+          SER_TORCH_DEVICE=cuda \
+          SER_TORCH_DTYPE=float16 \
+          SER_MODEL_FILE_NAME=ser_model_medium_cuda.pkl \
+          SER_TRAINING_REPORT_FILE_NAME=training_report_medium_cuda.json \
+          uv run --python ${{ inputs.python_version }} --extra medium ser --file sample.wav --profile medium
+
+      - name: Accurate profile train and predict (CUDA lane)
+        run: |
+          SER_TORCH_DEVICE=cuda \
+          SER_TORCH_DTYPE=float16 \
+          SER_ACCURATE_MODEL_ID=${{ inputs.accurate_model_id }} \
+          WHISPER_MODEL=tiny \
+          WHISPER_DEMUCS=false \
+          WHISPER_VAD=false \
+          SER_MODEL_FILE_NAME=ser_model_accurate_cuda.pkl \
+          SER_TRAINING_REPORT_FILE_NAME=training_report_accurate_cuda.json \
+          uv run --python ${{ inputs.python_version }} --extra medium ser --train --profile accurate
+
+          SER_TORCH_DEVICE=cuda \
+          SER_TORCH_DTYPE=float16 \
+          SER_ACCURATE_MODEL_ID=${{ inputs.accurate_model_id }} \
+          WHISPER_MODEL=tiny \
+          WHISPER_DEMUCS=false \
+          WHISPER_VAD=false \
+          SER_MODEL_FILE_NAME=ser_model_accurate_cuda.pkl \
+          SER_TRAINING_REPORT_FILE_NAME=training_report_accurate_cuda.json \
+          uv run --python ${{ inputs.python_version }} --extra medium ser --file sample.wav --profile accurate
+
+      - name: Accurate-research profile train and predict (optional)
+        if: ${{ inputs.run_accurate_research }}
+        run: |
+          SER_ENABLE_RESTRICTED_BACKENDS=true \
+          SER_TORCH_DEVICE=cuda \
+          SER_TORCH_DTYPE=float16 \
+          SER_ACCURATE_RESEARCH_MODEL_ID=${{ inputs.accurate_research_model_id }} \
+          SER_MODEL_FILE_NAME=ser_model_accurate_research_cuda.pkl \
+          SER_TRAINING_REPORT_FILE_NAME=training_report_accurate_research_cuda.json \
+          uv run --python ${{ inputs.python_version }} --extra full ser --train --profile accurate-research
+
+          SER_ENABLE_RESTRICTED_BACKENDS=true \
+          SER_TORCH_DEVICE=cuda \
+          SER_TORCH_DTYPE=float16 \
+          SER_ACCURATE_RESEARCH_MODEL_ID=${{ inputs.accurate_research_model_id }} \
+          SER_MODEL_FILE_NAME=ser_model_accurate_research_cuda.pkl \
+          SER_TRAINING_REPORT_FILE_NAME=training_report_accurate_research_cuda.json \
+          uv run --python ${{ inputs.python_version }} --extra full ser --file sample.wav --profile accurate-research
+
+      - name: Upload CUDA validation artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-selfhosted-cuda-validation-artifacts
+          path: |
+            ${{ runner.temp }}/ser-models/*
+            ${{ runner.temp }}/ser-transcripts/*
+
+  xpu-selfhosted-profile-smoke:
+    if: ${{ inputs.run_xpu }}
+    needs: [validate-selection]
+    runs-on: ${{ fromJSON(inputs.xpu_runner_labels_json) }}
+    timeout-minutes: 300
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure runtime directories
+        run: |
+          echo "SER_MAX_WORKERS=1" >> "$GITHUB_ENV"
+          echo "SER_MODELS_DIR=$RUNNER_TEMP/ser-models" >> "$GITHUB_ENV"
+          echo "SER_DATA_DIR=$RUNNER_TEMP/ser-data" >> "$GITHUB_ENV"
+          echo "SER_CACHE_DIR=$RUNNER_TEMP/ser-cache" >> "$GITHUB_ENV"
+          echo "SER_TRANSCRIPTS_DIR=$RUNNER_TEMP/ser-transcripts" >> "$GITHUB_ENV"
+          mkdir -p \
+            "$RUNNER_TEMP/ser-models" \
+            "$RUNNER_TEMP/ser-data" \
+            "$RUNNER_TEMP/ser-cache" \
+            "$RUNNER_TEMP/ser-transcripts"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python_version }}
+
+      - name: Install uv
+        run: python -m pip install --upgrade pip uv
+
+      - name: Verify ffmpeg availability on runner
+        run: |
+          if ! command -v ffmpeg >/dev/null 2>&1; then
+            echo "ffmpeg is required on self-hosted XPU runners." >&2
+            exit 1
+          fi
+          ffmpeg -version
+
+      - name: Cache uv
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/uv
+          key: uv-${{ runner.os }}-selfhosted-xpu-py${{ inputs.python_version }}-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            uv-${{ runner.os }}-selfhosted-xpu-py${{ inputs.python_version }}-
+
+      - name: Sync all dependency groups
+        run: uv sync --frozen --python ${{ inputs.python_version }} --all-extras
+
+      - name: Verify XPU runtime availability
+        run: |
+          uv run --python ${{ inputs.python_version }} python - <<'PY'
+          import importlib
+
+          torch = importlib.import_module("torch")
+          xpu = getattr(torch, "xpu", None)
+          is_available = getattr(xpu, "is_available", None)
+          available = bool(is_available()) if callable(is_available) else False
+          if not available:
+              raise SystemExit("XPU runtime unavailable on selected self-hosted runner.")
+          print(f"xpu_available={available}")
+          PY
+
+      - name: Build synthetic RAVDESS smoke dataset
+        run: python ./scripts/build_synthetic_ravdess_dataset.py
+
+      - name: Run XPU-focused policy/runtime tests
+        run: >
+          uv run --python ${{ inputs.python_version }} --extra dev pytest -q
+          tests/test_torch_inference.py
+          tests/test_feature_runtime_policy.py
+          tests/test_transcription_runtime_policy.py
+          tests/test_emotion2vec_backend.py
+          tests/test_accurate_research_inference.py
+
+      - name: Medium profile train and predict (XPU lane)
+        run: |
+          SER_TORCH_DEVICE=xpu \
+          SER_TORCH_DTYPE=float16 \
+          SER_MODEL_FILE_NAME=ser_model_medium_xpu.pkl \
+          SER_TRAINING_REPORT_FILE_NAME=training_report_medium_xpu.json \
+          uv run --python ${{ inputs.python_version }} --extra medium ser --train --profile medium
+
+          SER_TORCH_DEVICE=xpu \
+          SER_TORCH_DTYPE=float16 \
+          SER_MODEL_FILE_NAME=ser_model_medium_xpu.pkl \
+          SER_TRAINING_REPORT_FILE_NAME=training_report_medium_xpu.json \
+          uv run --python ${{ inputs.python_version }} --extra medium ser --file sample.wav --profile medium
+
+      - name: Accurate profile train and predict (XPU lane)
+        run: |
+          SER_TORCH_DEVICE=xpu \
+          SER_TORCH_DTYPE=float16 \
+          SER_ACCURATE_MODEL_ID=${{ inputs.accurate_model_id }} \
+          WHISPER_MODEL=tiny \
+          WHISPER_DEMUCS=false \
+          WHISPER_VAD=false \
+          SER_MODEL_FILE_NAME=ser_model_accurate_xpu.pkl \
+          SER_TRAINING_REPORT_FILE_NAME=training_report_accurate_xpu.json \
+          uv run --python ${{ inputs.python_version }} --extra medium ser --train --profile accurate
+
+          SER_TORCH_DEVICE=xpu \
+          SER_TORCH_DTYPE=float16 \
+          SER_ACCURATE_MODEL_ID=${{ inputs.accurate_model_id }} \
+          WHISPER_MODEL=tiny \
+          WHISPER_DEMUCS=false \
+          WHISPER_VAD=false \
+          SER_MODEL_FILE_NAME=ser_model_accurate_xpu.pkl \
+          SER_TRAINING_REPORT_FILE_NAME=training_report_accurate_xpu.json \
+          uv run --python ${{ inputs.python_version }} --extra medium ser --file sample.wav --profile accurate
+
+      - name: Accurate-research profile train and predict (optional)
+        if: ${{ inputs.run_accurate_research }}
+        run: |
+          SER_ENABLE_RESTRICTED_BACKENDS=true \
+          SER_TORCH_DEVICE=xpu \
+          SER_TORCH_DTYPE=float16 \
+          SER_ACCURATE_RESEARCH_MODEL_ID=${{ inputs.accurate_research_model_id }} \
+          SER_MODEL_FILE_NAME=ser_model_accurate_research_xpu.pkl \
+          SER_TRAINING_REPORT_FILE_NAME=training_report_accurate_research_xpu.json \
+          uv run --python ${{ inputs.python_version }} --extra full ser --train --profile accurate-research
+
+          SER_ENABLE_RESTRICTED_BACKENDS=true \
+          SER_TORCH_DEVICE=xpu \
+          SER_TORCH_DTYPE=float16 \
+          SER_ACCURATE_RESEARCH_MODEL_ID=${{ inputs.accurate_research_model_id }} \
+          SER_MODEL_FILE_NAME=ser_model_accurate_research_xpu.pkl \
+          SER_TRAINING_REPORT_FILE_NAME=training_report_accurate_research_xpu.json \
+          uv run --python ${{ inputs.python_version }} --extra full ser --file sample.wav --profile accurate-research
+
+      - name: Upload XPU validation artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-selfhosted-xpu-validation-artifacts
+          path: |
+            ${{ runner.temp }}/ser-models/*
+            ${{ runner.temp }}/ser-transcripts/*

--- a/.github/workflows/macos15-mps-validation.yml
+++ b/.github/workflows/macos15-mps-validation.yml
@@ -1,0 +1,176 @@
+name: macOS 15 MPS Validation
+
+on:
+  workflow_dispatch:
+    inputs:
+      python_version:
+        description: "Python version used for setup and validation."
+        required: true
+        default: "3.12"
+        type: string
+      accurate_model_id:
+        description: "Whisper model id used by accurate profile smoke."
+        required: true
+        default: "openai/whisper-tiny"
+        type: string
+      run_accurate_research:
+        description: "Run accurate-research profile smoke."
+        required: true
+        default: false
+        type: boolean
+      accurate_research_model_id:
+        description: "Model id used by accurate-research profile smoke."
+        required: true
+        default: "iic/emotion2vec_plus_large"
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  macos15-mps-profile-smoke:
+    runs-on: macos-15
+    timeout-minutes: 300
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure runtime directories
+        run: |
+          echo "SER_MAX_WORKERS=1" >> "$GITHUB_ENV"
+          echo "SER_MODELS_DIR=$RUNNER_TEMP/ser-models" >> "$GITHUB_ENV"
+          echo "SER_DATA_DIR=$RUNNER_TEMP/ser-data" >> "$GITHUB_ENV"
+          echo "SER_CACHE_DIR=$RUNNER_TEMP/ser-cache" >> "$GITHUB_ENV"
+          echo "SER_TRANSCRIPTS_DIR=$RUNNER_TEMP/ser-transcripts" >> "$GITHUB_ENV"
+          mkdir -p \
+            "$RUNNER_TEMP/ser-models" \
+            "$RUNNER_TEMP/ser-data" \
+            "$RUNNER_TEMP/ser-cache" \
+            "$RUNNER_TEMP/ser-transcripts"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python_version }}
+
+      - name: Install uv
+        run: python -m pip install --upgrade pip uv
+
+      - name: Ensure ffmpeg is available
+        run: |
+          if ! command -v ffmpeg >/dev/null 2>&1; then
+            brew install ffmpeg
+          fi
+          ffmpeg -version
+
+      - name: Cache uv
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/uv
+          key: uv-${{ runner.os }}-macos15-mps-py${{ inputs.python_version }}-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            uv-${{ runner.os }}-macos15-mps-py${{ inputs.python_version }}-
+
+      - name: Setup compatible environment
+        run: ./scripts/setup_compatible_env.sh --python ${{ inputs.python_version }}
+
+      - name: Verify MPS runtime availability
+        run: |
+          uv run --python ${{ inputs.python_version }} python - <<'PY'
+          import importlib
+          import platform
+
+          torch = importlib.import_module("torch")
+          backends = getattr(torch, "backends", None)
+          mps = getattr(backends, "mps", None)
+          is_available = getattr(mps, "is_available", None)
+          is_built = getattr(mps, "is_built", None)
+          available = bool(is_available()) if callable(is_available) else False
+          built = bool(is_built()) if callable(is_built) else False
+          machine = platform.machine().lower()
+          print(f"platform.machine={machine}, mps_available={available}, mps_built={built}")
+          if not (available and built):
+              raise SystemExit(
+                  "MPS runtime is unavailable on this macOS 15 runner. "
+                  "Use an Apple Silicon macOS 15 runner."
+              )
+          PY
+
+      - name: Build synthetic RAVDESS smoke dataset
+        run: python ./scripts/build_synthetic_ravdess_dataset.py
+
+      - name: Run MPS-focused runtime policy tests
+        run: >
+          uv run --python ${{ inputs.python_version }} --extra dev pytest -q
+          tests/test_torch_inference.py
+          tests/test_feature_runtime_policy.py
+          tests/test_transcription_runtime_policy.py
+          tests/test_stable_whisper_mps_compat.py
+          tests/test_transcription_mps_admission.py
+          tests/test_transcription_runtime_failures.py
+          tests/test_transcription_backends.py
+
+      - name: Medium profile train and predict (MPS lane)
+        run: |
+          SER_TORCH_DEVICE=auto \
+          SER_TORCH_DTYPE=auto \
+          SER_MODEL_FILE_NAME=ser_model_medium_macos15_mps.pkl \
+          SER_TRAINING_REPORT_FILE_NAME=training_report_medium_macos15_mps.json \
+          uv run --python ${{ inputs.python_version }} --extra medium ser --train --profile medium
+
+          SER_TORCH_DEVICE=auto \
+          SER_TORCH_DTYPE=auto \
+          SER_MODEL_FILE_NAME=ser_model_medium_macos15_mps.pkl \
+          SER_TRAINING_REPORT_FILE_NAME=training_report_medium_macos15_mps.json \
+          uv run --python ${{ inputs.python_version }} --extra medium ser --file sample.wav --profile medium
+
+      - name: Accurate profile train and predict (MPS lane)
+        run: |
+          SER_TORCH_DEVICE=auto \
+          SER_TORCH_DTYPE=auto \
+          SER_ACCURATE_MODEL_ID=${{ inputs.accurate_model_id }} \
+          WHISPER_MODEL=tiny \
+          WHISPER_DEMUCS=false \
+          WHISPER_VAD=false \
+          SER_MODEL_FILE_NAME=ser_model_accurate_macos15_mps.pkl \
+          SER_TRAINING_REPORT_FILE_NAME=training_report_accurate_macos15_mps.json \
+          uv run --python ${{ inputs.python_version }} --extra medium ser --train --profile accurate
+
+          SER_TORCH_DEVICE=auto \
+          SER_TORCH_DTYPE=auto \
+          SER_ACCURATE_MODEL_ID=${{ inputs.accurate_model_id }} \
+          WHISPER_MODEL=tiny \
+          WHISPER_DEMUCS=false \
+          WHISPER_VAD=false \
+          SER_MODEL_FILE_NAME=ser_model_accurate_macos15_mps.pkl \
+          SER_TRAINING_REPORT_FILE_NAME=training_report_accurate_macos15_mps.json \
+          uv run --python ${{ inputs.python_version }} --extra medium ser --file sample.wav --profile accurate
+
+      - name: Accurate-research profile train and predict (optional)
+        if: ${{ inputs.run_accurate_research }}
+        run: |
+          SER_ENABLE_RESTRICTED_BACKENDS=true \
+          SER_TORCH_DEVICE=auto \
+          SER_TORCH_DTYPE=auto \
+          SER_ACCURATE_RESEARCH_MODEL_ID=${{ inputs.accurate_research_model_id }} \
+          SER_MODEL_FILE_NAME=ser_model_accurate_research_macos15_mps.pkl \
+          SER_TRAINING_REPORT_FILE_NAME=training_report_accurate_research_macos15_mps.json \
+          uv run --python ${{ inputs.python_version }} --extra full ser --train --profile accurate-research
+
+          SER_ENABLE_RESTRICTED_BACKENDS=true \
+          SER_TORCH_DEVICE=auto \
+          SER_TORCH_DTYPE=auto \
+          SER_ACCURATE_RESEARCH_MODEL_ID=${{ inputs.accurate_research_model_id }} \
+          SER_MODEL_FILE_NAME=ser_model_accurate_research_macos15_mps.pkl \
+          SER_TRAINING_REPORT_FILE_NAME=training_report_accurate_research_macos15_mps.json \
+          uv run --python ${{ inputs.python_version }} --extra full ser --file sample.wav --profile accurate-research
+
+      - name: Upload validation artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos15-mps-validation-artifacts
+          path: |
+            ${{ runner.temp }}/ser-models/*
+            ${{ runner.temp }}/ser-transcripts/*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# Contributing
+
+Thanks for contributing to `ser`.
+
+## Development Setup
+
+```bash
+git clone https://github.com/jsugg/ser/
+cd ser
+./scripts/setup_compatible_env.sh
+```
+
+Platform/setup notes and runtime compatibility details remain in `README.md`.
+
+## Local Quality Gates
+
+Before opening a PR, run:
+
+```bash
+uv run --extra dev pre-commit run --all-files --hook-stage pre-push
+uv run --extra dev pytest -q
+```
+
+## CI and Validation
+
+- Default CI is defined in `.github/workflows/ci.yml`.
+- Slow and hardware-specific lanes are manual (`workflow_dispatch`).
+- Hardware validation instructions are documented in
+  [`docs/ci/hardware-validation.md`](docs/ci/hardware-validation.md).
+
+## Pull Requests
+
+- Keep diffs small and focused.
+- Add/adjust tests for behavior changes.
+- Avoid mixing unrelated refactors with functional fixes.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ sequenceDiagram;
 ## Audience Guide
 - **CLI users**: focus on `Installation`, `Usage`, and `Additional Options`.
 - **Library users**: also review `Configuration` (common overrides first).
-- **Contributors**: review `Contributing` and advanced sections in this README.
+- **Contributors**: review [CONTRIBUTING.md](CONTRIBUTING.md) and advanced sections in this README.
 -------
 ### Workflows and architectures
 

--- a/docs/ci/hardware-validation.md
+++ b/docs/ci/hardware-validation.md
@@ -1,0 +1,76 @@
+# Hardware Validation Workflows
+
+Manual hardware validation is intentionally separated from default CI.
+
+## MPS (GitHub-hosted)
+
+- Workflow: `.github/workflows/macos15-mps-validation.yml`
+- Trigger: `workflow_dispatch`
+- Runner: `macos-15`
+- Requirement: an Apple Silicon macOS 15 runner with MPS available.
+  - The workflow fails fast if `torch.backends.mps.is_available()` or
+    `torch.backends.mps.is_built()` is false.
+- Coverage:
+  - MPS-focused runtime policy tests.
+  - `medium` and `accurate` train/predict smoke.
+  - Optional `accurate-research` train/predict smoke.
+
+Run with GitHub CLI:
+
+```bash
+gh workflow run .github/workflows/macos15-mps-validation.yml \
+  -f python_version=3.12 \
+  -f accurate_model_id=openai/whisper-tiny \
+  -f run_accurate_research=false \
+  -f accurate_research_model_id=iic/emotion2vec_plus_large
+```
+
+## CUDA and XPU (Self-hosted)
+
+- Workflow: `.github/workflows/linux-selfhosted-gpu-validation.yml`
+- Trigger: `workflow_dispatch`
+- Runner: self-hosted Linux runners selected via JSON label inputs.
+  - Default CUDA labels: `["self-hosted","linux","x64","cuda"]`
+  - Default XPU labels: `["self-hosted","linux","x64","xpu"]`
+- Requirements:
+  - `ffmpeg` must be installed on the runner.
+  - CUDA lane requires `torch.cuda.is_available() == true`.
+  - XPU lane requires `torch.xpu.is_available() == true`.
+- Coverage:
+  - Device/policy runtime tests for selected lane.
+  - `medium` and `accurate` train/predict smoke.
+  - Optional `accurate-research` train/predict smoke.
+
+Run CUDA lane:
+
+```bash
+gh workflow run .github/workflows/linux-selfhosted-gpu-validation.yml \
+  -f python_version=3.12 \
+  -f run_cuda=true \
+  -f run_xpu=false \
+  -f cuda_runner_labels_json='["self-hosted","linux","x64","cuda"]' \
+  -f xpu_runner_labels_json='["self-hosted","linux","x64","xpu"]' \
+  -f accurate_model_id=openai/whisper-tiny \
+  -f run_accurate_research=false \
+  -f accurate_research_model_id=iic/emotion2vec_plus_large
+```
+
+Run XPU lane:
+
+```bash
+gh workflow run .github/workflows/linux-selfhosted-gpu-validation.yml \
+  -f python_version=3.12 \
+  -f run_cuda=false \
+  -f run_xpu=true \
+  -f cuda_runner_labels_json='["self-hosted","linux","x64","cuda"]' \
+  -f xpu_runner_labels_json='["self-hosted","linux","x64","xpu"]' \
+  -f accurate_model_id=openai/whisper-tiny \
+  -f run_accurate_research=true \
+  -f accurate_research_model_id=iic/emotion2vec_plus_large
+```
+
+## Notes
+
+- GitHub-hosted runner minimum for current macOS validation is `macos-15`.
+- `macos-13` is not used.
+- Keep hardware lanes manual unless runtime/cost constraints change.

--- a/ser/__main__.py
+++ b/ser/__main__.py
@@ -21,6 +21,12 @@ from ser.config import (
     reload_settings,
     resolve_profile_transcription_config,
 )
+from ser.diagnostics.service import (
+    format_startup_preflight_one_liner,
+    parse_preflight_mode,
+    run_startup_preflight,
+    should_fail_preflight,
+)
 from ser.license_check import (
     BackendLicensePolicy,
     BackendLicensePolicyError,
@@ -58,7 +64,12 @@ _DATASET_COMMAND_HELP = (
     "                     [--labels-csv-path PATH] [--audio-base-dir PATH] "
     "[--skip-download] [--accept-license]\n"
     "\n"
-    "Run `ser configure --help` and `ser data download --help` for details."
+    "Diagnostics commands:\n"
+    "  ser doctor [--profile fast|medium|accurate|accurate-research] "
+    "[--format text|json] [--strict]\n"
+    "\n"
+    "Run `ser configure --help`, `ser data download --help`, and "
+    "`ser doctor --help` for details."
 )
 
 
@@ -340,6 +351,49 @@ def _ensure_restricted_backends_ready_for_command(
         )
 
 
+def _preflight_command_requested(args: argparse.Namespace) -> bool:
+    """Returns whether the parsed CLI args request one executable workflow."""
+    return bool(args.train or args.file or args.calibrate_transcription_runtime)
+
+
+def _preflight_includes_transcription_checks(args: argparse.Namespace) -> bool:
+    """Returns whether startup preflight should include transcription checks."""
+    return bool(
+        args.calibrate_transcription_runtime or (args.file and not args.no_transcript)
+    )
+
+
+def _suppress_preflight_transcription_operational_relogs(
+    *,
+    settings: AppConfig,
+    report: object,
+) -> None:
+    """Pre-marks startup-reported transcription operational issues as emitted once."""
+    findings = getattr(report, "findings", ())
+    if not isinstance(findings, tuple | list):
+        return
+    issue_codes: list[str] = []
+    for finding in findings:
+        finding_code = getattr(finding, "code", None)
+        if not isinstance(finding_code, str):
+            continue
+        if finding_code.startswith("transcription_operational_"):
+            issue_codes.append(finding_code.removeprefix("transcription_operational_"))
+    if not issue_codes:
+        return
+    profile_name = resolve_profile_name(settings)
+    backend_id, _model_name, _use_demucs, _use_vad = (
+        resolve_profile_transcription_config(profile_name)
+    )
+    from ser.transcript.transcript_extractor import mark_compatibility_issues_as_emitted
+
+    mark_compatibility_issues_as_emitted(
+        backend_id=backend_id,
+        issue_kind="operational",
+        issue_codes=tuple(issue_codes),
+    )
+
+
 def main() -> None:
     """Parses CLI arguments and runs training or inference workflows."""
     load_dotenv()
@@ -349,20 +403,23 @@ def main() -> None:
     configure_logging(pre_args.log_level)
     settings: AppConfig = reload_settings()
 
-    # Subcommand dispatch for dataset workflows.
-    if pre_remaining and pre_remaining[0] in {"configure", "data"}:
+    # Subcommand dispatch for dataset and diagnostics workflows.
+    if pre_remaining and pre_remaining[0] in {"configure", "data", "doctor"}:
         from ser.data.cli import run_configure_command, run_data_command
+        from ser.diagnostics.command import run_doctor_command
 
         command = pre_remaining[0]
         command_argv = pre_remaining[1:]
         try:
             if command == "configure":
                 raise SystemExit(run_configure_command(command_argv))
-            raise SystemExit(run_data_command(command_argv))
+            if command == "data":
+                raise SystemExit(run_data_command(command_argv))
+            raise SystemExit(run_doctor_command(command_argv, settings=settings))
         except SystemExit:
             raise
         except Exception as err:
-            logger.error("Dataset command failed: %s", err)
+            logger.error("Command '%s' failed: %s", command, err)
             raise SystemExit(1) from err
 
     parser: argparse.ArgumentParser = argparse.ArgumentParser(
@@ -446,6 +503,15 @@ def main() -> None:
         ),
     )
     parser.add_argument(
+        "--preflight",
+        choices=("off", "warn", "strict"),
+        default="warn",
+        help=(
+            "Startup diagnostics gate: off=skip checks, warn=log findings and fail only "
+            "on blocking errors, strict=fail on warnings/errors."
+        ),
+    )
+    parser.add_argument(
         "--calibration-iterations",
         type=int,
         default=2,
@@ -470,6 +536,7 @@ def main() -> None:
         active_settings,
         disable_timeouts=bool(args.disable_timeouts),
     )
+    preflight_mode = parse_preflight_mode(str(args.preflight))
     if isinstance(active_settings, AppConfig):
         apply_settings(active_settings)
     use_profile_pipeline: bool = _profile_pipeline_enabled(active_settings)
@@ -520,6 +587,39 @@ def main() -> None:
             "Restricted backend opt-in flags require concrete AppConfig settings."
         )
         sys.exit(2)
+
+    if (
+        preflight_mode != "off"
+        and isinstance(active_settings, AppConfig)
+        and _preflight_command_requested(args)
+    ):
+        preflight_report = run_startup_preflight(
+            settings=active_settings,
+            include_transcription_checks=_preflight_includes_transcription_checks(args),
+        )
+        profile_hint = (
+            f" --profile {args.profile}" if isinstance(args.profile, str) else ""
+        )
+        doctor_command = f"ser doctor{profile_hint}"
+        fail_preflight = should_fail_preflight(
+            report=preflight_report, mode=preflight_mode
+        )
+        if preflight_report.findings:
+            preflight_summary = format_startup_preflight_one_liner(
+                preflight_report,
+                doctor_command=doctor_command,
+            )
+            if fail_preflight:
+                logger.error("%s", preflight_summary)
+            else:
+                logger.info("%s", preflight_summary)
+                _suppress_preflight_transcription_operational_relogs(
+                    settings=active_settings,
+                    report=preflight_report,
+                )
+        if fail_preflight:
+            logger.error("Startup preflight failed (mode=%s).", preflight_mode)
+            sys.exit(2)
 
     if args.calibrate_transcription_runtime:
         if not args.file:

--- a/ser/config.py
+++ b/ser/config.py
@@ -17,6 +17,7 @@ from ser.profiles import (
     TranscriptionBackendId,
     get_profile_catalog,
 )
+from ser.utils.torch_inference import normalize_torch_device_selector
 
 APP_NAME = "ser"
 DEFAULT_ACCURATE_MODEL_ID = "openai/whisper-large-v3"
@@ -571,10 +572,8 @@ def _read_torch_device_env(name: str, default: str = "auto") -> str:
     raw_value = os.getenv(name)
     if raw_value is None:
         return default
-    normalized = raw_value.strip().lower()
-    if normalized in {"auto", "cpu", "mps", "cuda"}:
-        return normalized
-    if re.fullmatch(r"cuda:\d+", normalized):
+    normalized = normalize_torch_device_selector(raw_value)
+    if normalized is not None:
         return normalized
     return default
 

--- a/ser/diagnostics/__init__.py
+++ b/ser/diagnostics/__init__.py
@@ -1,0 +1,37 @@
+"""Diagnostics package exports."""
+
+from .command import run_doctor_command
+from .domain import (
+    DiagnosticFinding,
+    DiagnosticReport,
+    DiagnosticSeverity,
+    PreflightMode,
+)
+from .service import (
+    apply_profile_override_for_diagnostics,
+    format_report_brief,
+    format_report_json,
+    format_report_text,
+    format_startup_preflight_one_liner,
+    parse_preflight_mode,
+    run_doctor_diagnostics,
+    run_startup_preflight,
+    should_fail_preflight,
+)
+
+__all__ = [
+    "DiagnosticFinding",
+    "DiagnosticReport",
+    "DiagnosticSeverity",
+    "PreflightMode",
+    "apply_profile_override_for_diagnostics",
+    "format_report_brief",
+    "format_report_json",
+    "format_startup_preflight_one_liner",
+    "format_report_text",
+    "parse_preflight_mode",
+    "run_doctor_command",
+    "run_doctor_diagnostics",
+    "run_startup_preflight",
+    "should_fail_preflight",
+]

--- a/ser/diagnostics/command.py
+++ b/ser/diagnostics/command.py
@@ -1,0 +1,80 @@
+"""CLI command helpers for SER runtime diagnostics."""
+
+from __future__ import annotations
+
+import argparse
+from typing import cast
+
+from ser.config import AppConfig, get_settings
+from ser.diagnostics.service import (
+    apply_profile_override_for_diagnostics,
+    format_report_json,
+    format_report_text,
+    run_doctor_diagnostics,
+)
+from ser.profiles import ProfileName
+
+_PROFILE_CHOICES: tuple[ProfileName, ...] = (
+    "fast",
+    "medium",
+    "accurate",
+    "accurate-research",
+)
+
+
+def run_doctor_command(argv: list[str], *, settings: AppConfig | None = None) -> int:
+    """Runs `ser doctor ...` command."""
+    parser = argparse.ArgumentParser(prog="ser doctor")
+    parser.add_argument(
+        "--profile",
+        choices=_PROFILE_CHOICES,
+        default=None,
+        help=(
+            "Profile context for diagnostics "
+            "(fast, medium, accurate, accurate-research)."
+        ),
+    )
+    parser.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Output format for diagnostics findings.",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Return non-zero exit code when warning or error findings are present.",
+    )
+    parser.add_argument(
+        "--include-noise-findings",
+        action="store_true",
+        help="Include informational dependency-noise findings in output.",
+    )
+    parser.add_argument(
+        "--skip-transcription-checks",
+        action="store_true",
+        help="Skip transcription backend checks.",
+    )
+    args = parser.parse_args(argv)
+
+    active_settings = settings if settings is not None else get_settings()
+    active_settings = apply_profile_override_for_diagnostics(
+        active_settings,
+        profile=cast(ProfileName | None, args.profile),
+    )
+    report = run_doctor_diagnostics(
+        settings=active_settings,
+        include_transcription_checks=not bool(args.skip_transcription_checks),
+        include_noise_findings=bool(args.include_noise_findings),
+    )
+    formatted_output = (
+        format_report_json(report)
+        if args.format == "json"
+        else format_report_text(report)
+    )
+    print(formatted_output)
+    if report.has_blocking_findings or report.has_error:
+        return 2
+    if args.strict and report.has_warning_or_higher:
+        return 1
+    return 0

--- a/ser/diagnostics/domain.py
+++ b/ser/diagnostics/domain.py
@@ -1,0 +1,72 @@
+"""Domain models for SER environment diagnostics and preflight checks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+type DiagnosticSeverity = Literal["info", "warning", "error"]
+type PreflightMode = Literal["off", "warn", "strict"]
+
+
+@dataclass(frozen=True, slots=True)
+class DiagnosticFinding:
+    """Represents one actionable diagnostic finding."""
+
+    code: str
+    severity: DiagnosticSeverity
+    message: str
+    remediation: tuple[str, ...] = ()
+    blocking: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class DiagnosticReport:
+    """Aggregates findings produced by one diagnostics execution."""
+
+    findings: tuple[DiagnosticFinding, ...]
+
+    @property
+    def has_blocking_findings(self) -> bool:
+        """Returns whether any finding requires failing execution."""
+        return any(finding.blocking for finding in self.findings)
+
+    @property
+    def has_warning_or_higher(self) -> bool:
+        """Returns whether any warning or error finding exists."""
+        return any(
+            finding.severity in {"warning", "error"} for finding in self.findings
+        )
+
+    @property
+    def has_error(self) -> bool:
+        """Returns whether any error finding exists."""
+        return any(finding.severity == "error" for finding in self.findings)
+
+    def counts_by_severity(self) -> dict[DiagnosticSeverity, int]:
+        """Returns one severity-count index for report summarization."""
+        counts: dict[DiagnosticSeverity, int] = {"info": 0, "warning": 0, "error": 0}
+        for finding in self.findings:
+            counts[finding.severity] += 1
+        return counts
+
+    def to_dict(self) -> dict[str, object]:
+        """Returns one JSON-serializable report payload."""
+        return {
+            "summary": {
+                "counts": self.counts_by_severity(),
+                "has_blocking_findings": self.has_blocking_findings,
+                "has_warning_or_higher": self.has_warning_or_higher,
+                "has_error": self.has_error,
+            },
+            "findings": [
+                {
+                    "code": finding.code,
+                    "severity": finding.severity,
+                    "message": finding.message,
+                    "blocking": finding.blocking,
+                    "remediation": list(finding.remediation),
+                }
+                for finding in self.findings
+            ],
+        }

--- a/ser/diagnostics/service.py
+++ b/ser/diagnostics/service.py
@@ -1,0 +1,367 @@
+"""Diagnostics service for startup preflight and doctor command workflows."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from dataclasses import replace
+from typing import cast
+
+from ser.config import (
+    AppConfig,
+    resolve_profile_transcription_config,
+)
+from ser.diagnostics.domain import (
+    DiagnosticFinding,
+    DiagnosticReport,
+    PreflightMode,
+)
+from ser.profiles import ProfileName, get_profile_catalog, resolve_profile_name
+from ser.runtime.registry import resolve_runtime_capability
+from ser.transcript.backends import (
+    BackendRuntimeRequest,
+    resolve_transcription_backend_adapter,
+)
+from ser.transcript.runtime_policy import (
+    DEFAULT_MPS_LOW_MEMORY_THRESHOLD_GB,
+    resolve_transcription_runtime_policy,
+)
+from ser.utils.transcription_compat import (
+    FASTER_WHISPER_OPENMP_CONFLICT_ISSUE_CODE,
+    resolve_transcription_compatibility_lane,
+)
+
+_SUPPORTED_PREFLIGHT_MODES: frozenset[str] = frozenset({"off", "warn", "strict"})
+
+
+def parse_preflight_mode(raw_mode: str) -> PreflightMode:
+    """Parses one user-facing preflight mode string."""
+    normalized = raw_mode.strip().lower()
+    if normalized in _SUPPORTED_PREFLIGHT_MODES:
+        return cast(PreflightMode, normalized)
+    return "warn"
+
+
+def apply_profile_override_for_diagnostics(
+    settings: AppConfig,
+    *,
+    profile: ProfileName | None,
+) -> AppConfig:
+    """Returns settings with runtime profile flags overridden for diagnostics only."""
+    if profile is None:
+        return settings
+    runtime_flags = replace(
+        settings.runtime_flags,
+        profile_pipeline=True,
+        medium_profile=profile == "medium",
+        accurate_profile=profile == "accurate",
+        accurate_research_profile=profile == "accurate-research",
+        restricted_backends=bool(settings.runtime_flags.restricted_backends),
+    )
+    return replace(settings, runtime_flags=runtime_flags)
+
+
+def run_startup_preflight(
+    *,
+    settings: AppConfig,
+    include_transcription_checks: bool,
+) -> DiagnosticReport:
+    """Runs one fast startup preflight report for command execution gating."""
+    findings = _run_checks(
+        settings=settings,
+        include_transcription_checks=include_transcription_checks,
+        include_noise_findings=False,
+        include_lane_info=False,
+    )
+    return DiagnosticReport(findings=tuple(findings))
+
+
+def run_doctor_diagnostics(
+    *,
+    settings: AppConfig,
+    include_transcription_checks: bool,
+    include_noise_findings: bool,
+) -> DiagnosticReport:
+    """Runs one comprehensive diagnostics report for interactive troubleshooting."""
+    findings = _run_checks(
+        settings=settings,
+        include_transcription_checks=include_transcription_checks,
+        include_noise_findings=include_noise_findings,
+        include_lane_info=True,
+    )
+    return DiagnosticReport(findings=tuple(findings))
+
+
+def should_fail_preflight(*, report: DiagnosticReport, mode: PreflightMode) -> bool:
+    """Returns whether one startup preflight report should block command execution."""
+    if mode == "off":
+        return False
+    if report.has_blocking_findings:
+        return True
+    return mode == "strict" and report.has_warning_or_higher
+
+
+def format_report_text(report: DiagnosticReport) -> str:
+    """Formats one diagnostic report into human-readable CLI text."""
+    counts = report.counts_by_severity()
+    lines: list[str] = [
+        "SER diagnostics report",
+        (
+            "summary: "
+            f"info={counts['info']} warning={counts['warning']} error={counts['error']}"
+        ),
+    ]
+    if not report.findings:
+        lines.append("status: ok (no findings)")
+        return "\n".join(lines)
+    for finding in report.findings:
+        level = finding.severity.upper()
+        status_label = (
+            " blocking"
+            if finding.blocking
+            else (" advisory" if finding.severity == "warning" else "")
+        )
+        lines.append(f"[{level}] {finding.code}:{status_label} {finding.message}")
+        for remediation in finding.remediation:
+            lines.append(f"  remediation: {remediation}")
+    return "\n".join(lines)
+
+
+def format_report_brief(
+    report: DiagnosticReport,
+    *,
+    max_findings: int = 3,
+    max_message_chars: int = 180,
+) -> str:
+    """Formats one compact report variant for startup log hygiene."""
+    counts = report.counts_by_severity()
+    lines: list[str] = [
+        "SER diagnostics preflight summary",
+        (
+            "summary: "
+            f"info={counts['info']} warning={counts['warning']} error={counts['error']}"
+        ),
+    ]
+    if not report.findings:
+        lines.append("status: ok (no findings)")
+        return "\n".join(lines)
+    for finding in report.findings[:max_findings]:
+        status_label = (
+            "blocking"
+            if finding.blocking
+            else ("advisory" if finding.severity == "warning" else "info")
+        )
+        lines.append(
+            f"[{finding.severity.upper()}] {finding.code} ({status_label}): "
+            f"{_condense_message(finding.message, max_chars=max_message_chars)}"
+        )
+    omitted_count = len(report.findings) - max_findings
+    if omitted_count > 0:
+        lines.append(f"... {omitted_count} additional finding(s) omitted.")
+    return "\n".join(lines)
+
+
+def format_startup_preflight_one_liner(
+    report: DiagnosticReport,
+    *,
+    doctor_command: str,
+) -> str:
+    """Formats one single-line preflight summary for concise startup logging."""
+    if not report.findings:
+        return "Startup preflight: no findings."
+    primary = report.findings[0]
+    additional = len(report.findings) - 1
+    additional_suffix = f" (+{additional} more)" if additional > 0 else ""
+    if primary.blocking or report.has_error:
+        return (
+            f"Startup preflight blocking issue [{primary.code}]{additional_suffix}. "
+            f"Execution halted. Run `{doctor_command}` for full details."
+        )
+    return (
+        f"Startup preflight advisory [{primary.code}]{additional_suffix}. "
+        f"Runtime will continue. Run `{doctor_command}` for full details."
+    )
+
+
+def format_report_json(report: DiagnosticReport) -> str:
+    """Formats one diagnostic report as stable JSON output."""
+    return json.dumps(report.to_dict(), indent=2, sort_keys=True)
+
+
+def _run_checks(
+    *,
+    settings: AppConfig,
+    include_transcription_checks: bool,
+    include_noise_findings: bool,
+    include_lane_info: bool,
+) -> list[DiagnosticFinding]:
+    """Runs one deterministic diagnostics check suite."""
+    findings: list[DiagnosticFinding] = []
+    if include_lane_info:
+        lane = resolve_transcription_compatibility_lane()
+        findings.append(
+            DiagnosticFinding(
+                code="environment_transcription_lane",
+                severity="info",
+                message=f"Resolved transcription compatibility lane: {lane}.",
+            )
+        )
+    findings.extend(_check_runtime_capability(settings))
+    if include_transcription_checks:
+        findings.extend(_check_ffmpeg_binary())
+        findings.extend(
+            _check_transcription_backend_compatibility(
+                settings=settings,
+                include_noise_findings=include_noise_findings,
+            )
+        )
+    return findings
+
+
+def _check_runtime_capability(settings: AppConfig) -> tuple[DiagnosticFinding, ...]:
+    """Validates runtime profile dependency availability for selected profile."""
+    known_backend_ids: frozenset[str] = frozenset(
+        {"handcrafted", *(entry.backend_id for entry in get_profile_catalog().values())}
+    )
+    capability = resolve_runtime_capability(
+        settings,
+        available_backend_hooks=known_backend_ids,
+    )
+    if capability.available:
+        return ()
+    return (
+        DiagnosticFinding(
+            code="runtime_capability_unavailable",
+            severity="error",
+            message=capability.message
+            or "Selected runtime profile capability is unavailable.",
+            blocking=True,
+        ),
+    )
+
+
+def _check_ffmpeg_binary() -> tuple[DiagnosticFinding, ...]:
+    """Ensures one ffmpeg executable is available on PATH for transcription workflows."""
+    if shutil.which("ffmpeg") is not None:
+        return ()
+    return (
+        DiagnosticFinding(
+            code="ffmpeg_binary_missing",
+            severity="error",
+            message=(
+                "ffmpeg executable was not found on PATH; transcription workflows "
+                "require ffmpeg."
+            ),
+            remediation=(
+                "Install ffmpeg and rerun diagnostics (`brew install ffmpeg` on macOS).",
+            ),
+            blocking=True,
+        ),
+    )
+
+
+def _check_transcription_backend_compatibility(
+    *,
+    settings: AppConfig,
+    include_noise_findings: bool,
+) -> tuple[DiagnosticFinding, ...]:
+    """Collects transcription backend compatibility findings for active profile."""
+    profile_name = resolve_profile_name(settings)
+    backend_id, model_name, use_demucs, use_vad = resolve_profile_transcription_config(
+        profile_name
+    )
+    torch_runtime = settings.torch_runtime
+    requested_device = (
+        torch_runtime.device if isinstance(torch_runtime.device, str) else "cpu"
+    )
+    requested_dtype = (
+        torch_runtime.dtype if isinstance(torch_runtime.dtype, str) else "auto"
+    )
+    requested_threshold = settings.transcription.mps_low_memory_threshold_gb
+    runtime_policy = resolve_transcription_runtime_policy(
+        backend_id=backend_id,
+        requested_device=requested_device,
+        requested_dtype=requested_dtype,
+        mps_low_memory_threshold_gb=(
+            requested_threshold
+            if (
+                isinstance(requested_threshold, int | float)
+                and not isinstance(requested_threshold, bool)
+            )
+            else DEFAULT_MPS_LOW_MEMORY_THRESHOLD_GB
+        ),
+    )
+    runtime_request = BackendRuntimeRequest(
+        model_name=model_name,
+        use_demucs=use_demucs,
+        use_vad=use_vad,
+        device_spec=runtime_policy.device_spec,
+        device_type=runtime_policy.device_type,
+        precision_candidates=runtime_policy.precision_candidates,
+        memory_tier=runtime_policy.memory_tier,
+    )
+    adapter = resolve_transcription_backend_adapter(backend_id)
+    report = adapter.check_compatibility(
+        runtime_request=runtime_request,
+        settings=settings,
+    )
+    findings: list[DiagnosticFinding] = []
+    for issue in report.functional_issues:
+        if _is_advisory_faster_whisper_openmp_conflict(
+            backend_id=backend_id,
+            issue_code=issue.code,
+        ):
+            findings.append(
+                DiagnosticFinding(
+                    code=f"transcription_operational_{issue.code}",
+                    severity="warning",
+                    message=issue.message,
+                )
+            )
+            continue
+        findings.append(
+            DiagnosticFinding(
+                code=f"transcription_functional_{issue.code}",
+                severity="error",
+                message=issue.message,
+                blocking=True,
+            )
+        )
+    for issue in report.operational_issues:
+        findings.append(
+            DiagnosticFinding(
+                code=f"transcription_operational_{issue.code}",
+                severity="warning",
+                message=issue.message,
+            )
+        )
+    if include_noise_findings:
+        for issue in report.noise_issues:
+            findings.append(
+                DiagnosticFinding(
+                    code=f"transcription_noise_{issue.code}",
+                    severity="info",
+                    message=issue.message,
+                )
+            )
+    return tuple(findings)
+
+
+def _is_advisory_faster_whisper_openmp_conflict(
+    *,
+    backend_id: str,
+    issue_code: str,
+) -> bool:
+    """Returns whether one faster-whisper OpenMP conflict is non-blocking in CLI runtime."""
+    return (
+        backend_id == "faster_whisper"
+        and issue_code == FASTER_WHISPER_OPENMP_CONFLICT_ISSUE_CODE
+    )
+
+
+def _condense_message(message: str, *, max_chars: int) -> str:
+    """Returns one single-line message summary bounded by max chars."""
+    normalized = " ".join(message.split())
+    if len(normalized) <= max_chars:
+        return normalized
+    return f"{normalized[: max_chars - 3].rstrip()}..."

--- a/ser/profiles.py
+++ b/ser/profiles.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import importlib
-import re
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Literal, cast
+
+from ser.utils.torch_inference import normalize_torch_device_selector
 
 if TYPE_CHECKING:
     from ser.config import AppConfig
@@ -234,12 +235,7 @@ def _read_required_int(
 
 def _normalize_torch_device_selector(value: str) -> str | None:
     """Normalizes one torch device selector or returns None when invalid."""
-    normalized = value.strip().lower()
-    if normalized in {"auto", "cpu", "mps", "cuda"}:
-        return normalized
-    if re.fullmatch(r"cuda:\d+", normalized):
-        return normalized
-    return None
+    return normalize_torch_device_selector(value)
 
 
 def _normalize_torch_dtype_selector(value: str) -> str | None:

--- a/ser/repr/emotion2vec.py
+++ b/ser/repr/emotion2vec.py
@@ -26,6 +26,7 @@ from ser.utils.logger import (
     get_logger,
     scoped_dependency_log_policy,
 )
+from ser.utils.torch_inference import normalize_torch_device_selector
 
 logger = get_logger(__name__)
 _NOISY_DEPENDENCY_POLICY: Final[DependencyLogPolicy] = DependencyLogPolicy(
@@ -121,7 +122,8 @@ class Emotion2VecBackend:
         Args:
             model_id: Emotion2Vec model identifier on the selected hub.
             hub: Optional hub override (`ms`/`modelscope` or `hf`/`huggingface`).
-            device: FunASR runtime device selector (`cpu`, `cuda`, or `cuda:N`).
+            device: FunASR runtime device selector (`cpu`, `cuda`/`cuda:N`, or
+                `xpu`/`xpu:N`).
             max_chunk_seconds: Maximum chunk duration for bounded-memory encoding.
             modelscope_cache_root: Optional ModelScope cache root for `hub=ms`.
             huggingface_cache_root: Optional Hugging Face cache root for `hub=hf`.
@@ -136,10 +138,10 @@ class Emotion2VecBackend:
             raise ValueError(
                 "feature_extractor and model must be provided together or omitted together."
             )
-        normalized_device = device.strip().lower()
-        if normalized_device != "cpu" and not normalized_device.startswith("cuda"):
+        normalized_device = normalize_torch_device_selector(device)
+        if normalized_device in {None, "auto", "mps"}:
             raise ValueError(
-                "device must be one of 'cpu', 'cuda', or a 'cuda:N' selector."
+                "device must be one of 'cpu', 'cuda'/'cuda:N', or 'xpu'/'xpu:N'."
             )
         self._model_id = model_id
         self._hub = self._resolve_hub(model_id=model_id, hub=hub)
@@ -334,8 +336,32 @@ class Emotion2VecBackend:
                     kwargs.pop("disable_pbar", None)
                     return auto_model_class(**kwargs)
 
+            def _init_auto_model_with_cpu_fallback(
+                *,
+                source: str,
+                include_hub: bool,
+            ) -> object:
+                try:
+                    return _init_auto_model(source=source, include_hub=include_hub)
+                except Exception as err:
+                    if self._device == "cpu":
+                        raise
+                    requested_device = self._device
+                    logger.warning(
+                        "Emotion2Vec initialization failed on device=%s; "
+                        "retrying on cpu (%s).",
+                        requested_device,
+                        err,
+                    )
+                    self._device = "cpu"
+                    try:
+                        return _init_auto_model(source=source, include_hub=include_hub)
+                    except Exception:
+                        self._device = requested_device
+                        raise
+
             try:
-                model = _init_auto_model(
+                model = _init_auto_model_with_cpu_fallback(
                     source=model_source,
                     include_hub=not is_local_source,
                 )
@@ -348,7 +374,7 @@ class Emotion2VecBackend:
                         self._model_id,
                     )
                     try:
-                        model = _init_auto_model(
+                        model = _init_auto_model_with_cpu_fallback(
                             source=self._model_id,
                             include_hub=True,
                         )

--- a/ser/repr/runtime_policy.py
+++ b/ser/repr/runtime_policy.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Literal
 
-from ser.utils.torch_inference import TorchRuntime, maybe_resolve_torch_runtime
+from ser.utils.torch_inference import (
+    TorchRuntime,
+    maybe_resolve_torch_runtime,
+    normalize_torch_device_selector,
+)
 
 type FeatureBackendId = Literal["handcrafted", "hf_xlsr", "hf_whisper", "emotion2vec"]
 
@@ -118,11 +122,11 @@ def _resolve_emotion2vec_policy(
             dtype="float32",
             reason="torch_runtime_unavailable",
         )
-    if runtime.device_type == "cuda":
+    if runtime.device_type in {"cuda", "xpu"}:
         return FeatureRuntimePolicy(
             device=runtime.device_spec,
             dtype=requested_dtype,
-            reason="emotion2vec_cuda_enabled",
+            reason=f"emotion2vec_{runtime.device_type}_enabled",
         )
     return FeatureRuntimePolicy(
         device="cpu",
@@ -141,12 +145,8 @@ def _probe_runtime(requested_device: str) -> TorchRuntime | None:
 
 def _normalize_device_selector(value: str) -> str:
     """Normalizes one runtime device selector."""
-    normalized = value.strip().lower()
-    if normalized in {"auto", "cpu", "mps", "cuda"}:
-        return normalized
-    if normalized.startswith("cuda:"):
-        return normalized
-    return "auto"
+    normalized = normalize_torch_device_selector(value)
+    return normalized if normalized is not None else "auto"
 
 
 def _normalize_dtype_selector(value: str) -> str:
@@ -161,12 +161,7 @@ def _normalize_optional_device_selector(value: str | None) -> str | None:
     """Normalizes an optional runtime device selector override."""
     if not isinstance(value, str) or not value.strip():
         return None
-    normalized = value.strip().lower()
-    if normalized in {"auto", "cpu", "mps", "cuda"}:
-        return normalized
-    if normalized.startswith("cuda:"):
-        return normalized
-    return None
+    return normalize_torch_device_selector(value)
 
 
 def _normalize_optional_dtype_selector(value: str | None) -> str | None:

--- a/ser/transcript/backends/stable_whisper.py
+++ b/ser/transcript/backends/stable_whisper.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ctypes
 import gc
 import importlib
 import importlib.util
@@ -11,6 +12,7 @@ import os
 import sys
 from collections.abc import Callable
 from contextlib import nullcontext
+from functools import lru_cache
 from pathlib import Path
 from types import ModuleType
 from typing import TYPE_CHECKING, Literal, cast
@@ -56,6 +58,7 @@ from ser.utils.logger import (
     scoped_dependency_log_policy,
 )
 from ser.utils.transcription_compat import (
+    format_torio_ffmpeg_remediation,
     has_known_stable_whisper_sparse_mps_incompatibility,
 )
 
@@ -75,8 +78,11 @@ _DEMUCS_DEPRECATED_MESSAGE_REGEX = (
 _TRANSCRIBE_WARNING_MODULE_REGEX = (
     r"^stable_whisper\.whisper_word_level\.original_whisper$"
 )
+_TORIO_FFMPEG_PROBE_POLICY_ID = "torio.ffmpeg_probe_debug_traceback"
 _STABLE_WHISPER_IMPORT_POLICY = DependencyLogPolicy(
-    logger_prefixes=frozenset(),
+    logger_prefixes=frozenset({"torio"}),
+    demote_from_level=logging.DEBUG,
+    demote_to_level=logging.DEBUG,
     backend_ids=frozenset({"stable_whisper"}),
     warning_policies=(
         WarningPolicy(
@@ -143,6 +149,7 @@ class StableWhisperAdapter(TranscriptionBackendAdapter):
         del runtime_request
         del settings
         functional_issues: list[CompatibilityIssue] = []
+        operational_issues: list[CompatibilityIssue] = []
         noise_issues: list[CompatibilityIssue] = [
             CompatibilityIssue(
                 code="stable_whisper_invalid_escape_sequence",
@@ -169,6 +176,28 @@ class StableWhisperAdapter(TranscriptionBackendAdapter):
                 ),
             ),
         ]
+        with scoped_dependency_log_policy(
+            policy=_STABLE_WHISPER_IMPORT_POLICY,
+            context=DependencyPolicyContext(
+                backend_id=self.backend_id,
+                phase_name=PHASE_TRANSCRIPTION_MODEL_LOAD,
+                op_tag="stable_whisper.compatibility",
+            ),
+            keep_demoted=False,
+        ):
+            torio_issue = self._detect_torio_ffmpeg_operational_issue()
+        if torio_issue is not None:
+            operational_issues.append(torio_issue)
+            noise_issues.append(
+                CompatibilityIssue(
+                    code="torio_ffmpeg_probe_debug_traceback",
+                    message=(
+                        "torio may emit DEBUG traceback probe logs while checking "
+                        "FFmpeg extension availability; adapter applies scoped "
+                        "suppression to keep dependency noise bounded."
+                    ),
+                )
+            )
         if not self._is_module_available("stable_whisper"):
             functional_issues.append(
                 CompatibilityIssue(
@@ -182,11 +211,13 @@ class StableWhisperAdapter(TranscriptionBackendAdapter):
         return CompatibilityReport(
             backend_id="stable_whisper",
             functional_issues=tuple(functional_issues),
+            operational_issues=tuple(operational_issues),
             noise_issues=tuple(noise_issues),
             policy_ids=(
                 _INVALID_ESCAPE_POLICY_ID,
                 _FP16_CPU_WARNING_POLICY_ID,
                 _DEMUCS_DEPRECATED_POLICY_ID,
+                _TORIO_FFMPEG_PROBE_POLICY_ID,
             ),
         )
 
@@ -250,6 +281,7 @@ class StableWhisperAdapter(TranscriptionBackendAdapter):
                 phase_name=PHASE_TRANSCRIPTION_MODEL_LOAD,
                 op_tag="stable_whisper.import",
             ),
+            keep_demoted=False,
         ):
             try:
                 stable_whisper = importlib.import_module("stable_whisper")
@@ -860,6 +892,7 @@ class StableWhisperAdapter(TranscriptionBackendAdapter):
                 phase_name=PHASE_TRANSCRIPTION,
                 op_tag="stable_whisper.result.import",
             ),
+            keep_demoted=False,
         ):
             stable_result_module = importlib.import_module("stable_whisper.result")
         whisper_result_ctor = getattr(stable_result_module, "WhisperResult", None)
@@ -906,3 +939,122 @@ class StableWhisperAdapter(TranscriptionBackendAdapter):
             return importlib.util.find_spec(module_name) is not None
         except ValueError:
             return module_name in sys.modules
+
+    @staticmethod
+    @lru_cache(maxsize=1)
+    def _detect_torio_ffmpeg_operational_issue() -> CompatibilityIssue | None:
+        """Detects one torio FFmpeg runtime issue that does not block transcription."""
+        if not StableWhisperAdapter._is_module_available("torchaudio"):
+            return None
+        try:
+            torchaudio_module = importlib.import_module("torchaudio")
+        except Exception:
+            return None
+        list_backends = getattr(torchaudio_module, "list_audio_backends", None)
+        if not callable(list_backends):
+            return None
+        try:
+            available_backends = list_backends()
+        except Exception:
+            return None
+        if not isinstance(available_backends, list | tuple):
+            return None
+        normalized_backends = frozenset(
+            str(entry).strip().lower()
+            for entry in available_backends
+            if isinstance(entry, str) and entry.strip()
+        )
+        if "ffmpeg" in normalized_backends:
+            return None
+        loader_error = StableWhisperAdapter._probe_torio_ffmpeg_loader_error()
+        if loader_error is None:
+            remediation = format_torio_ffmpeg_remediation(missing_library=None)
+            return CompatibilityIssue(
+                code="torio_ffmpeg_extension_unavailable",
+                message=(
+                    "torchaudio FFmpeg extension is unavailable in the active runtime; "
+                    "this is a non-blocking advisory and stable-whisper continues "
+                    "with soundfile/sox backends. "
+                    f"{remediation}"
+                ),
+            )
+        missing_library = StableWhisperAdapter._extract_missing_dynamic_library(
+            loader_error
+        )
+        remediation = format_torio_ffmpeg_remediation(missing_library=missing_library)
+        if missing_library is None:
+            return CompatibilityIssue(
+                code="torio_ffmpeg_extension_unavailable",
+                message=(
+                    "torchaudio FFmpeg extension could not be loaded; "
+                    "this is a non-blocking advisory and stable-whisper continues "
+                    "with soundfile/sox backends "
+                    f"(loader_error={loader_error}). {remediation}"
+                ),
+            )
+        if "libavutil" not in missing_library:
+            return CompatibilityIssue(
+                code="torio_ffmpeg_extension_unavailable",
+                message=(
+                    "torchaudio FFmpeg extension could not be loaded due to missing "
+                    f"{missing_library}; this is a non-blocking advisory and "
+                    "stable-whisper continues with "
+                    f"soundfile/sox backends. {remediation}"
+                ),
+            )
+        return CompatibilityIssue(
+            code="torio_ffmpeg_abi_mismatch",
+            message=(
+                "torchaudio FFmpeg extension could not be loaded because "
+                f"{missing_library} is unavailable (FFmpeg ABI mismatch). "
+                "This is a non-blocking advisory and stable-whisper continues "
+                "with soundfile/sox backends. "
+                f"{remediation}"
+            ),
+        )
+
+    @staticmethod
+    def _probe_torio_ffmpeg_loader_error() -> str | None:
+        """Returns one deterministic torio FFmpeg loader error summary when available."""
+        if not StableWhisperAdapter._is_module_available("torio._extension.utils"):
+            return None
+        try:
+            torio_utils = importlib.import_module("torio._extension.utils")
+        except Exception:
+            return None
+        get_lib_path = getattr(torio_utils, "_get_lib_path", None)
+        ffmpeg_versions = getattr(torio_utils, "_FFMPEG_VERS", ())
+        if not callable(get_lib_path):
+            return None
+        if not isinstance(ffmpeg_versions, list | tuple):
+            return None
+        for version in ffmpeg_versions:
+            if not isinstance(version, str):
+                continue
+            library_name = f"libtorio_ffmpeg{version}"
+            try:
+                library_path_value = get_lib_path(library_name)
+            except Exception:
+                continue
+            library_path = Path(str(library_path_value))
+            if not library_path.exists():
+                continue
+            try:
+                ctypes.CDLL(str(library_path))
+            except OSError as err:
+                error_text = str(err).strip()
+                if error_text:
+                    return error_text
+            except Exception:
+                continue
+        return None
+
+    @staticmethod
+    def _extract_missing_dynamic_library(error_text: str) -> str | None:
+        """Extracts one missing dynamic library token from a loader error message."""
+        marker = "Library not loaded: "
+        marker_index = error_text.find(marker)
+        if marker_index < 0:
+            return None
+        missing = error_text[marker_index + len(marker) :].splitlines()[0].strip()
+        return missing or None

--- a/ser/transcript/transcript_extractor.py
+++ b/ser/transcript/transcript_extractor.py
@@ -80,6 +80,16 @@ type _WorkerPhaseMessage = tuple[Literal["phase"], _WorkerPhase]
 type _WorkerSuccessMessage = tuple[Literal["ok"], list[tuple[str, float, float]]]
 type _WorkerErrorMessage = tuple[Literal["err"], str, str, str]
 type _WorkerMessage = _WorkerPhaseMessage | _WorkerSuccessMessage | _WorkerErrorMessage
+type _CompatibilityIssueKind = Literal["noise", "operational"]
+
+_EMITTED_COMPATIBILITY_ISSUE_KEYS: set[tuple[str, str, str]] = set()
+_INFO_OPERATIONAL_ISSUE_CODES: frozenset[str] = frozenset(
+    {
+        "torio_ffmpeg_abi_mismatch",
+        "torio_ffmpeg_extension_unavailable",
+        "faster_whisper_openmp_runtime_conflict",
+    }
+)
 
 
 def _resolve_backend_id(raw_backend_id: object) -> TranscriptionBackendId:
@@ -166,19 +176,19 @@ def _check_adapter_compatibility(
     )
     if report.noise_issues:
         for issue in report.noise_issues:
-            logger.debug(
-                "Transcription backend '%s' noise issue [%s]: %s",
-                active_profile.backend_id,
-                issue.code,
-                issue.message,
+            _log_compatibility_issue_once(
+                backend_id=active_profile.backend_id,
+                issue_kind="noise",
+                issue_code=issue.code,
+                issue_message=issue.message,
             )
     if report.operational_issues:
         for issue in report.operational_issues:
-            logger.warning(
-                "Transcription backend '%s' operational issue [%s]: %s",
-                active_profile.backend_id,
-                issue.code,
-                issue.message,
+            _log_compatibility_issue_once(
+                backend_id=active_profile.backend_id,
+                issue_kind="operational",
+                issue_code=issue.code,
+                issue_message=issue.message,
             )
     if report.has_blocking_issues:
         details = (
@@ -187,6 +197,60 @@ def _check_adapter_compatibility(
         )
         raise TranscriptionError(details)
     return report
+
+
+def _log_compatibility_issue_once(
+    *,
+    backend_id: TranscriptionBackendId,
+    issue_kind: _CompatibilityIssueKind,
+    issue_code: str,
+    issue_message: str,
+) -> None:
+    """Logs one non-blocking compatibility issue once per backend/kind/code tuple."""
+    issue_key = (backend_id, issue_kind, issue_code)
+    if issue_key in _EMITTED_COMPATIBILITY_ISSUE_KEYS:
+        return
+    _EMITTED_COMPATIBILITY_ISSUE_KEYS.add(issue_key)
+    if issue_kind == "noise":
+        logger.debug(
+            "Transcription backend '%s' noise issue [%s]: %s",
+            backend_id,
+            issue_code,
+            issue_message,
+        )
+        return
+    log_level = (
+        logging.INFO if issue_code in _INFO_OPERATIONAL_ISSUE_CODES else logging.WARNING
+    )
+    logger.log(
+        log_level,
+        "Transcription backend '%s' non-blocking operational issue [%s]: %s "
+        "Run `ser doctor` for full remediation details.",
+        backend_id,
+        issue_code,
+        _summarize_operational_issue_message(issue_message, max_chars=180),
+    )
+
+
+def _summarize_operational_issue_message(issue_message: str, *, max_chars: int) -> str:
+    """Returns one concise operational issue message for CLI log hygiene."""
+    normalized = " ".join(issue_message.split())
+    if len(normalized) <= max_chars:
+        return normalized
+    return f"{normalized[: max_chars - 3].rstrip()}..."
+
+
+def mark_compatibility_issues_as_emitted(
+    *,
+    backend_id: TranscriptionBackendId,
+    issue_kind: _CompatibilityIssueKind,
+    issue_codes: tuple[str, ...],
+) -> None:
+    """Marks compatibility issues as already emitted to prevent duplicate logs."""
+    for issue_code in issue_codes:
+        if not issue_code:
+            continue
+        _EMITTED_COMPATIBILITY_ISSUE_KEYS.add((backend_id, issue_kind, issue_code))
 
 
 def _transcription_setup_required(

--- a/ser/utils/torch_inference.py
+++ b/ser/utils/torch_inference.py
@@ -3,10 +3,16 @@
 from __future__ import annotations
 
 import importlib
+import re
 from collections.abc import Mapping
 from contextlib import AbstractContextManager, nullcontext
 from dataclasses import dataclass
 from typing import cast
+
+_SUPPORTED_TORCH_DEVICE_SELECTORS: frozenset[str] = frozenset(
+    {"auto", "cpu", "mps", "cuda", "xpu"}
+)
+_INDEXED_TORCH_DEVICE_SELECTOR_PATTERN = re.compile(r"(cuda|xpu):\d+")
 
 
 @dataclass(frozen=True)
@@ -18,6 +24,16 @@ class TorchRuntime:
     device_spec: str
     device_type: str
     dtype_name: str
+
+
+def normalize_torch_device_selector(value: str) -> str | None:
+    """Returns a normalized torch device selector when valid."""
+    normalized = value.strip().lower()
+    if normalized in _SUPPORTED_TORCH_DEVICE_SELECTORS:
+        return normalized
+    if _INDEXED_TORCH_DEVICE_SELECTOR_PATTERN.fullmatch(normalized):
+        return normalized
+    return None
 
 
 def _cuda_is_available(torch_module: object) -> bool:
@@ -45,17 +61,34 @@ def _mps_is_available(torch_module: object) -> bool:
     return available and built
 
 
+def _xpu_is_available(torch_module: object) -> bool:
+    """Returns whether Intel XPU runtime is available."""
+    xpu = getattr(torch_module, "xpu", None)
+    is_available = getattr(xpu, "is_available", None)
+    return bool(is_available()) if callable(is_available) else False
+
+
 def _resolve_device_spec(torch_module: object, requested_device: str) -> str:
     """Resolves runtime device selector from one requested device string."""
-    normalized: str = requested_device.strip().lower()
+    normalized = normalize_torch_device_selector(requested_device)
     if normalized == "auto":
         if _cuda_is_available(torch_module):
             return "cuda"
+        if _xpu_is_available(torch_module):
+            return "xpu"
         return "mps" if _mps_is_available(torch_module) else "cpu"
-    if normalized.startswith("cuda"):
+    if normalized is None:
+        return "cpu"
+    if normalized == "cuda" or normalized.startswith("cuda:"):
         if not _cuda_is_available(torch_module):
             raise RuntimeError(
                 "SER_TORCH_DEVICE requested CUDA, but CUDA is unavailable."
+            )
+        return normalized
+    if normalized == "xpu" or normalized.startswith("xpu:"):
+        if not _xpu_is_available(torch_module):
+            raise RuntimeError(
+                "SER_TORCH_DEVICE requested XPU, but XPU is unavailable."
             )
         return normalized
     if normalized == "mps":
@@ -94,8 +127,10 @@ def _resolve_dtype_name(
             else "float16"
         )
     elif normalized == "bfloat16":
-        if device_type == "mps":
-            raise RuntimeError("SER_TORCH_DTYPE=bfloat16 is unsupported for MPS.")
+        if device_type in {"mps", "xpu"}:
+            raise RuntimeError(
+                "SER_TORCH_DTYPE=bfloat16 is unsupported for MPS/XPU runtimes."
+            )
         if device_type == "cuda" and not _cuda_bf16_is_supported(torch_module):
             raise RuntimeError(
                 "SER_TORCH_DTYPE=bfloat16 requested, but CUDA bf16 is unsupported."
@@ -120,7 +155,11 @@ def maybe_resolve_torch_runtime(
     resolved_device_type: str = (
         "cuda"
         if resolved_device_spec.startswith("cuda")
-        else ("mps" if resolved_device_spec == "mps" else "cpu")
+        else (
+            "xpu"
+            if resolved_device_spec.startswith("xpu")
+            else ("mps" if resolved_device_spec == "mps" else "cpu")
+        )
     )
     resolved_dtype_name: str = _resolve_dtype_name(
         torch_module,

--- a/ser/utils/transcription_compat.py
+++ b/ser/utils/transcription_compat.py
@@ -7,6 +7,7 @@ import platform
 import sys
 from functools import lru_cache
 from pathlib import Path
+from typing import Literal
 
 FASTER_WHISPER_OPENMP_CONFLICT_ISSUE_CODE = "faster_whisper_openmp_runtime_conflict"
 STABLE_WHISPER_SPARSE_MPS_INCOMPATIBLE_ISSUE_CODE = (
@@ -38,6 +39,49 @@ _STABLE_WHISPER_MODEL_ALIASES: dict[str, str] = {
     "openai/whisper-large-v3": "large-v3",
     "openai/whisper-large-v3-turbo": "turbo",
 }
+
+type TranscriptionCompatibilityLane = Literal[
+    "darwin_x86_64_py312_pinned",
+    "darwin_x86_64_py313_partial",
+    "generic",
+]
+
+
+def resolve_transcription_compatibility_lane() -> TranscriptionCompatibilityLane:
+    """Resolves one compatibility lane for environment-specific remediation guidance."""
+    machine = platform.machine().strip().lower()
+    python_major, python_minor = sys.version_info[:2]
+    if sys.platform == "darwin" and machine in {"x86_64", "amd64"}:
+        if (python_major, python_minor) < (3, 13):
+            return "darwin_x86_64_py312_pinned"
+        return "darwin_x86_64_py313_partial"
+    return "generic"
+
+
+def format_torio_ffmpeg_remediation(*, missing_library: str | None) -> str:
+    """Formats one lane-aware remediation message for torio FFmpeg loader issues."""
+    lane = resolve_transcription_compatibility_lane()
+    required_library = missing_library or "required FFmpeg runtime library"
+    if lane == "darwin_x86_64_py312_pinned":
+        return (
+            "This lane pins torch/torchaudio for compatibility "
+            "(darwin-x86_64 Python 3.12), so do not upgrade torch here. "
+            "Install FFmpeg 6 runtime libraries (for example `brew install ffmpeg@6`) "
+            "and rerun with `DYLD_FALLBACK_LIBRARY_PATH` including the `ffmpeg@6` "
+            f"library directory so {required_library} can be resolved."
+        )
+    if lane == "darwin_x86_64_py313_partial":
+        return (
+            "Darwin x86_64 Python 3.13 is a partial fast-profile lane. "
+            "For medium/accurate/accurate-research, switch to the supported "
+            "Python 3.12 setup (`./scripts/setup_compatible_env.sh --python 3.12`) "
+            "and install FFmpeg 6 runtime libraries."
+        )
+    return (
+        f"Install FFmpeg runtime libraries compatible with {required_library}. "
+        "If your environment policy allows torch upgrades, update torch/torchaudio "
+        "to versions compatible with your system FFmpeg."
+    )
 
 
 def has_known_faster_whisper_openmp_runtime_conflict() -> bool:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,6 +9,7 @@ import pytest
 import ser.__main__ as cli
 import ser.config as config_module
 import ser.models.emotion_model as emotion_model
+from ser.diagnostics.domain import DiagnosticFinding, DiagnosticReport
 from ser.runtime import InferenceRequest
 from ser.runtime.accurate_inference import AccurateRuntimeDependencyError
 from ser.runtime.medium_inference import MediumRuntimeDependencyError
@@ -893,6 +894,142 @@ def test_cli_dispatches_data_subcommand_after_global_log_level(
 
     assert exc_info.value.code == 0
     assert captured["argv"] == ["download", "--dataset", "ravdess"]
+
+
+def test_cli_dispatches_doctor_subcommand_after_global_log_level(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Diagnostics doctor subcommand should dispatch when global flags appear first."""
+    _patch_common_cli_dependencies(monkeypatch)
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        ["ser", "--log-level", "INFO", "doctor", "--strict"],
+    )
+    captured: dict[str, object] = {}
+
+    def _run_doctor_command(argv: list[str], *, settings: object | None = None) -> int:
+        captured["argv"] = argv
+        captured["settings"] = settings
+        return 0
+
+    monkeypatch.setattr(
+        "ser.diagnostics.command.run_doctor_command",
+        _run_doctor_command,
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main()
+
+    assert exc_info.value.code == 0
+    assert captured["argv"] == ["--strict"]
+    assert isinstance(captured["settings"], SimpleNamespace)
+
+
+def test_cli_preflight_warn_mode_logs_findings_and_allows_inference(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Warn preflight should log findings but continue execution when non-blocking."""
+    monkeypatch.setattr(cli, "load_dotenv", lambda: None)
+    settings = config_module.reload_settings()
+    monkeypatch.setattr(cli, "reload_settings", lambda: settings)
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        ["ser", "--file", "sample.wav", "--preflight", "warn"],
+    )
+    report = DiagnosticReport(
+        findings=(
+            DiagnosticFinding(
+                code="transcription_operational_torio_ffmpeg_abi_mismatch",
+                severity="warning",
+                message="Test warning",
+            ),
+        )
+    )
+    captured: dict[str, object] = {}
+    info_logs: list[str] = []
+
+    def _run_startup_preflight(
+        *,
+        settings: config_module.AppConfig,
+        include_transcription_checks: bool,
+    ) -> DiagnosticReport:
+        captured["settings"] = settings
+        captured["include_transcription_checks"] = include_transcription_checks
+        return report
+
+    class FakePipeline:
+        def run_inference(self, _request: object) -> object:
+            captured["inference_called"] = True
+            return SimpleNamespace(timeline_csv_path=None)
+
+    monkeypatch.setattr(cli, "run_startup_preflight", _run_startup_preflight)
+    monkeypatch.setattr(
+        cli, "_build_runtime_pipeline", lambda _settings: FakePipeline()
+    )
+    monkeypatch.setattr(
+        cli.logger,
+        "info",
+        lambda msg, *args, **_kwargs: info_logs.append(msg % args if args else msg),
+    )
+
+    cli.main()
+
+    assert captured["settings"] is settings
+    assert captured["include_transcription_checks"] is True
+    assert captured["inference_called"] is True
+    assert any("Startup preflight advisory" in message for message in info_logs)
+    assert any("ser doctor" in message for message in info_logs)
+
+
+def test_cli_preflight_strict_mode_exits_two_on_warning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Strict preflight should fail command execution when warnings are present."""
+    monkeypatch.setattr(cli, "load_dotenv", lambda: None)
+    settings = config_module.reload_settings()
+    monkeypatch.setattr(cli, "reload_settings", lambda: settings)
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        ["ser", "--file", "sample.wav", "--preflight", "strict"],
+    )
+    report = DiagnosticReport(
+        findings=(
+            DiagnosticFinding(
+                code="transcription_operational_torio_ffmpeg_abi_mismatch",
+                severity="warning",
+                message="Test warning",
+            ),
+        )
+    )
+    called = {"inference": False}
+
+    def _run_startup_preflight(
+        *,
+        settings: config_module.AppConfig,
+        include_transcription_checks: bool,
+    ) -> DiagnosticReport:
+        assert settings is not None
+        assert include_transcription_checks is True
+        return report
+
+    class FakePipeline:
+        def run_inference(self, _request: object) -> object:
+            called["inference"] = True
+            return SimpleNamespace(timeline_csv_path=None)
+
+    monkeypatch.setattr(cli, "run_startup_preflight", _run_startup_preflight)
+    monkeypatch.setattr(
+        cli, "_build_runtime_pipeline", lambda _settings: FakePipeline()
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main()
+
+    assert exc_info.value.code == 2
+    assert called["inference"] is False
 
 
 def test_cli_dataset_workflow_configure_download_and_registry_load(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -717,7 +717,16 @@ def test_cli_disable_timeouts_flag_applies_to_selected_profile(
     monkeypatch.setattr(
         cli.sys,
         "argv",
-        ["ser", "--file", "sample.wav", "--profile", "accurate", "--disable-timeouts"],
+        [
+            "ser",
+            "--file",
+            "sample.wav",
+            "--profile",
+            "accurate",
+            "--disable-timeouts",
+            "--preflight",
+            "off",
+        ],
     )
 
     captured: dict[str, object] = {}
@@ -816,7 +825,15 @@ def test_cli_interactive_restricted_backend_prompt_persists_consent(
     monkeypatch.setattr(
         cli.sys,
         "argv",
-        ["ser", "--file", "sample.wav", "--profile", "accurate-research"],
+        [
+            "ser",
+            "--file",
+            "sample.wav",
+            "--profile",
+            "accurate-research",
+            "--preflight",
+            "off",
+        ],
     )
     monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: True)
     monkeypatch.setattr(cli.sys.stdout, "isatty", lambda: True)

--- a/tests/test_config_feature_flags.py
+++ b/tests/test_config_feature_flags.py
@@ -390,6 +390,17 @@ def test_invalid_torch_runtime_env_falls_back_to_auto(
     assert settings.torch_runtime.dtype == "auto"
 
 
+def test_torch_runtime_env_accepts_xpu_selector(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """XPU device selectors should be accepted as valid torch runtime config."""
+    monkeypatch.setenv("SER_TORCH_DEVICE", "xpu:1")
+
+    settings = config.reload_settings()
+
+    assert settings.torch_runtime.device == "xpu:1"
+
+
 def test_torch_runtime_inherits_pytorch_mps_fallback_env(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_diagnostics_command.py
+++ b/tests/test_diagnostics_command.py
@@ -1,0 +1,78 @@
+"""Tests for `ser doctor` command behavior."""
+
+from __future__ import annotations
+
+import pytest
+
+import ser.config as config_module
+from ser.diagnostics.command import run_doctor_command
+from ser.diagnostics.domain import DiagnosticFinding, DiagnosticReport
+
+
+def test_run_doctor_command_strict_returns_one_for_warnings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Strict mode should fail with exit code 1 when only warnings are present."""
+    settings = config_module.reload_settings()
+    report = DiagnosticReport(
+        findings=(
+            DiagnosticFinding(
+                code="transcription_operational_torio_ffmpeg_abi_mismatch",
+                severity="warning",
+                message="Operational warning",
+            ),
+        )
+    )
+
+    monkeypatch.setattr(
+        "ser.diagnostics.command.run_doctor_diagnostics",
+        lambda **_kwargs: report,
+    )
+
+    exit_code = run_doctor_command(["--strict"], settings=settings)
+    assert exit_code == 1
+
+
+def test_run_doctor_command_returns_two_for_blocking_findings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Blocking diagnostics findings should return exit code 2."""
+    settings = config_module.reload_settings()
+    report = DiagnosticReport(
+        findings=(
+            DiagnosticFinding(
+                code="runtime_capability_unavailable",
+                severity="error",
+                message="Missing dependency",
+                blocking=True,
+            ),
+        )
+    )
+
+    monkeypatch.setattr(
+        "ser.diagnostics.command.run_doctor_diagnostics",
+        lambda **_kwargs: report,
+    )
+
+    exit_code = run_doctor_command([], settings=settings)
+    assert exit_code == 2
+
+
+def test_run_doctor_command_json_output(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """JSON output flag should print a JSON diagnostics payload."""
+    settings = config_module.reload_settings()
+    report = DiagnosticReport(findings=())
+
+    monkeypatch.setattr(
+        "ser.diagnostics.command.run_doctor_diagnostics",
+        lambda **_kwargs: report,
+    )
+
+    exit_code = run_doctor_command(["--format", "json"], settings=settings)
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert '"summary"' in output
+    assert '"findings"' in output

--- a/tests/test_diagnostics_service.py
+++ b/tests/test_diagnostics_service.py
@@ -1,0 +1,196 @@
+"""Tests for diagnostics report semantics and formatting."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from types import SimpleNamespace
+
+import pytest
+
+import ser.config as config_module
+import ser.diagnostics.service as diagnostics_service
+from ser.diagnostics.domain import DiagnosticFinding, DiagnosticReport
+from ser.diagnostics.service import (
+    format_report_brief,
+    format_report_json,
+    format_report_text,
+    parse_preflight_mode,
+    run_startup_preflight,
+    should_fail_preflight,
+)
+from ser.transcript.backends import CompatibilityIssue, CompatibilityReport
+from ser.utils.transcription_compat import FASTER_WHISPER_OPENMP_CONFLICT_ISSUE_CODE
+
+
+def test_parse_preflight_mode_falls_back_to_warn_for_invalid_values() -> None:
+    """Invalid preflight mode inputs should resolve to warn."""
+    assert parse_preflight_mode("strict") == "strict"
+    assert parse_preflight_mode("off") == "off"
+    assert parse_preflight_mode("warn") == "warn"
+    assert parse_preflight_mode("invalid-mode") == "warn"
+
+
+def test_should_fail_preflight_obeys_mode_semantics() -> None:
+    """Preflight failure logic should reflect off/warn/strict contracts."""
+    blocking_report = DiagnosticReport(
+        findings=(
+            DiagnosticFinding(
+                code="runtime_capability_unavailable",
+                severity="error",
+                message="Backend unavailable",
+                blocking=True,
+            ),
+        )
+    )
+    warning_report = DiagnosticReport(
+        findings=(
+            DiagnosticFinding(
+                code="transcription_operational_torio_ffmpeg_abi_mismatch",
+                severity="warning",
+                message="Operational warning",
+            ),
+        )
+    )
+    assert should_fail_preflight(report=blocking_report, mode="off") is False
+    assert should_fail_preflight(report=blocking_report, mode="warn") is True
+    assert should_fail_preflight(report=warning_report, mode="warn") is False
+    assert should_fail_preflight(report=warning_report, mode="strict") is True
+
+
+def test_format_report_text_and_json_include_remediation_details() -> None:
+    """Report formatters should preserve remediation and summary details."""
+    report = DiagnosticReport(
+        findings=(
+            DiagnosticFinding(
+                code="ffmpeg_binary_missing",
+                severity="error",
+                message="ffmpeg executable was not found on PATH.",
+                remediation=("Install ffmpeg.",),
+                blocking=True,
+            ),
+        )
+    )
+    text_output = format_report_text(report)
+    json_output = format_report_json(report)
+    payload = json.loads(json_output)
+
+    assert "SER diagnostics report" in text_output
+    assert "[ERROR] ffmpeg_binary_missing: blocking" in text_output
+    assert "remediation: Install ffmpeg." in text_output
+    assert payload["summary"]["has_blocking_findings"] is True
+    assert payload["findings"][0]["code"] == "ffmpeg_binary_missing"
+    assert payload["findings"][0]["remediation"] == ["Install ffmpeg."]
+
+
+def test_format_report_text_marks_warnings_as_advisory_when_non_blocking() -> None:
+    """Non-blocking warnings should be rendered as advisory in text output."""
+    report = DiagnosticReport(
+        findings=(
+            DiagnosticFinding(
+                code="transcription_operational_torio_ffmpeg_abi_mismatch",
+                severity="warning",
+                message="Non-blocking runtime advisory.",
+            ),
+        )
+    )
+
+    text_output = format_report_text(report)
+    assert (
+        "[WARNING] transcription_operational_torio_ffmpeg_abi_mismatch: advisory"
+        in text_output
+    )
+
+
+def test_format_report_brief_condenses_long_messages() -> None:
+    """Compact preflight formatter should avoid long repeated remediation logs."""
+    report = DiagnosticReport(
+        findings=(
+            DiagnosticFinding(
+                code="transcription_operational_torio_ffmpeg_abi_mismatch",
+                severity="warning",
+                message=(
+                    "torchaudio FFmpeg extension could not be loaded because "
+                    "@rpath/libavutil.58.dylib is unavailable (FFmpeg ABI mismatch). "
+                    "This is a non-blocking advisory and stable-whisper continues "
+                    "with soundfile/sox backends."
+                ),
+            ),
+        )
+    )
+    brief = format_report_brief(report, max_message_chars=90)
+    assert "SER diagnostics preflight summary" in brief
+    assert (
+        "[WARNING] transcription_operational_torio_ffmpeg_abi_mismatch (advisory):"
+        in brief
+    )
+    assert "..." in brief
+
+
+def test_fast_openmp_conflict_is_warning_for_cli_diagnostics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Faster-whisper OpenMP conflict should be advisory in CLI diagnostics."""
+    settings = config_module.reload_settings()
+    settings = replace(
+        settings,
+        runtime_flags=replace(
+            settings.runtime_flags,
+            profile_pipeline=True,
+            medium_profile=False,
+            accurate_profile=False,
+            accurate_research_profile=False,
+        ),
+    )
+
+    class _FakeAdapter:
+        def check_compatibility(
+            self,
+            *,
+            runtime_request: object,
+            settings: object,
+        ) -> CompatibilityReport:
+            del runtime_request
+            del settings
+            return CompatibilityReport(
+                backend_id="faster_whisper",
+                functional_issues=(
+                    CompatibilityIssue(
+                        code=FASTER_WHISPER_OPENMP_CONFLICT_ISSUE_CODE,
+                        message="OpenMP conflict detected.",
+                    ),
+                ),
+            )
+
+    monkeypatch.setattr(
+        diagnostics_service,
+        "resolve_runtime_capability",
+        lambda *args, **kwargs: SimpleNamespace(available=True),
+    )
+    monkeypatch.setattr(
+        diagnostics_service.shutil, "which", lambda _name: "/usr/bin/ffmpeg"
+    )
+    monkeypatch.setattr(
+        diagnostics_service,
+        "resolve_profile_transcription_config",
+        lambda _profile: ("faster_whisper", "distil-large-v3", False, True),
+    )
+    monkeypatch.setattr(
+        diagnostics_service,
+        "resolve_transcription_backend_adapter",
+        lambda _backend_id: _FakeAdapter(),
+    )
+
+    report = run_startup_preflight(
+        settings=settings,
+        include_transcription_checks=True,
+    )
+
+    assert report.has_blocking_findings is False
+    assert any(
+        finding.code
+        == "transcription_operational_faster_whisper_openmp_runtime_conflict"
+        and finding.severity == "warning"
+        for finding in report.findings
+    )
+    assert should_fail_preflight(report=report, mode="warn") is False

--- a/tests/test_emotion2vec_backend.py
+++ b/tests/test_emotion2vec_backend.py
@@ -108,6 +108,18 @@ def test_emotion2vec_backend_encode_sequence_preserves_chunk_timestamps() -> Non
     assert model.call_sizes == [6, 6]
 
 
+def test_emotion2vec_backend_accepts_xpu_device_selector() -> None:
+    """Backend constructor should accept XPU device selectors."""
+    backend = Emotion2VecBackend(
+        device="xpu:0",
+        feature_extractor=_FakeFeatureExtractor(),
+        model=_FakeModel(hidden_size=4),
+    )
+
+    assert backend.backend_id == "emotion2vec"
+    assert backend.feature_dim == 4
+
+
 def test_emotion2vec_backend_missing_dependency_error_is_actionable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -300,6 +312,47 @@ def test_emotion2vec_backend_falls_back_to_hub_when_local_snapshot_invalid(
     assert captured_calls[0]["model"] == str(model_dir)
     assert captured_calls[1]["model"] == "iic/emotion2vec_plus_large"
     assert captured_calls[1]["hub"] == "ms"
+
+
+def test_emotion2vec_backend_falls_back_to_cpu_when_xpu_init_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """XPU initialization failures should retry FunASR initialization on CPU."""
+    original_find_spec = importlib.util.find_spec
+    original_import_module = importlib.import_module
+
+    def fake_find_spec(module_name: str, package: str | None = None) -> object | None:
+        if module_name in {"torch", "funasr", "modelscope"}:
+            return object()
+        return original_find_spec(module_name, package)
+
+    captured_calls: list[dict[str, object]] = []
+
+    class FakeAutoModel:
+        def __init__(self, **kwargs: object) -> None:
+            captured_calls.append(dict(kwargs))
+            requested_device = str(kwargs.get("device", "cpu")).strip().lower()
+            if requested_device.startswith("xpu"):
+                raise RuntimeError("xpu runtime unsupported")
+            self.model = SimpleNamespace(cfg={"embed_dim": 768})
+
+    def fake_import_module(module_name: str) -> object:
+        if module_name == "funasr.auto.auto_model":
+            return SimpleNamespace(AutoModel=FakeAutoModel)
+        return original_import_module(module_name)
+
+    monkeypatch.setattr(importlib.util, "find_spec", fake_find_spec)
+    monkeypatch.setattr(importlib, "import_module", fake_import_module)
+
+    backend = Emotion2VecBackend(
+        model_id="iic/emotion2vec_plus_large",
+        device="xpu:0",
+    )
+    backend._ensure_funasr_model()
+
+    assert len(captured_calls) == 2
+    assert captured_calls[0]["device"] == "xpu:0"
+    assert captured_calls[1]["device"] == "cpu"
 
 
 def test_emotion2vec_backend_suppresses_dependency_noise_outside_debug(

--- a/tests/test_feature_runtime_policy.py
+++ b/tests/test_feature_runtime_policy.py
@@ -83,6 +83,27 @@ def test_feature_runtime_policy_enables_emotion2vec_cuda_when_available(
     assert resolved.reason == "emotion2vec_cuda_enabled"
 
 
+def test_feature_runtime_policy_enables_emotion2vec_xpu_when_available(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Emotion2Vec should enable XPU runtime when probe resolves XPU."""
+    monkeypatch.setattr(
+        runtime_policy,
+        "maybe_resolve_torch_runtime",
+        lambda *, device, dtype: _runtime(device_spec="xpu:1", device_type="xpu"),
+    )
+
+    resolved = resolve_feature_runtime_policy(
+        backend_id="emotion2vec",
+        requested_device="auto",
+        requested_dtype="auto",
+    )
+
+    assert resolved.device == "xpu:1"
+    assert resolved.dtype == "auto"
+    assert resolved.reason == "emotion2vec_xpu_enabled"
+
+
 def test_feature_runtime_policy_defaults_emotion2vec_to_cpu_without_cuda(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -148,3 +169,25 @@ def test_feature_runtime_policy_keeps_xlsr_mps_guard_with_overrides(
     assert resolved.device == "cpu"
     assert resolved.dtype == "float32"
     assert resolved.reason == "hf_xlsr_mps_stability_guard"
+
+
+def test_feature_runtime_policy_accepts_xpu_override_for_whisper(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Whisper runtime policy should preserve valid XPU override selectors."""
+    monkeypatch.setattr(
+        runtime_policy,
+        "maybe_resolve_torch_runtime",
+        lambda *, device, dtype: _runtime(device_spec="xpu:0", device_type="xpu"),
+    )
+
+    resolved = resolve_feature_runtime_policy(
+        backend_id="hf_whisper",
+        requested_device="auto",
+        requested_dtype="auto",
+        backend_override_device="xpu:0",
+    )
+
+    assert resolved.device == "xpu:0"
+    assert resolved.dtype == "auto"
+    assert resolved.reason == "torch_backend_requested_selectors"

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -56,6 +56,9 @@ def test_compute_ser_metrics_rejects_mismatched_lengths() -> None:
         compute_ser_metrics(y_true=["happy"], y_pred=[])
 
 
+@pytest.mark.filterwarnings(
+    "ignore:A single label was found in 'y_true' and 'y_pred'\\. For the confusion matrix to have the correct shape, use the 'labels' parameter to pass all known labels\\.:UserWarning:sklearn\\.metrics\\._classification"
+)
 def test_grouped_ser_metrics_by_sample_aggregates_majority_vote() -> None:
     """Window-level predictions should collapse to per-sample grouped metrics."""
     grouped = compute_grouped_ser_metrics_by_sample(

--- a/tests/test_profile_resolution.py
+++ b/tests/test_profile_resolution.py
@@ -122,6 +122,17 @@ def test_validate_feature_runtime_defaults_rejects_invalid_dtype() -> None:
         )
 
 
+def test_validate_feature_runtime_defaults_accepts_xpu_device() -> None:
+    """Feature-runtime defaults should accept explicit XPU selectors."""
+    parsed = _validate_feature_runtime_defaults(
+        name="medium",
+        raw={"torch_device": "xpu:0"},
+    )
+    assert parsed is not None
+    assert parsed.torch_device == "xpu:0"
+    assert parsed.torch_dtype is None
+
+
 def test_validate_feature_runtime_defaults_requires_one_selector() -> None:
     """Feature-runtime defaults should require at least one selector override."""
     with pytest.raises(RuntimeError, match="must define at least one"):

--- a/tests/test_torch_inference.py
+++ b/tests/test_torch_inference.py
@@ -41,6 +41,17 @@ class _FakeMps:
         return self._built
 
 
+class _FakeXpu:
+    """Minimal XPU capability stub."""
+
+    def __init__(self, *, available: bool) -> None:
+        self._available = available
+
+    def is_available(self) -> bool:
+        """Returns configured XPU availability."""
+        return self._available
+
+
 class _FakeBackends:
     """Container for torch.backends namespace stubs."""
 
@@ -62,11 +73,13 @@ class _FakeTorchModule:
         cuda_bf16_supported: bool,
         mps_available: bool,
         mps_built: bool,
+        xpu_available: bool = False,
     ) -> None:
         self.cuda = _FakeCuda(
             available=cuda_available,
             bf16_supported=cuda_bf16_supported,
         )
+        self.xpu = _FakeXpu(available=xpu_available)
         self.backends = _FakeBackends(
             mps=_FakeMps(available=mps_available, built=mps_built)
         )
@@ -121,6 +134,7 @@ def test_maybe_resolve_torch_runtime_prefers_cuda_and_bf16_when_supported(
         cuda_bf16_supported=True,
         mps_available=True,
         mps_built=True,
+        xpu_available=True,
     )
     monkeypatch.setattr(
         torch_inference.importlib,
@@ -155,6 +169,75 @@ def test_maybe_resolve_torch_runtime_rejects_non_float32_cpu_dtype(
     )
     with pytest.raises(RuntimeError, match="CPU runtime only supports"):
         torch_inference.maybe_resolve_torch_runtime(device="cpu", dtype="float16")
+
+
+def test_maybe_resolve_torch_runtime_prefers_xpu_when_cuda_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Auto selectors should pick XPU when CUDA is unavailable and XPU is present."""
+    fake_torch = _FakeTorchModule(
+        cuda_available=False,
+        cuda_bf16_supported=False,
+        mps_available=True,
+        mps_built=True,
+        xpu_available=True,
+    )
+    monkeypatch.setattr(
+        torch_inference.importlib,
+        "import_module",
+        lambda name: fake_torch if name == "torch" else None,
+    )
+
+    runtime = torch_inference.maybe_resolve_torch_runtime(device="auto", dtype="auto")
+
+    assert runtime is not None
+    assert runtime.device_spec == "xpu"
+    assert runtime.device_type == "xpu"
+    assert runtime.dtype_name == "float16"
+    assert runtime.device == "device:xpu"
+    assert runtime.dtype == "float16"
+
+
+def test_maybe_resolve_torch_runtime_rejects_unavailable_xpu_selector(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Explicit XPU selector should fail fast when XPU runtime is unavailable."""
+    fake_torch = _FakeTorchModule(
+        cuda_available=False,
+        cuda_bf16_supported=False,
+        mps_available=False,
+        mps_built=False,
+        xpu_available=False,
+    )
+    monkeypatch.setattr(
+        torch_inference.importlib,
+        "import_module",
+        lambda name: fake_torch if name == "torch" else None,
+    )
+
+    with pytest.raises(RuntimeError, match="requested XPU, but XPU is unavailable"):
+        torch_inference.maybe_resolve_torch_runtime(device="xpu:0", dtype="float16")
+
+
+def test_maybe_resolve_torch_runtime_rejects_bfloat16_on_xpu(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """XPU runtime should reject explicit bfloat16 selector for now."""
+    fake_torch = _FakeTorchModule(
+        cuda_available=False,
+        cuda_bf16_supported=False,
+        mps_available=False,
+        mps_built=False,
+        xpu_available=True,
+    )
+    monkeypatch.setattr(
+        torch_inference.importlib,
+        "import_module",
+        lambda name: fake_torch if name == "torch" else None,
+    )
+
+    with pytest.raises(RuntimeError, match="unsupported for MPS/XPU"):
+        torch_inference.maybe_resolve_torch_runtime(device="xpu", dtype="bfloat16")
 
 
 def test_move_inputs_to_runtime_casts_only_selected_dtype_keys() -> None:

--- a/tests/test_transcript_extractor.py
+++ b/tests/test_transcript_extractor.py
@@ -13,6 +13,7 @@ import pytest
 from ser.domain import TranscriptWord
 from ser.transcript import transcript_extractor as te
 from ser.transcript.backends import faster_whisper as faster_whisper_adapter
+from ser.transcript.backends.base import CompatibilityIssue
 
 if TYPE_CHECKING:
     from stable_whisper.result import WhisperResult
@@ -426,6 +427,81 @@ def test_faster_whisper_info_logs_are_demoted_to_debug_during_transcription() ->
     ]
     assert faster_records, "Expected faster_whisper logs to be captured."
     assert all(record.levelno == logging.DEBUG for record in faster_records)
+
+
+def test_check_adapter_compatibility_logs_non_blocking_issues_once(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Repeated compatibility checks should emit non-blocking issues once."""
+    compatibility_report = te.CompatibilityReport(
+        backend_id="stable_whisper",
+        operational_issues=(
+            CompatibilityIssue(
+                code="torio_ffmpeg_abi_mismatch",
+                message="torchaudio FFmpeg extension ABI mismatch",
+            ),
+        ),
+        noise_issues=(
+            CompatibilityIssue(
+                code="stable_whisper_invalid_escape_sequence",
+                message="stable-whisper import warning noise",
+            ),
+        ),
+    )
+
+    class _FakeAdapter:
+        def check_compatibility(
+            self,
+            *,
+            runtime_request: te.BackendRuntimeRequest,
+            settings: object,
+        ) -> te.CompatibilityReport:
+            del runtime_request
+            del settings
+            return compatibility_report
+
+    monkeypatch.setattr(
+        te,
+        "resolve_transcription_backend_adapter",
+        lambda _backend_id: _FakeAdapter(),
+    )
+    monkeypatch.setattr(te, "_EMITTED_COMPATIBILITY_ISSUE_KEYS", set())
+    runtime_request = te.BackendRuntimeRequest(
+        model_name="large-v2",
+        use_demucs=False,
+        use_vad=True,
+    )
+    profile = te.TranscriptionProfile(
+        backend_id="stable_whisper",
+        model_name="large-v2",
+    )
+    settings = cast(te.AppConfig, SimpleNamespace())
+
+    with caplog.at_level(logging.DEBUG):
+        _ = te._check_adapter_compatibility(
+            active_profile=profile,
+            settings=settings,
+            runtime_request=runtime_request,
+        )
+        _ = te._check_adapter_compatibility(
+            active_profile=profile,
+            settings=settings,
+            runtime_request=runtime_request,
+        )
+
+    noise_records = [
+        record
+        for record in caplog.records
+        if "noise issue [stable_whisper_invalid_escape_sequence]" in record.getMessage()
+    ]
+    operational_records = [
+        record
+        for record in caplog.records
+        if "operational issue [torio_ffmpeg_abi_mismatch]" in record.getMessage()
+    ]
+    assert len(noise_records) == 1
+    assert len(operational_records) == 1
 
 
 def test_extract_transcript_logs_setup_before_model_load_when_required(

--- a/tests/test_transcription_backends.py
+++ b/tests/test_transcription_backends.py
@@ -13,7 +13,7 @@ from typing import cast
 import pytest
 
 from ser.config import AppConfig
-from ser.transcript.backends.base import BackendRuntimeRequest
+from ser.transcript.backends.base import BackendRuntimeRequest, CompatibilityIssue
 from ser.transcript.backends.faster_whisper import FasterWhisperAdapter
 from ser.transcript.backends.stable_whisper import StableWhisperAdapter
 from ser.utils.transcription_compat import FASTER_WHISPER_OPENMP_CONFLICT_ISSUE_CODE
@@ -35,6 +35,11 @@ def test_stable_whisper_compatibility_report_is_noise_aware(
     """Stable adapter should expose noise policy metadata without blocking."""
     adapter = StableWhisperAdapter()
     monkeypatch.setattr(adapter, "_is_module_available", lambda _name: True)
+    monkeypatch.setattr(
+        adapter,
+        "_detect_torio_ffmpeg_operational_issue",
+        lambda: None,
+    )
     report = adapter.check_compatibility(
         runtime_request=BackendRuntimeRequest(
             model_name="large-v2",
@@ -49,6 +54,7 @@ def test_stable_whisper_compatibility_report_is_noise_aware(
         "stable_whisper.invalid_escape_sequence",
         "stable_whisper.fp16_cpu_fallback_warning",
         "stable_whisper.demucs_deprecated_warning",
+        "torio.ffmpeg_probe_debug_traceback",
     )
     assert report.noise_issues
 
@@ -59,6 +65,11 @@ def test_stable_whisper_compatibility_blocks_on_missing_dependency(
     """Stable adapter should block when stable_whisper dependency is unavailable."""
     adapter = StableWhisperAdapter()
     monkeypatch.setattr(adapter, "_is_module_available", lambda _name: False)
+    monkeypatch.setattr(
+        adapter,
+        "_detect_torio_ffmpeg_operational_issue",
+        lambda: None,
+    )
     report = adapter.check_compatibility(
         runtime_request=BackendRuntimeRequest(
             model_name="large-v2",
@@ -73,6 +84,106 @@ def test_stable_whisper_compatibility_blocks_on_missing_dependency(
         issue.code == "missing_dependency_stable_whisper"
         for issue in report.functional_issues
     )
+
+
+def test_stable_whisper_compatibility_reports_torio_ffmpeg_operational_issue(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stable adapter should surface torio FFmpeg ABI mismatch as operational."""
+    adapter = StableWhisperAdapter()
+    monkeypatch.setattr(adapter, "_is_module_available", lambda _name: True)
+    monkeypatch.setattr(
+        adapter,
+        "_detect_torio_ffmpeg_operational_issue",
+        lambda: CompatibilityIssue(
+            code="torio_ffmpeg_abi_mismatch",
+            message=(
+                "torchaudio FFmpeg extension could not be loaded because "
+                "@rpath/libavutil.58.dylib is unavailable."
+            ),
+        ),
+    )
+
+    report = adapter.check_compatibility(
+        runtime_request=BackendRuntimeRequest(
+            model_name="large-v2",
+            use_demucs=True,
+            use_vad=True,
+        ),
+        settings=cast(AppConfig, SimpleNamespace()),
+    )
+
+    assert any(
+        issue.code == "torio_ffmpeg_abi_mismatch" for issue in report.operational_issues
+    )
+    assert any(
+        issue.code == "torio_ffmpeg_probe_debug_traceback"
+        for issue in report.noise_issues
+    )
+
+
+def test_stable_whisper_extract_missing_dynamic_library_parses_darwin_dlopen() -> None:
+    """Helper should extract one missing library token from Darwin loader errors."""
+    missing = StableWhisperAdapter._extract_missing_dynamic_library(
+        "dlopen(...): Library not loaded: @rpath/libavutil.58.dylib\n"
+        "  Referenced from: /tmp/libtorio_ffmpeg6.so"
+    )
+    assert missing == "@rpath/libavutil.58.dylib"
+
+
+def test_stable_whisper_detect_torio_ffmpeg_issue_reports_abi_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """FFmpeg backend missing with libavutil loader error should report ABI mismatch."""
+    StableWhisperAdapter._detect_torio_ffmpeg_operational_issue.cache_clear()
+    fake_library = tmp_path / "libtorio_ffmpeg6.so"
+    fake_library.write_text("stub", encoding="utf-8")
+    fake_torchaudio = SimpleNamespace(list_audio_backends=lambda: ["sox", "soundfile"])
+    fake_torio_utils = SimpleNamespace(
+        _FFMPEG_VERS=["6"],
+        _get_lib_path=lambda _lib: fake_library,
+    )
+
+    def _fake_import_module(name: str) -> object:
+        if name == "torchaudio":
+            return fake_torchaudio
+        if name == "torio._extension.utils":
+            return fake_torio_utils
+        raise ModuleNotFoundError(name)
+
+    monkeypatch.setattr(
+        "ser.transcript.backends.stable_whisper.importlib.import_module",
+        _fake_import_module,
+    )
+    monkeypatch.setattr(
+        "ser.transcript.backends.stable_whisper.StableWhisperAdapter._is_module_available",
+        lambda _module_name: True,
+    )
+    monkeypatch.setattr(
+        "ser.transcript.backends.stable_whisper.format_torio_ffmpeg_remediation",
+        lambda *, missing_library: (
+            f"lane-aware-remediation:{missing_library or 'none'}"
+        ),
+    )
+
+    def _raise_dlopen(_path: str) -> object:
+        raise OSError(
+            "dlopen(...): Library not loaded: @rpath/libavutil.58.dylib\n"
+            "  Referenced from: /tmp/libtorio_ffmpeg6.so"
+        )
+
+    monkeypatch.setattr(
+        "ser.transcript.backends.stable_whisper.ctypes.CDLL",
+        _raise_dlopen,
+    )
+
+    issue = StableWhisperAdapter._detect_torio_ffmpeg_operational_issue()
+
+    assert issue is not None
+    assert issue.code == "torio_ffmpeg_abi_mismatch"
+    assert "lane-aware-remediation:@rpath/libavutil.58.dylib" in issue.message
+    StableWhisperAdapter._detect_torio_ffmpeg_operational_issue.cache_clear()
 
 
 def test_faster_whisper_demucs_issue_is_operational_not_blocking(

--- a/tests/test_transcription_compat.py
+++ b/tests/test_transcription_compat.py
@@ -116,3 +116,64 @@ def test_stable_whisper_sparse_mps_incompatibility_returns_false_when_mps_unavai
     assert compat.has_known_stable_whisper_sparse_mps_incompatibility() is False
 
     compat.has_known_stable_whisper_sparse_mps_incompatibility.cache_clear()
+
+
+def test_resolve_transcription_compatibility_lane_detects_pinned_darwin_py312(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Darwin x86_64 Python 3.12 should map to pinned compatibility lane."""
+    monkeypatch.setattr(compat.sys, "platform", "darwin")
+    monkeypatch.setattr(compat.platform, "machine", lambda: "x86_64")
+    monkeypatch.setattr(compat.sys, "version_info", (3, 12, 9, "final", 0))
+
+    assert (
+        compat.resolve_transcription_compatibility_lane()
+        == "darwin_x86_64_py312_pinned"
+    )
+
+
+def test_format_torio_ffmpeg_remediation_for_pinned_lane_avoids_torch_upgrade_hint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pinned Darwin lane remediation should explicitly avoid torch upgrade guidance."""
+    monkeypatch.setattr(compat.sys, "platform", "darwin")
+    monkeypatch.setattr(compat.platform, "machine", lambda: "x86_64")
+    monkeypatch.setattr(compat.sys, "version_info", (3, 12, 9, "final", 0))
+
+    message = compat.format_torio_ffmpeg_remediation(
+        missing_library="@rpath/libavutil.58.dylib"
+    )
+
+    assert "do not upgrade torch" in message.lower()
+    assert "brew install ffmpeg@6" in message
+
+
+def test_format_torio_ffmpeg_remediation_for_darwin_py313_recommends_lane_switch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Darwin x86_64 Python 3.13 remediation should recommend supported lane switch."""
+    monkeypatch.setattr(compat.sys, "platform", "darwin")
+    monkeypatch.setattr(compat.platform, "machine", lambda: "x86_64")
+    monkeypatch.setattr(compat.sys, "version_info", (3, 13, 0, "final", 0))
+
+    message = compat.format_torio_ffmpeg_remediation(
+        missing_library="@rpath/libavutil.58.dylib"
+    )
+
+    assert "partial fast-profile lane" in message
+    assert "setup_compatible_env.sh --python 3.12" in message
+
+
+def test_format_torio_ffmpeg_remediation_for_generic_lane_allows_torch_upgrade_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Generic lane remediation can include optional torch upgrade guidance."""
+    monkeypatch.setattr(compat.sys, "platform", "linux")
+    monkeypatch.setattr(compat.platform, "machine", lambda: "x86_64")
+    monkeypatch.setattr(compat.sys, "version_info", (3, 12, 9, "final", 0))
+
+    message = compat.format_torio_ffmpeg_remediation(
+        missing_library="@rpath/libavutil.58.dylib"
+    )
+
+    assert "if your environment policy allows torch upgrades" in message.lower()

--- a/tests/test_transcription_runtime_policy.py
+++ b/tests/test_transcription_runtime_policy.py
@@ -164,3 +164,25 @@ def test_policy_passes_configured_mps_threshold_to_memory_tier_resolver(
     )
 
     assert captured["threshold"] == pytest.approx(28.5)
+
+
+def test_policy_falls_back_to_cpu_for_xpu_when_backend_lacks_support(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """faster-whisper should remain NVIDIA-only and demote XPU to CPU."""
+    monkeypatch.setattr(
+        runtime_policy,
+        "maybe_resolve_torch_runtime",
+        lambda **_kwargs: _runtime(device_spec="xpu:0", device_type="xpu"),
+    )
+
+    policy = runtime_policy.resolve_transcription_runtime_policy(
+        backend_id="faster_whisper",
+        requested_device="auto",
+        requested_dtype="auto",
+    )
+
+    assert policy.device_spec == "cpu"
+    assert policy.device_type == "cpu"
+    assert policy.precision_candidates == ("float32",)
+    assert "backend_faster_whisper_does_not_support_device_xpu" in policy.reason


### PR DESCRIPTION
## Summary
This PR introduces a diagnostics/preflight tool, reduces non-blocking startup log noise, and improves environment-specific remediation for transcription runtime compatibility issues. Also, added XPU support + testing. 

## What Changed
- Added `ser doctor` diagnostics command with:
  - profile override support
  - text/json output
  - strict mode exit behavior
  - optional noise/transcription checks
- Added startup preflight gate to CLI:
  - `--preflight off|warn|strict`
  - one-line summary output for cleaner logs
  - fail/continue behavior based on mode and finding severity
- Added compatibility issue deduping to avoid repeated advisories in the same run.
- Added stable-whisper operational detection for torio/FFmpeg loader issues and lane-aware remediation guidance.
- Classified `faster_whisper_openmp_runtime_conflict` as advisory in CLI preflight context.
- Added centralized torch device selector normalization and XPU selector support across config/profile/runtime policy/emotion2vec.
- Added manual hardware validation workflows:
  - macOS 15 MPS
  - self-hosted Linux CUDA/XPU
- Added contributor and CI hardware-validation documentation updates.

## User-Visible Behavior
- Startup now logs a single concise preflight advisory/blocking line instead of verbose repeated warning blocks.
- `ser doctor` is the detailed troubleshooting path.
- Fast profile in preflight warn mode is no longer blocked by the known OpenMP runtime conflict advisory.

## Test Coverage
- New/updated tests for:
  - CLI doctor dispatch and preflight mode behavior
  - diagnostics formatting and exit semantics
  - compatibility issue dedupe/logging
  - stable-whisper torio/FFmpeg operational detection
  - lane-aware remediation text
  - XPU device/runtime policy handling