### PR TITLE
Unify training orchestration and tighten the public config facade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .git
 .DS_Store
 ser/dataset/**/*.wav
+ser/dataset/ravdess/
 ser/models/*.pkl
 ser/models/OpenAI/**
 transcripts/**/*
@@ -10,3 +11,17 @@ transcripts/**/*
 dist/
 build/
 *.egg-info/
+
+memory.json
+.serena/
+.ruff_cache/
+.qodo/
+.pytest_cache/
+.mypy_cache/
+.uv-cache/
+.uv-tools/
+.tmp/
+docs/adr/
+docs/compatibility-matrix.md
+tmp/
+ser/models/*.json

--- a/.gitignore
+++ b/.gitignore
@@ -12,16 +12,11 @@ dist/
 build/
 *.egg-info/
 
-memory.json
-.serena/
 .ruff_cache/
-.qodo/
 .pytest_cache/
 .mypy_cache/
 .uv-cache/
 .uv-tools/
 .tmp/
-docs/adr/
-docs/compatibility-matrix.md
 tmp/
 ser/models/*.json

--- a/ser/_internal/api/runtime.py
+++ b/ser/_internal/api/runtime.py
@@ -46,7 +46,6 @@ from ser.config import (
     AppConfig,
     profile_artifact_file_names,
     resolve_profile_transcription_config,
-    settings_override,
 )
 from ser.profiles import ProfileName, get_profile_catalog, resolve_profile_name
 from ser.utils.logger import get_logger
@@ -272,19 +271,16 @@ def run_training_workflow(
     use_profile_pipeline: bool,
     pipeline_builder: _RuntimePipelineBuilder | None = None,
 ) -> None:
-    """Runs CLI-equivalent training workflow through one API boundary."""
-    if use_profile_pipeline:
-        builder = (
-            pipeline_builder
-            if pipeline_builder is not None
-            else _build_runtime_pipeline
-        )
-        builder(settings).run_training()
-        return
-    from ser.models.emotion_model import train_model
+    """Runs CLI-equivalent training workflow through the runtime pipeline.
 
-    with settings_override(settings):
-        train_model()
+    The ``use_profile_pipeline`` parameter is retained for compatibility with older
+    callers, but training now uses the pipeline for every profile so orchestration
+    remains single-owned.
+    """
+    builder = (
+        pipeline_builder if pipeline_builder is not None else _build_runtime_pipeline
+    )
+    builder(settings).run_training()
 
 
 def train(
@@ -294,7 +290,7 @@ def train(
     use_profile_pipeline: bool = True,
     pipeline_builder: _RuntimePipelineBuilder | None = None,
 ) -> None:
-    """Runs training for the selected profile with optional explicit settings."""
+    """Runs training for the selected profile through the runtime pipeline."""
     scoped_settings = _settings_for_profile(settings, profile=profile)
     run_training_workflow(
         settings=scoped_settings,

--- a/ser/api.py
+++ b/ser/api.py
@@ -209,7 +209,7 @@ def train(
     use_profile_pipeline: bool = True,
     pipeline_builder: RuntimePipelineBuilder | None = None,
 ) -> None:
-    """Runs training using the active settings snapshot."""
+    """Runs training using the active settings snapshot via the runtime pipeline."""
     active_settings = settings if settings is not None else get_settings()
     return _train(
         profile=profile,

--- a/ser/config.py
+++ b/ser/config.py
@@ -2,12 +2,7 @@
 
 from __future__ import annotations
 
-import os as os
-import sys as sys
-
 from ser._internal.config.bootstrap import (
-    _build_settings,
-    _resolve_settings_inputs,
     apply_settings,
     get_settings,
     reload_settings,
@@ -50,9 +45,6 @@ from ser._internal.config.settings_inputs import (
     ResolvedSettingsInputs,
     SettingsInputDeps,
 )
-from ser._internal.config.settings_inputs import (
-    resolve_settings_inputs as _resolve_settings_inputs_from_internal,
-)
 from ser.profiles import (
     ProfileCatalogEntry,
     TranscriptionBackendId,
@@ -93,18 +85,13 @@ __all__ = [
     "TranscriptionBackendId",
     "TranscriptionConfig",
     "WhisperModelConfig",
-    "_build_settings",
-    "_resolve_settings_inputs",
-    "_resolve_settings_inputs_from_internal",
     "apply_settings",
     "default_profile_model_id",
     "get_profile_catalog",
     "get_settings",
     "normalize_torch_device_selector",
-    "os",
     "profile_artifact_file_names",
     "reload_settings",
     "resolve_profile_transcription_config",
     "settings_override",
-    "sys",
 ]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -662,46 +662,68 @@ def test_run_training_workflow_uses_pipeline_builder_when_enabled(
     assert calls["training"] is True
 
 
-def test_run_training_workflow_uses_legacy_training_when_disabled(
+def test_run_training_workflow_uses_pipeline_builder_when_disabled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Training workflow should delegate to legacy trainer when pipeline is disabled."""
+    """Training workflow should keep routing through the pipeline when disabled."""
     settings = config_module.reload_settings()
-    calls: dict[str, bool] = {"training": False}
+    captured: dict[str, object] = {"training": False}
 
-    def _fake_train_model() -> None:
-        calls["training"] = True
+    class _FakePipeline:
+        def run_training(self) -> None:
+            captured["training"] = True
 
-    monkeypatch.setattr("ser.models.emotion_model.train_model", _fake_train_model)
+        def run_inference(self, request: InferenceRequest) -> InferenceExecution:
+            del request
+            raise AssertionError("unreachable")
+
+    def _pipeline_builder(received_settings: AppConfig) -> _FakePipeline:
+        captured["settings"] = received_settings
+        return _FakePipeline()
+
+    monkeypatch.setattr(
+        "ser.models.emotion_model.train_model",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("Legacy training branch should remain unreachable.")
+        ),
+    )
 
     api.run_training_workflow(
         settings=settings,
         use_profile_pipeline=False,
+        pipeline_builder=_pipeline_builder,
     )
 
-    assert calls["training"] is True
+    assert captured["settings"] is settings
+    assert captured["training"] is True
 
 
-def test_run_training_workflow_scopes_settings_for_legacy_training(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Legacy training path should honor explicit workflow settings."""
-    ambient_settings = config_module.reload_settings()
-    scoped_settings = replace(ambient_settings, default_language="pt-BR")
-    captured: dict[str, object] = {}
+def test_run_training_workflow_passes_scoped_settings_to_pipeline_builder() -> None:
+    """Training workflow should pass explicit profile-scoped settings to the builder."""
+    base_settings = config_module.reload_settings()
+    scoped_settings = replace(base_settings, default_language="pt-BR")
+    captured: dict[str, object] = {"training": False}
 
-    def _fake_train_model() -> None:
-        captured["active_settings"] = config_module.get_settings()
+    class _FakePipeline:
+        def run_training(self) -> None:
+            captured["training"] = True
 
-    monkeypatch.setattr("ser.models.emotion_model.train_model", _fake_train_model)
+        def run_inference(self, request: InferenceRequest) -> InferenceExecution:
+            del request
+            raise AssertionError("unreachable")
+
+    def _pipeline_builder(received_settings: AppConfig) -> _FakePipeline:
+        captured["settings"] = received_settings
+        return _FakePipeline()
 
     api.run_training_workflow(
         settings=scoped_settings,
         use_profile_pipeline=False,
+        pipeline_builder=_pipeline_builder,
     )
 
-    assert captured["active_settings"] is scoped_settings
-    assert config_module.get_settings() is ambient_settings
+    assert captured["settings"] is scoped_settings
+    assert captured["training"] is True
 
 
 def test_run_inference_workflow_builds_inference_request(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -38,7 +38,7 @@ def test_reload_settings_reads_environment(monkeypatch: pytest.MonkeyPatch) -> N
     monkeypatch.setenv("WHISPER_MODEL", "base")
     monkeypatch.setenv("WHISPER_DEMUCS", "false")
     monkeypatch.setenv("WHISPER_VAD", "true")
-    monkeypatch.setattr(config.os, "cpu_count", lambda: 4)
+    monkeypatch.setattr(bootstrap.os, "cpu_count", lambda: 4)
 
     settings = config.reload_settings()
 
@@ -76,17 +76,17 @@ def test_reload_settings_reads_environment(monkeypatch: pytest.MonkeyPatch) -> N
 
 def test_reload_settings_uses_cpu_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
     """When cpu_count is unavailable, configuration should default to one core."""
-    monkeypatch.setattr(config.os, "cpu_count", lambda: None)
+    monkeypatch.setattr(bootstrap.os, "cpu_count", lambda: None)
 
     settings = config.reload_settings()
 
     assert settings.models.num_cores == 1
 
 
-def test_build_settings_delegates_to_internal_settings_builder(
+def test_bootstrap_build_settings_delegates_to_internal_settings_builder(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The public config facade should reuse bootstrap's shared builder owner."""
+    """Bootstrap should keep single ownership of settings construction."""
     expected = config.reload_settings()
     call_count = 0
 
@@ -103,16 +103,15 @@ def test_build_settings_delegates_to_internal_settings_builder(
         _fake_build_settings_from_inputs,
     )
 
-    assert config._build_settings is bootstrap._build_settings
-    assert config._build_settings() is expected
+    assert bootstrap._build_settings() is expected
     assert call_count == 1
 
 
-def test_resolve_settings_inputs_delegates_to_internal_resolver(
+def test_bootstrap_resolve_settings_inputs_delegates_to_internal_resolver(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The public config facade should reuse bootstrap's shared input resolver."""
-    expected = config._resolve_settings_inputs()
+    """Bootstrap should keep single ownership of settings input resolution."""
+    expected = bootstrap._resolve_settings_inputs()
     call_count = 0
 
     def _fake_resolve_settings_inputs_from_internal(
@@ -130,6 +129,17 @@ def test_resolve_settings_inputs_delegates_to_internal_resolver(
         _fake_resolve_settings_inputs_from_internal,
     )
 
-    assert config._resolve_settings_inputs is bootstrap._resolve_settings_inputs
-    assert config._resolve_settings_inputs() is expected
+    assert bootstrap._resolve_settings_inputs() is expected
     assert call_count == 1
+
+
+def test_public_config_facade_does_not_expose_private_builder_helpers() -> None:
+    """Public config facade should not expose private bootstrap builder helpers."""
+    for private_name in (
+        "_build_settings",
+        "_resolve_settings_inputs",
+        "_resolve_settings_inputs_from_internal",
+        "os",
+        "sys",
+    ):
+        assert not hasattr(config, private_name)

--- a/tests/test_config_feature_flags.py
+++ b/tests/test_config_feature_flags.py
@@ -134,12 +134,11 @@ def test_resolve_settings_inputs_rejects_conflicting_feature_runtime_defaults(
         ),
     )
     with pytest.MonkeyPatch.context() as conflict_patch:
-        assert config._resolve_settings_inputs is bootstrap._resolve_settings_inputs
         conflict_patch.setattr(
             bootstrap, "get_profile_catalog", lambda: profile_catalog
         )
         with pytest.raises(RuntimeError, match="conflicting feature runtime defaults"):
-            config._resolve_settings_inputs()
+            bootstrap._resolve_settings_inputs()
 
 
 def test_runtime_flags_and_schema_env_overrides(


### PR DESCRIPTION
## Summary

- Route training through the runtime pipeline for all callers
- Keep use_profile_pipeline in the API for compatibility, but stop using it as a training execution fork
- Tighten ser.config by removing private/test-only re-exports and module aliases
- Update config tests to depend on the bootstrap owner module directly
- Add regression coverage to prevent both the legacy training branch and the leaked config helpers from returning
- Expand .gitignore for local caches and generated artifacts

## Why

This change addresses two architecture issues:

1. Training still had a split execution model, while inference was already pipeline-owned.
2. ser.config exposed internal builder helpers and module aliases that were only used by tests, which blurred the public boundary.

Unifying training keeps orchestration single-owned. Tightening the config facade makes the public surface smaller and more intentional.

## Implementation Details

- ser/_internal/api/runtime.py
    - run_training_workflow() now always builds a runtime pipeline and calls run_training()
    - use_profile_pipeline remains in the signature for backward compatibility
- ser/api.py
    - update training docstrings to reflect pipeline-owned behavior
- ser/config.py
    - remove _build_settings, _resolve_settings_inputs, _resolve_settings_inputs_from_internal, os, and sys from the public facade
- tests/test_api.py
    - replace legacy-training expectations with regression tests that assert the pipeline is still used when use_profile_pipeline=False
- tests/test_config.py
    - move internal builder/resolver assertions to ser._internal.config.bootstrap
    - add a regression test that ser.config does not expose private builder helpers
- tests/test_config_feature_flags.py
    - call the bootstrap resolver directly for internal conflict-resolution coverage