### PR TITLE
Centralize runtime worker lifecycle orchestration

### DIFF
--- a/ser/_internal/runtime/process_timeout.py
+++ b/ser/_internal/runtime/process_timeout.py
@@ -1,0 +1,124 @@
+"""Shared process-timeout orchestration for runtime inference workers."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import TypeVar
+
+_PayloadT = TypeVar("_PayloadT")
+_WorkerMessageT = TypeVar("_WorkerMessageT")
+_ResultT = TypeVar("_ResultT")
+
+
+def run_with_process_timeout(
+    *,
+    payload: _PayloadT,
+    resolve_profile: Callable[[_PayloadT], str],
+    timeout_seconds: float,
+    get_context: Callable[[str], object],
+    logger: logging.Logger,
+    setup_phase_name: str,
+    inference_phase_name: str,
+    log_phase_started: Callable[..., float | None],
+    log_phase_completed: Callable[..., float | None],
+    log_phase_failed: Callable[..., float | None],
+    run_process_setup_compute_handshake: Callable[..., _WorkerMessageT],
+    worker_target: Callable[..., None],
+    recv_worker_message: Callable[..., _WorkerMessageT],
+    is_setup_complete_message: Callable[[_WorkerMessageT], bool],
+    terminate_worker_process: Callable[..., None],
+    timeout_error_factory: Callable[[str], Exception] | type[Exception],
+    execution_error_factory: Callable[[str], Exception] | type[Exception],
+    worker_label: str,
+    process_join_grace_seconds: float,
+    parse_worker_completion_message: Callable[[_WorkerMessageT], _ResultT],
+) -> _ResultT:
+    """Runs one process-isolated setup+compute attempt under one timeout budget."""
+    profile = resolve_profile(payload)
+    setup_started_at = log_phase_started(
+        logger,
+        phase_name=setup_phase_name,
+        profile=profile,
+    )
+    setup_completed = False
+    inference_started_at: float | None = None
+    context = get_context("spawn")
+
+    def _on_setup_complete() -> None:
+        nonlocal inference_started_at
+        nonlocal setup_completed
+        setup_completed = True
+        log_phase_completed(
+            logger,
+            phase_name=setup_phase_name,
+            started_at=setup_started_at,
+            profile=profile,
+        )
+        inference_started_at = log_phase_started(
+            logger,
+            phase_name=inference_phase_name,
+            profile=profile,
+        )
+
+    try:
+        worker_message = run_process_setup_compute_handshake(
+            context=context,
+            worker_target=worker_target,
+            payload=payload,
+            timeout_seconds=timeout_seconds,
+            recv_worker_message=recv_worker_message,
+            is_setup_complete_message=is_setup_complete_message,
+            terminate_worker_process=terminate_worker_process,
+            timeout_error_factory=timeout_error_factory,
+            execution_error_factory=execution_error_factory,
+            worker_label=worker_label,
+            process_join_grace_seconds=process_join_grace_seconds,
+            on_setup_complete=_on_setup_complete,
+        )
+    except Exception:
+        if inference_started_at is not None:
+            log_phase_failed(
+                logger,
+                phase_name=inference_phase_name,
+                started_at=inference_started_at,
+                profile=profile,
+            )
+        elif not setup_completed:
+            log_phase_failed(
+                logger,
+                phase_name=setup_phase_name,
+                started_at=setup_started_at,
+                profile=profile,
+            )
+        raise
+
+    try:
+        result = parse_worker_completion_message(worker_message)
+    except Exception:
+        if inference_started_at is not None:
+            log_phase_failed(
+                logger,
+                phase_name=inference_phase_name,
+                started_at=inference_started_at,
+                profile=profile,
+            )
+        elif not setup_completed:
+            log_phase_failed(
+                logger,
+                phase_name=setup_phase_name,
+                started_at=setup_started_at,
+                profile=profile,
+            )
+        raise
+    if inference_started_at is not None:
+        log_phase_completed(
+            logger,
+            phase_name=inference_phase_name,
+            started_at=inference_started_at,
+            profile=profile,
+        )
+    return result
+
+
+__all__ = ["run_with_process_timeout"]

--- a/ser/_internal/runtime/retry_scaffold.py
+++ b/ser/_internal/runtime/retry_scaffold.py
@@ -1,0 +1,170 @@
+"""Shared retry/setup scaffolding for runtime inference operations."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import TypeVar
+
+_PayloadT = TypeVar("_PayloadT")
+_PreparedT = TypeVar("_PreparedT")
+_BackendT = TypeVar("_BackendT")
+_ResultT = TypeVar("_ResultT")
+
+
+def prepare_retry_state(
+    *,
+    use_process_isolation: bool,
+    logger: logging.Logger,
+    profile: str,
+    setup_phase_name: str,
+    log_phase_started: Callable[..., float | None],
+    log_phase_failed: Callable[..., float | None],
+    build_process_payload: Callable[[], _PayloadT],
+    prepare_in_process_operation: Callable[[], _PreparedT],
+) -> tuple[_PayloadT | None, _PreparedT | None, float | None]:
+    """Builds process payload or in-process prepared operation for one request."""
+    if use_process_isolation:
+        return build_process_payload(), None, None
+
+    setup_started_at = log_phase_started(
+        logger,
+        phase_name=setup_phase_name,
+        profile=profile,
+    )
+    try:
+        prepared_operation = prepare_in_process_operation()
+    except Exception:
+        if setup_started_at is not None:
+            log_phase_failed(
+                logger,
+                phase_name=setup_phase_name,
+                started_at=setup_started_at,
+                profile=profile,
+            )
+        raise
+    return None, prepared_operation, setup_started_at
+
+
+def finalize_in_process_setup(
+    *,
+    use_process_isolation: bool,
+    backend: _BackendT | None,
+    setup_started_at: float | None,
+    logger: logging.Logger,
+    profile: str,
+    setup_phase_name: str,
+    prepare_backend_runtime: Callable[[_BackendT], None],
+    log_phase_completed: Callable[..., float | None],
+    log_phase_failed: Callable[..., float | None],
+    missing_backend_message: str,
+    runtime_error_factory: Callable[[str], Exception],
+) -> None:
+    """Finalizes in-process setup and emits setup phase diagnostics."""
+    if use_process_isolation:
+        return
+    if backend is None:
+        raise runtime_error_factory(missing_backend_message)
+    try:
+        prepare_backend_runtime(backend)
+    except Exception:
+        if setup_started_at is not None:
+            log_phase_failed(
+                logger,
+                phase_name=setup_phase_name,
+                started_at=setup_started_at,
+                profile=profile,
+            )
+        raise
+    if setup_started_at is not None:
+        log_phase_completed(
+            logger,
+            phase_name=setup_phase_name,
+            started_at=setup_started_at,
+            profile=profile,
+        )
+
+
+def run_retryable_operation(
+    *,
+    enforce_timeout: bool,
+    use_process_isolation: bool,
+    process_payload: _PayloadT | None,
+    timeout_seconds: float,
+    logger: logging.Logger,
+    profile: str,
+    phase_name: str,
+    log_phase_started: Callable[..., float | None],
+    log_phase_completed: Callable[..., float | None],
+    log_phase_failed: Callable[..., float | None],
+    run_with_process_timeout: Callable[[_PayloadT], _ResultT],
+    run_once_inprocess: Callable[[], _ResultT],
+    run_with_timeout: Callable[..., _ResultT],
+    timeout_error_factory: Callable[[str], Exception] | type[Exception],
+    timeout_label: str,
+    missing_process_payload_message: str,
+    runtime_error_factory: Callable[[str], Exception],
+) -> _ResultT:
+    """Runs one retryable inference operation with shared phase orchestration."""
+    if enforce_timeout:
+        if use_process_isolation:
+            if process_payload is None:
+                raise runtime_error_factory(missing_process_payload_message)
+            return run_with_process_timeout(process_payload)
+        inference_started_at = log_phase_started(
+            logger,
+            phase_name=phase_name,
+            profile=profile,
+        )
+        try:
+            result = run_with_timeout(
+                operation=run_once_inprocess,
+                timeout_seconds=timeout_seconds,
+                timeout_error_factory=timeout_error_factory,
+                timeout_label=timeout_label,
+            )
+        except Exception:
+            log_phase_failed(
+                logger,
+                phase_name=phase_name,
+                started_at=inference_started_at,
+                profile=profile,
+            )
+            raise
+        log_phase_completed(
+            logger,
+            phase_name=phase_name,
+            started_at=inference_started_at,
+            profile=profile,
+        )
+        return result
+
+    inference_started_at = log_phase_started(
+        logger,
+        phase_name=phase_name,
+        profile=profile,
+    )
+    try:
+        result = run_once_inprocess()
+    except Exception:
+        log_phase_failed(
+            logger,
+            phase_name=phase_name,
+            started_at=inference_started_at,
+            profile=profile,
+        )
+        raise
+    log_phase_completed(
+        logger,
+        phase_name=phase_name,
+        started_at=inference_started_at,
+        profile=profile,
+    )
+    return result
+
+
+__all__ = [
+    "finalize_in_process_setup",
+    "prepare_retry_state",
+    "run_retryable_operation",
+]

--- a/ser/_internal/runtime/worker_bindings.py
+++ b/ser/_internal/runtime/worker_bindings.py
@@ -1,0 +1,130 @@
+"""Shared adapter helpers for runtime worker lifecycle bindings."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from multiprocessing.connection import Connection
+from multiprocessing.process import BaseProcess
+from typing import Any, TypeVar, cast
+
+_WorkerMessageT = TypeVar("_WorkerMessageT", bound=tuple[Any, ...], covariant=True)
+_ResultT = TypeVar("_ResultT")
+_PayloadT = TypeVar("_PayloadT")
+_PreparedT = TypeVar("_PreparedT")
+
+
+def recv_worker_message(
+    *,
+    connection: Connection,
+    stage: str,
+    impl: Callable[..., tuple[Any, ...]],
+    worker_label: str,
+    error_factory: Callable[[str], Exception] | type[Exception],
+) -> _WorkerMessageT:
+    """Delegates worker-message reads with stable label/error wiring."""
+    return cast(
+        _WorkerMessageT,
+        impl(
+            connection=connection,
+            stage=stage,
+            worker_label=worker_label,
+            error_factory=error_factory,
+        ),
+    )
+
+
+def is_setup_complete_message(
+    *,
+    message: _WorkerMessageT,
+    impl: Callable[..., bool],
+    worker_label: str,
+    error_factory: Callable[[str], Exception] | type[Exception],
+) -> bool:
+    """Delegates setup-complete message validation with shared wiring."""
+    return impl(
+        message=message,
+        worker_label=worker_label,
+        error_factory=error_factory,
+    )
+
+
+def parse_worker_completion_message(
+    *,
+    worker_message: _WorkerMessageT,
+    impl: Callable[..., _ResultT],
+    worker_label: str,
+    error_factory: Callable[[str], Exception] | type[Exception],
+    raise_worker_error: Callable[[str, str], None],
+    result_type: type[_ResultT],
+) -> _ResultT:
+    """Delegates worker completion parsing with shared wiring."""
+    return impl(
+        worker_message=worker_message,
+        worker_label=worker_label,
+        error_factory=error_factory,
+        raise_worker_error=raise_worker_error,
+        result_type=result_type,
+    )
+
+
+def run_worker_entry(
+    *,
+    payload: _PayloadT,
+    connection: Connection,
+    prepare_process_operation: Callable[[_PayloadT], _PreparedT],
+    run_process_operation: Callable[[_PreparedT], _ResultT],
+) -> None:
+    """Executes one process worker using the standard phase/ok/err envelope."""
+    try:
+        prepared_operation = prepare_process_operation(payload)
+        connection.send(("phase", "setup_complete"))
+        result = run_process_operation(prepared_operation)
+        connection.send(("ok", result))
+    except BaseException as err:
+        connection.send(("err", type(err).__name__, str(err)))
+    finally:
+        connection.close()
+
+
+def terminate_worker_process(
+    *,
+    process: BaseProcess,
+    impl: Callable[..., None],
+    terminate_grace_seconds: float,
+    kill_grace_seconds: float,
+) -> None:
+    """Delegates worker termination with shared grace-period wiring."""
+    impl(
+        process=process,
+        terminate_grace_seconds=terminate_grace_seconds,
+        kill_grace_seconds=kill_grace_seconds,
+    )
+
+
+def raise_worker_error(
+    *,
+    error_type: str,
+    message: str,
+    impl: Callable[..., None],
+    known_error_factories: dict[str, Callable[[str], Exception]],
+    unknown_error_factory: Callable[[str], Exception] | type[Exception],
+    worker_label: str,
+) -> None:
+    """Delegates worker error hydration with shared mapping wiring."""
+    impl(
+        error_type=error_type,
+        message=message,
+        known_error_factories=known_error_factories,
+        unknown_error_factory=unknown_error_factory,
+        worker_label=worker_label,
+    )
+
+
+__all__ = [
+    "is_setup_complete_message",
+    "parse_worker_completion_message",
+    "raise_worker_error",
+    "recv_worker_message",
+    "run_worker_entry",
+    "terminate_worker_process",
+]

--- a/ser/_internal/runtime/worker_bindings.py
+++ b/ser/_internal/runtime/worker_bindings.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 from collections.abc import Callable
 from multiprocessing.connection import Connection
 from multiprocessing.process import BaseProcess
-from typing import Any, TypeVar, cast
+from typing import Any, TypeVar
 
-_WorkerMessageT = TypeVar("_WorkerMessageT", bound=tuple[Any, ...], covariant=True)
+_WorkerMessageT = TypeVar("_WorkerMessageT", bound=tuple[Any, ...])
 _ResultT = TypeVar("_ResultT")
 _PayloadT = TypeVar("_PayloadT")
 _PreparedT = TypeVar("_PreparedT")
@@ -17,19 +17,16 @@ def recv_worker_message(
     *,
     connection: Connection,
     stage: str,
-    impl: Callable[..., tuple[Any, ...]],
+    impl: Callable[..., _WorkerMessageT],
     worker_label: str,
     error_factory: Callable[[str], Exception] | type[Exception],
 ) -> _WorkerMessageT:
     """Delegates worker-message reads with stable label/error wiring."""
-    return cast(
-        _WorkerMessageT,
-        impl(
-            connection=connection,
-            stage=stage,
-            worker_label=worker_label,
-            error_factory=error_factory,
-        ),
+    return impl(
+        connection=connection,
+        stage=stage,
+        worker_label=worker_label,
+        error_factory=error_factory,
     )
 
 

--- a/ser/runtime/accurate_inference.py
+++ b/ser/runtime/accurate_inference.py
@@ -15,6 +15,24 @@ import numpy as np
 from numpy.typing import NDArray
 
 from ser._internal.runtime.single_flight import SingleFlightRegistry
+from ser._internal.runtime.worker_bindings import (
+    is_setup_complete_message as _is_setup_complete_message_binding,
+)
+from ser._internal.runtime.worker_bindings import (
+    parse_worker_completion_message as _parse_worker_completion_message_binding,
+)
+from ser._internal.runtime.worker_bindings import (
+    raise_worker_error as _raise_worker_error_binding,
+)
+from ser._internal.runtime.worker_bindings import (
+    recv_worker_message as _recv_worker_message_binding,
+)
+from ser._internal.runtime.worker_bindings import (
+    run_worker_entry as _run_worker_entry_binding,
+)
+from ser._internal.runtime.worker_bindings import (
+    terminate_worker_process as _terminate_worker_process_binding,
+)
 from ser._internal.runtime.worker_lifecycle import (
     is_setup_complete_message as _is_setup_complete_message_impl,
 )
@@ -524,21 +542,20 @@ def _recv_worker_message(
     stage: str,
 ) -> WorkerMessage:
     """Receives one worker message and validates tuple envelope shape."""
-    return cast(
-        WorkerMessage,
-        _recv_worker_message_impl(
-            connection=connection,
-            stage=stage,
-            worker_label="Accurate inference",
-            error_factory=AccurateInferenceExecutionError,
-        ),
+    return _recv_worker_message_binding(
+        connection=connection,
+        stage=stage,
+        impl=_recv_worker_message_impl,
+        worker_label="Accurate inference",
+        error_factory=AccurateInferenceExecutionError,
     )
 
 
 def _is_setup_complete_message(message: WorkerMessage) -> bool:
     """Returns whether one worker message marks setup completion."""
-    return _is_setup_complete_message_impl(
+    return _is_setup_complete_message_binding(
         message=message,
+        impl=_is_setup_complete_message_impl,
         worker_label="Accurate inference",
         error_factory=AccurateInferenceExecutionError,
     )
@@ -546,8 +563,9 @@ def _is_setup_complete_message(message: WorkerMessage) -> bool:
 
 def _parse_worker_completion_message(worker_message: WorkerMessage) -> InferenceResult:
     """Parses one worker completion message and returns inference result."""
-    return _parse_worker_completion_message_impl(
+    return _parse_worker_completion_message_binding(
         worker_message=worker_message,
+        impl=_parse_worker_completion_message_impl,
         worker_label="Accurate inference",
         error_factory=AccurateInferenceExecutionError,
         raise_worker_error=_raise_worker_error,
@@ -560,15 +578,12 @@ def _worker_entry(
     connection: Connection,
 ) -> None:
     """Executes one inference operation inside child process."""
-    try:
-        prepared_operation = _prepare_process_operation(payload)
-        connection.send(("phase", "setup_complete"))
-        result = _run_process_operation(prepared_operation)
-        connection.send(("ok", result))
-    except BaseException as err:
-        connection.send(("err", type(err).__name__, str(err)))
-    finally:
-        connection.close()
+    _run_worker_entry_binding(
+        payload=payload,
+        connection=connection,
+        prepare_process_operation=_prepare_process_operation,
+        run_process_operation=_run_process_operation,
+    )
 
 
 def _prepare_in_process_accurate_operation(
@@ -720,8 +735,9 @@ def _build_backend_for_profile(
 
 def _terminate_worker_process(process: BaseProcess) -> None:
     """Terminates a timed-out worker process with kill fallback."""
-    _terminate_worker_process_impl(
+    _terminate_worker_process_binding(
         process=process,
+        impl=_terminate_worker_process_impl,
         terminate_grace_seconds=_TERMINATE_GRACE_SECONDS,
         kill_grace_seconds=_KILL_GRACE_SECONDS,
     )
@@ -729,9 +745,10 @@ def _terminate_worker_process(process: BaseProcess) -> None:
 
 def _raise_worker_error(error_type: str, message: str) -> None:
     """Rehydrates child-process errors into runtime-domain exceptions."""
-    _raise_worker_error_impl(
+    _raise_worker_error_binding(
         error_type=error_type,
         message=message,
+        impl=_raise_worker_error_impl,
         known_error_factories=_WORKER_ERROR_FACTORIES,
         unknown_error_factory=AccurateInferenceExecutionError,
         worker_label="Accurate inference",

--- a/ser/runtime/accurate_process_timeout.py
+++ b/ser/runtime/accurate_process_timeout.py
@@ -6,6 +6,10 @@ import logging
 from collections.abc import Callable
 from typing import Protocol, TypeVar
 
+from ser._internal.runtime.process_timeout import (
+    run_with_process_timeout as _run_with_process_timeout_impl,
+)
+
 _WorkerMessageT = TypeVar("_WorkerMessageT")
 _ResultT = TypeVar("_ResultT")
 
@@ -40,89 +44,28 @@ def run_with_process_timeout(
     parse_worker_completion_message: Callable[[_WorkerMessageT], _ResultT],
 ) -> _ResultT:
     """Runs one process-isolated attempt with timeout budget on compute phase."""
-    setup_started_at = log_phase_started(
-        logger,
-        phase_name=setup_phase_name,
-        profile=payload.expected_profile,
+    return _run_with_process_timeout_impl(
+        payload=payload,
+        resolve_profile=lambda active_payload: active_payload.expected_profile,
+        timeout_seconds=timeout_seconds,
+        get_context=get_context,
+        logger=logger,
+        setup_phase_name=setup_phase_name,
+        inference_phase_name=inference_phase_name,
+        log_phase_started=log_phase_started,
+        log_phase_completed=log_phase_completed,
+        log_phase_failed=log_phase_failed,
+        run_process_setup_compute_handshake=run_process_setup_compute_handshake,
+        worker_target=worker_target,
+        recv_worker_message=recv_worker_message,
+        is_setup_complete_message=is_setup_complete_message,
+        terminate_worker_process=terminate_worker_process,
+        timeout_error_factory=timeout_error_factory,
+        execution_error_factory=execution_error_factory,
+        worker_label=worker_label,
+        process_join_grace_seconds=process_join_grace_seconds,
+        parse_worker_completion_message=parse_worker_completion_message,
     )
-    setup_completed = False
-    inference_started_at: float | None = None
-    context = get_context("spawn")
-
-    def _on_setup_complete() -> None:
-        nonlocal inference_started_at
-        nonlocal setup_completed
-        setup_completed = True
-        log_phase_completed(
-            logger,
-            phase_name=setup_phase_name,
-            started_at=setup_started_at,
-            profile=payload.expected_profile,
-        )
-        inference_started_at = log_phase_started(
-            logger,
-            phase_name=inference_phase_name,
-            profile=payload.expected_profile,
-        )
-
-    try:
-        worker_message = run_process_setup_compute_handshake(
-            context=context,
-            worker_target=worker_target,
-            payload=payload,
-            timeout_seconds=timeout_seconds,
-            recv_worker_message=recv_worker_message,
-            is_setup_complete_message=is_setup_complete_message,
-            terminate_worker_process=terminate_worker_process,
-            timeout_error_factory=timeout_error_factory,
-            execution_error_factory=execution_error_factory,
-            worker_label=worker_label,
-            process_join_grace_seconds=process_join_grace_seconds,
-            on_setup_complete=_on_setup_complete,
-        )
-    except Exception:
-        if inference_started_at is not None:
-            log_phase_failed(
-                logger,
-                phase_name=inference_phase_name,
-                started_at=inference_started_at,
-                profile=payload.expected_profile,
-            )
-        elif not setup_completed:
-            log_phase_failed(
-                logger,
-                phase_name=setup_phase_name,
-                started_at=setup_started_at,
-                profile=payload.expected_profile,
-            )
-        raise
-
-    try:
-        result = parse_worker_completion_message(worker_message)
-    except Exception:
-        if inference_started_at is not None:
-            log_phase_failed(
-                logger,
-                phase_name=inference_phase_name,
-                started_at=inference_started_at,
-                profile=payload.expected_profile,
-            )
-        elif not setup_completed:
-            log_phase_failed(
-                logger,
-                phase_name=setup_phase_name,
-                started_at=setup_started_at,
-                profile=payload.expected_profile,
-            )
-        raise
-    if inference_started_at is not None:
-        log_phase_completed(
-            logger,
-            phase_name=inference_phase_name,
-            started_at=inference_started_at,
-            profile=payload.expected_profile,
-        )
-    return result
 
 
 __all__ = ["run_with_process_timeout"]

--- a/ser/runtime/accurate_retry_operation.py
+++ b/ser/runtime/accurate_retry_operation.py
@@ -6,6 +6,10 @@ import logging
 from collections.abc import Callable
 from typing import TypeVar
 
+from ser._internal.runtime.retry_scaffold import (
+    run_retryable_operation as _run_retryable_operation_impl,
+)
+
 _PayloadT = TypeVar("_PayloadT")
 _ResultT = TypeVar("_ResultT")
 
@@ -28,63 +32,27 @@ def run_accurate_retry_operation(
     phase_name: str,
 ) -> _ResultT:
     """Runs one accurate retry operation with timeout and phase logging."""
-    if enforce_timeout:
-        if use_process_isolation:
-            if process_payload is None:
-                raise RuntimeError(
-                    "Accurate process payload is missing for isolated execution."
-                )
-            return run_with_process_timeout(process_payload)
-        inference_started_at = log_phase_started(
-            logger,
-            phase_name=phase_name,
-            profile=expected_profile,
-        )
-        try:
-            result = run_with_timeout(
-                operation=run_once_inprocess,
-                timeout_seconds=timeout_seconds,
-                timeout_error_factory=timeout_error_factory,
-                timeout_label="Accurate inference",
-            )
-        except Exception:
-            log_phase_failed(
-                logger,
-                phase_name=phase_name,
-                started_at=inference_started_at,
-                profile=expected_profile,
-            )
-            raise
-        log_phase_completed(
-            logger,
-            phase_name=phase_name,
-            started_at=inference_started_at,
-            profile=expected_profile,
-        )
-        return result
-
-    inference_started_at = log_phase_started(
-        logger,
-        phase_name=phase_name,
+    return _run_retryable_operation_impl(
+        enforce_timeout=enforce_timeout,
+        use_process_isolation=use_process_isolation,
+        process_payload=process_payload,
+        timeout_seconds=timeout_seconds,
+        logger=logger,
         profile=expected_profile,
-    )
-    try:
-        result = run_once_inprocess()
-    except Exception:
-        log_phase_failed(
-            logger,
-            phase_name=phase_name,
-            started_at=inference_started_at,
-            profile=expected_profile,
-        )
-        raise
-    log_phase_completed(
-        logger,
         phase_name=phase_name,
-        started_at=inference_started_at,
-        profile=expected_profile,
+        log_phase_started=log_phase_started,
+        log_phase_completed=log_phase_completed,
+        log_phase_failed=log_phase_failed,
+        run_with_process_timeout=run_with_process_timeout,
+        run_once_inprocess=run_once_inprocess,
+        run_with_timeout=run_with_timeout,
+        timeout_error_factory=timeout_error_factory,
+        timeout_label="Accurate inference",
+        missing_process_payload_message=(
+            "Accurate process payload is missing for isolated execution."
+        ),
+        runtime_error_factory=RuntimeError,
     )
-    return result
 
 
 def run_accurate_inference_with_retry_policy(

--- a/ser/runtime/accurate_worker_operation.py
+++ b/ser/runtime/accurate_worker_operation.py
@@ -5,11 +5,17 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Generic, Protocol, TypeVar
+from typing import Generic, Protocol, TypeVar, cast
 
 import numpy as np
 from numpy.typing import NDArray
 
+from ser._internal.runtime.retry_scaffold import (
+    finalize_in_process_setup as _finalize_in_process_setup_impl,
+)
+from ser._internal.runtime.retry_scaffold import (
+    prepare_retry_state as _prepare_retry_state_impl,
+)
 from ser.config import AppConfig, ProfileRuntimeConfig
 
 
@@ -91,41 +97,29 @@ def prepare_retry_state(
 ]:
     """Builds initial retry state for accurate runtime and performs untimed setup."""
     retry_state = AccurateRetryOperationState[_PayloadT, _BackendT]()
-    setup_started_at: float | None = None
-    if use_process_isolation:
-        if process_payload is None:
-            raise RuntimeError(
-                "Accurate process payload is missing for isolated execution."
-            )
-        retry_state.process_payload = process_payload
-        return retry_state, None, setup_started_at
-
-    setup_started_at = log_phase_started(
-        logger,
-        phase_name=setup_phase_name,
-        profile=profile,
-    )
-    prepared_operation: PreparedAccurateOperation[_LoadedModelT, _BackendT] | None = (
-        None
-    )
-    try:
-        prepared_operation = prepare_in_process_operation(
-            request=request,
-            settings=settings,
-            runtime_config=runtime_config,
-            loaded_model=loaded_model,
-            backend=backend,
+    if use_process_isolation and process_payload is None:
+        raise RuntimeError("Accurate process payload is missing for isolated execution.")
+    active_process_payload, prepared_operation, setup_started_at = (
+        _prepare_retry_state_impl(
+            use_process_isolation=use_process_isolation,
+            logger=logger,
+            profile=profile,
+            setup_phase_name=setup_phase_name,
+            log_phase_started=log_phase_started,
+            log_phase_failed=log_phase_failed,
+            build_process_payload=lambda: cast(_PayloadT, process_payload),
+            prepare_in_process_operation=lambda: prepare_in_process_operation(
+                request=request,
+                settings=settings,
+                runtime_config=runtime_config,
+                loaded_model=loaded_model,
+                backend=backend,
+            ),
         )
+    )
+    retry_state.process_payload = active_process_payload
+    if prepared_operation is not None:
         retry_state.active_backend = prepared_operation.backend
-    except Exception:
-        if setup_started_at is not None:
-            log_phase_failed(
-                logger,
-                phase_name=setup_phase_name,
-                started_at=setup_started_at,
-                profile=profile,
-            )
-        raise
     return retry_state, prepared_operation, setup_started_at
 
 
@@ -143,30 +137,19 @@ def finalize_in_process_setup(
     runtime_error_factory: Callable[[str], Exception],
 ) -> None:
     """Prepares in-process backend runtime and emits setup phase diagnostics."""
-    if use_process_isolation:
-        return
-    if state.active_backend is None:
-        raise runtime_error_factory(
-            "Accurate backend is missing for in-process inference."
-        )
-    try:
-        prepare_accurate_backend_runtime(state.active_backend)
-    except Exception:
-        if setup_started_at is not None:
-            log_phase_failed(
-                logger,
-                phase_name=setup_phase_name,
-                started_at=setup_started_at,
-                profile=profile,
-            )
-        raise
-    if setup_started_at is not None:
-        log_phase_completed(
-            logger,
-            phase_name=setup_phase_name,
-            started_at=setup_started_at,
-            profile=profile,
-        )
+    _finalize_in_process_setup_impl(
+        use_process_isolation=use_process_isolation,
+        backend=state.active_backend,
+        setup_started_at=setup_started_at,
+        logger=logger,
+        profile=profile,
+        setup_phase_name=setup_phase_name,
+        prepare_backend_runtime=prepare_accurate_backend_runtime,
+        log_phase_completed=log_phase_completed,
+        log_phase_failed=log_phase_failed,
+        missing_backend_message="Accurate backend is missing for in-process inference.",
+        runtime_error_factory=runtime_error_factory,
+    )
 
 
 def prepare_in_process_operation(

--- a/ser/runtime/accurate_worker_operation.py
+++ b/ser/runtime/accurate_worker_operation.py
@@ -98,7 +98,9 @@ def prepare_retry_state(
     """Builds initial retry state for accurate runtime and performs untimed setup."""
     retry_state = AccurateRetryOperationState[_PayloadT, _BackendT]()
     if use_process_isolation and process_payload is None:
-        raise RuntimeError("Accurate process payload is missing for isolated execution.")
+        raise RuntimeError(
+            "Accurate process payload is missing for isolated execution."
+        )
     active_process_payload, prepared_operation, setup_started_at = (
         _prepare_retry_state_impl(
             use_process_isolation=use_process_isolation,

--- a/ser/runtime/fast_inference.py
+++ b/ser/runtime/fast_inference.py
@@ -7,9 +7,30 @@ from collections.abc import Callable
 from dataclasses import dataclass, replace
 from multiprocessing.connection import Connection
 from multiprocessing.process import BaseProcess
-from typing import Literal, cast
+from typing import Literal
 
 from ser._internal.runtime.single_flight import SingleFlightRegistry
+from ser._internal.runtime.process_timeout import (
+    run_with_process_timeout as _run_with_process_timeout_orchestration,
+)
+from ser._internal.runtime.worker_bindings import (
+    is_setup_complete_message as _is_setup_complete_message_binding,
+)
+from ser._internal.runtime.worker_bindings import (
+    parse_worker_completion_message as _parse_worker_completion_message_binding,
+)
+from ser._internal.runtime.worker_bindings import (
+    raise_worker_error as _raise_worker_error_binding,
+)
+from ser._internal.runtime.worker_bindings import (
+    recv_worker_message as _recv_worker_message_binding,
+)
+from ser._internal.runtime.worker_bindings import (
+    run_worker_entry as _run_worker_entry_binding,
+)
+from ser._internal.runtime.worker_bindings import (
+    terminate_worker_process as _terminate_worker_process_binding,
+)
 from ser._internal.runtime.worker_lifecycle import (
     is_setup_complete_message as _is_setup_complete_message_impl,
 )
@@ -21,6 +42,9 @@ from ser._internal.runtime.worker_lifecycle import (
 )
 from ser._internal.runtime.worker_lifecycle import (
     recv_worker_message as _recv_worker_message_impl,
+)
+from ser._internal.runtime.worker_lifecycle import (
+    run_process_setup_compute_handshake as _run_process_setup_compute_handshake_impl,
 )
 from ser._internal.runtime.worker_lifecycle import (
     run_with_timeout as _run_with_timeout_impl,
@@ -286,106 +310,28 @@ def _run_with_process_timeout(
     timeout_seconds: float,
 ) -> InferenceResult:
     """Runs one process-isolated attempt with timeout applied only to compute."""
-    setup_started_at = log_phase_started(
-        logger,
-        phase_name=PHASE_EMOTION_SETUP,
-        profile="fast",
+    return _run_with_process_timeout_orchestration(
+        payload=payload,
+        resolve_profile=lambda _payload: "fast",
+        timeout_seconds=timeout_seconds,
+        get_context=mp.get_context,
+        logger=logger,
+        setup_phase_name=PHASE_EMOTION_SETUP,
+        inference_phase_name=PHASE_EMOTION_INFERENCE,
+        log_phase_started=log_phase_started,
+        log_phase_completed=log_phase_completed,
+        log_phase_failed=log_phase_failed,
+        run_process_setup_compute_handshake=_run_process_setup_compute_handshake_impl,
+        worker_target=_worker_entry,
+        recv_worker_message=_recv_worker_message,
+        is_setup_complete_message=_is_setup_complete_message,
+        terminate_worker_process=_terminate_worker_process,
+        timeout_error_factory=FastInferenceTimeoutError,
+        execution_error_factory=FastInferenceExecutionError,
+        worker_label="Fast inference",
+        process_join_grace_seconds=_TERMINATE_GRACE_SECONDS,
+        parse_worker_completion_message=_parse_worker_completion_message,
     )
-    setup_completed = False
-    inference_started_at: float | None = None
-    context = mp.get_context("spawn")
-    parent_conn, child_conn = context.Pipe(duplex=False)
-    process = context.Process(
-        target=_worker_entry,
-        args=(payload, child_conn),
-        daemon=False,
-    )
-    process.start()
-    child_conn.close()
-    try:
-        try:
-            setup_message = _recv_worker_message(parent_conn, stage="setup")
-            if _is_setup_complete_message(setup_message):
-                setup_completed = True
-                log_phase_completed(
-                    logger,
-                    phase_name=PHASE_EMOTION_SETUP,
-                    started_at=setup_started_at,
-                    profile="fast",
-                )
-                inference_started_at = log_phase_started(
-                    logger,
-                    phase_name=PHASE_EMOTION_INFERENCE,
-                    profile="fast",
-                )
-                if timeout_seconds <= 0.0:
-                    worker_message = _recv_worker_message(parent_conn, stage="compute")
-                else:
-                    if not parent_conn.poll(timeout_seconds):
-                        if process.is_alive():
-                            _terminate_worker_process(process)
-                            raise FastInferenceTimeoutError(
-                                f"Fast inference exceeded timeout budget ({timeout_seconds:.2f}s)."
-                            )
-                        raise FastInferenceExecutionError(
-                            "Fast inference worker exited before sending compute result."
-                        )
-                    worker_message = _recv_worker_message(parent_conn, stage="compute")
-            else:
-                worker_message = setup_message
-            if process.is_alive():
-                process.join(timeout=_TERMINATE_GRACE_SECONDS)
-            if process.exitcode not in (0, None) and not parent_conn.poll():
-                raise FastInferenceExecutionError(
-                    "Fast inference worker exited without a result payload."
-                )
-        finally:
-            parent_conn.close()
-            if process.is_alive():
-                _terminate_worker_process(process)
-    except Exception:
-        if inference_started_at is not None:
-            log_phase_failed(
-                logger,
-                phase_name=PHASE_EMOTION_INFERENCE,
-                started_at=inference_started_at,
-                profile="fast",
-            )
-        elif not setup_completed:
-            log_phase_failed(
-                logger,
-                phase_name=PHASE_EMOTION_SETUP,
-                started_at=setup_started_at,
-                profile="fast",
-            )
-        raise
-
-    try:
-        result = _parse_worker_completion_message(worker_message)
-    except Exception:
-        if inference_started_at is not None:
-            log_phase_failed(
-                logger,
-                phase_name=PHASE_EMOTION_INFERENCE,
-                started_at=inference_started_at,
-                profile="fast",
-            )
-        elif not setup_completed:
-            log_phase_failed(
-                logger,
-                phase_name=PHASE_EMOTION_SETUP,
-                started_at=setup_started_at,
-                profile="fast",
-            )
-        raise
-    if inference_started_at is not None:
-        log_phase_completed(
-            logger,
-            phase_name=PHASE_EMOTION_INFERENCE,
-            started_at=inference_started_at,
-            profile="fast",
-        )
-    return result
 
 
 def _recv_worker_message(
@@ -394,21 +340,20 @@ def _recv_worker_message(
     stage: str,
 ) -> WorkerMessage:
     """Receives one worker message and validates tuple envelope shape."""
-    return cast(
-        WorkerMessage,
-        _recv_worker_message_impl(
-            connection=connection,
-            stage=stage,
-            worker_label="Fast inference",
-            error_factory=FastInferenceExecutionError,
-        ),
+    return _recv_worker_message_binding(
+        connection=connection,
+        stage=stage,
+        impl=_recv_worker_message_impl,
+        worker_label="Fast inference",
+        error_factory=FastInferenceExecutionError,
     )
 
 
 def _is_setup_complete_message(message: WorkerMessage) -> bool:
     """Returns whether one worker message marks setup completion."""
-    return _is_setup_complete_message_impl(
+    return _is_setup_complete_message_binding(
         message=message,
+        impl=_is_setup_complete_message_impl,
         worker_label="Fast inference",
         error_factory=FastInferenceExecutionError,
     )
@@ -416,8 +361,9 @@ def _is_setup_complete_message(message: WorkerMessage) -> bool:
 
 def _parse_worker_completion_message(worker_message: WorkerMessage) -> InferenceResult:
     """Parses one worker completion message and returns inference result."""
-    return _parse_worker_completion_message_impl(
+    return _parse_worker_completion_message_binding(
         worker_message=worker_message,
+        impl=_parse_worker_completion_message_impl,
         worker_label="Fast inference",
         error_factory=FastInferenceExecutionError,
         raise_worker_error=_raise_worker_error,
@@ -427,15 +373,12 @@ def _parse_worker_completion_message(worker_message: WorkerMessage) -> Inference
 
 def _worker_entry(payload: FastProcessPayload, connection: Connection) -> None:
     """Executes one fast inference operation inside child process."""
-    try:
-        prepared_operation = _prepare_process_operation(payload)
-        connection.send(("phase", "setup_complete"))
-        result = _run_process_operation(prepared_operation)
-        connection.send(("ok", result))
-    except BaseException as err:
-        connection.send(("err", type(err).__name__, str(err)))
-    finally:
-        connection.close()
+    _run_worker_entry_binding(
+        payload=payload,
+        connection=connection,
+        prepare_process_operation=_prepare_process_operation,
+        run_process_operation=_run_process_operation,
+    )
 
 
 def _prepare_process_operation(payload: FastProcessPayload) -> _PreparedFastOperation:
@@ -479,8 +422,9 @@ def _ensure_fast_compatible_model(loaded_model: LoadedModel) -> None:
 
 def _terminate_worker_process(process: BaseProcess) -> None:
     """Terminates a timed-out worker process with kill fallback."""
-    _terminate_worker_process_impl(
+    _terminate_worker_process_binding(
         process=process,
+        impl=_terminate_worker_process_impl,
         terminate_grace_seconds=_TERMINATE_GRACE_SECONDS,
         kill_grace_seconds=_KILL_GRACE_SECONDS,
     )
@@ -488,9 +432,10 @@ def _terminate_worker_process(process: BaseProcess) -> None:
 
 def _raise_worker_error(error_type: str, message: str) -> None:
     """Rehydrates child-process errors into runtime-domain exceptions."""
-    _raise_worker_error_impl(
+    _raise_worker_error_binding(
         error_type=error_type,
         message=message,
+        impl=_raise_worker_error_impl,
         known_error_factories=_WORKER_ERROR_FACTORIES,
         unknown_error_factory=FastInferenceExecutionError,
         worker_label="Fast inference",

--- a/ser/runtime/fast_inference.py
+++ b/ser/runtime/fast_inference.py
@@ -9,10 +9,10 @@ from multiprocessing.connection import Connection
 from multiprocessing.process import BaseProcess
 from typing import Literal
 
-from ser._internal.runtime.single_flight import SingleFlightRegistry
 from ser._internal.runtime.process_timeout import (
     run_with_process_timeout as _run_with_process_timeout_orchestration,
 )
+from ser._internal.runtime.single_flight import SingleFlightRegistry
 from ser._internal.runtime.worker_bindings import (
     is_setup_complete_message as _is_setup_complete_message_binding,
 )

--- a/ser/runtime/medium_inference.py
+++ b/ser/runtime/medium_inference.py
@@ -8,12 +8,30 @@ from dataclasses import dataclass, replace
 from functools import partial
 from multiprocessing.connection import Connection
 from multiprocessing.process import BaseProcess
-from typing import Literal, cast
+from typing import Literal
 
 import numpy as np
 from numpy.typing import NDArray
 
 from ser._internal.runtime.single_flight import SingleFlightRegistry
+from ser._internal.runtime.worker_bindings import (
+    is_setup_complete_message as _is_setup_complete_message_binding,
+)
+from ser._internal.runtime.worker_bindings import (
+    parse_worker_completion_message as _parse_worker_completion_message_binding,
+)
+from ser._internal.runtime.worker_bindings import (
+    raise_worker_error as _raise_worker_error_binding,
+)
+from ser._internal.runtime.worker_bindings import (
+    recv_worker_message as _recv_worker_message_binding,
+)
+from ser._internal.runtime.worker_bindings import (
+    run_worker_entry as _run_worker_entry_binding,
+)
+from ser._internal.runtime.worker_bindings import (
+    terminate_worker_process as _terminate_worker_process_binding,
+)
 from ser._internal.runtime.worker_lifecycle import (
     is_setup_complete_message as _is_setup_complete_message_impl,
 )
@@ -450,21 +468,20 @@ def _recv_worker_message(
     stage: str,
 ) -> WorkerMessage:
     """Receives one worker message and validates tuple envelope shape."""
-    return cast(
-        WorkerMessage,
-        _recv_worker_message_impl(
-            connection=connection,
-            stage=stage,
-            worker_label="Medium inference",
-            error_factory=MediumInferenceExecutionError,
-        ),
+    return _recv_worker_message_binding(
+        connection=connection,
+        stage=stage,
+        impl=_recv_worker_message_impl,
+        worker_label="Medium inference",
+        error_factory=MediumInferenceExecutionError,
     )
 
 
 def _is_setup_complete_message(message: WorkerMessage) -> bool:
     """Returns whether one worker message marks setup completion."""
-    return _is_setup_complete_message_impl(
+    return _is_setup_complete_message_binding(
         message=message,
+        impl=_is_setup_complete_message_impl,
         worker_label="Medium inference",
         error_factory=MediumInferenceExecutionError,
     )
@@ -472,8 +489,9 @@ def _is_setup_complete_message(message: WorkerMessage) -> bool:
 
 def _parse_worker_completion_message(worker_message: WorkerMessage) -> InferenceResult:
     """Parses one worker completion message and returns inference result."""
-    return _parse_worker_completion_message_impl(
+    return _parse_worker_completion_message_binding(
         worker_message=worker_message,
+        impl=_parse_worker_completion_message_impl,
         worker_label="Medium inference",
         error_factory=MediumInferenceExecutionError,
         raise_worker_error=_raise_worker_error,
@@ -486,15 +504,12 @@ def _worker_entry(
     connection: Connection,
 ) -> None:
     """Executes one medium inference operation inside a child process."""
-    try:
-        prepared_operation = _prepare_process_operation(payload)
-        connection.send(("phase", "setup_complete"))
-        result = _run_process_operation(prepared_operation)
-        connection.send(("ok", result))
-    except BaseException as err:
-        connection.send(("err", type(err).__name__, str(err)))
-    finally:
-        connection.close()
+    _run_worker_entry_binding(
+        payload=payload,
+        connection=connection,
+        prepare_process_operation=_prepare_process_operation,
+        run_process_operation=_run_process_operation,
+    )
 
 
 def _prepare_in_process_operation(
@@ -666,8 +681,9 @@ def _build_medium_backend(
 
 def _terminate_worker_process(process: BaseProcess) -> None:
     """Terminates a timed-out worker process with kill fallback."""
-    _terminate_worker_process_impl(
+    _terminate_worker_process_binding(
         process=process,
+        impl=_terminate_worker_process_impl,
         terminate_grace_seconds=_TERMINATE_GRACE_SECONDS,
         kill_grace_seconds=_KILL_GRACE_SECONDS,
     )
@@ -675,9 +691,10 @@ def _terminate_worker_process(process: BaseProcess) -> None:
 
 def _raise_worker_error(error_type: str, message: str) -> None:
     """Rehydrates child-process errors into runtime-domain exceptions."""
-    _raise_worker_error_impl(
+    _raise_worker_error_binding(
         error_type=error_type,
         message=message,
+        impl=_raise_worker_error_impl,
         known_error_factories=_WORKER_ERROR_FACTORIES,
         unknown_error_factory=MediumInferenceExecutionError,
         worker_label="Medium inference",

--- a/ser/runtime/medium_process_timeout.py
+++ b/ser/runtime/medium_process_timeout.py
@@ -6,6 +6,10 @@ import logging
 from collections.abc import Callable
 from typing import TypeVar
 
+from ser._internal.runtime.process_timeout import (
+    run_with_process_timeout as _run_with_process_timeout_impl,
+)
+
 _WorkerMessageT = TypeVar("_WorkerMessageT")
 _ResultT = TypeVar("_ResultT")
 
@@ -34,89 +38,28 @@ def run_with_process_timeout(
     parse_worker_completion_message: Callable[[_WorkerMessageT], _ResultT],
 ) -> _ResultT:
     """Runs one process-isolated attempt with timeout budget on compute phase."""
-    setup_started_at = log_phase_started(
-        logger,
-        phase_name=setup_phase_name,
-        profile=profile,
+    return _run_with_process_timeout_impl(
+        payload=payload,
+        resolve_profile=lambda _payload: profile,
+        timeout_seconds=timeout_seconds,
+        get_context=get_context,
+        logger=logger,
+        setup_phase_name=setup_phase_name,
+        inference_phase_name=inference_phase_name,
+        log_phase_started=log_phase_started,
+        log_phase_completed=log_phase_completed,
+        log_phase_failed=log_phase_failed,
+        run_process_setup_compute_handshake=run_process_setup_compute_handshake,
+        worker_target=worker_target,
+        recv_worker_message=recv_worker_message,
+        is_setup_complete_message=is_setup_complete_message,
+        terminate_worker_process=terminate_worker_process,
+        timeout_error_factory=timeout_error_factory,
+        execution_error_factory=execution_error_factory,
+        worker_label=worker_label,
+        process_join_grace_seconds=process_join_grace_seconds,
+        parse_worker_completion_message=parse_worker_completion_message,
     )
-    setup_completed = False
-    inference_started_at: float | None = None
-    context = get_context("spawn")
-
-    def _on_setup_complete() -> None:
-        nonlocal inference_started_at
-        nonlocal setup_completed
-        setup_completed = True
-        log_phase_completed(
-            logger,
-            phase_name=setup_phase_name,
-            started_at=setup_started_at,
-            profile=profile,
-        )
-        inference_started_at = log_phase_started(
-            logger,
-            phase_name=inference_phase_name,
-            profile=profile,
-        )
-
-    try:
-        worker_message = run_process_setup_compute_handshake(
-            context=context,
-            worker_target=worker_target,
-            payload=payload,
-            timeout_seconds=timeout_seconds,
-            recv_worker_message=recv_worker_message,
-            is_setup_complete_message=is_setup_complete_message,
-            terminate_worker_process=terminate_worker_process,
-            timeout_error_factory=timeout_error_factory,
-            execution_error_factory=execution_error_factory,
-            worker_label=worker_label,
-            process_join_grace_seconds=process_join_grace_seconds,
-            on_setup_complete=_on_setup_complete,
-        )
-    except Exception:
-        if inference_started_at is not None:
-            log_phase_failed(
-                logger,
-                phase_name=inference_phase_name,
-                started_at=inference_started_at,
-                profile=profile,
-            )
-        elif not setup_completed:
-            log_phase_failed(
-                logger,
-                phase_name=setup_phase_name,
-                started_at=setup_started_at,
-                profile=profile,
-            )
-        raise
-
-    try:
-        result = parse_worker_completion_message(worker_message)
-    except Exception:
-        if inference_started_at is not None:
-            log_phase_failed(
-                logger,
-                phase_name=inference_phase_name,
-                started_at=inference_started_at,
-                profile=profile,
-            )
-        elif not setup_completed:
-            log_phase_failed(
-                logger,
-                phase_name=setup_phase_name,
-                started_at=setup_started_at,
-                profile=profile,
-            )
-        raise
-    if inference_started_at is not None:
-        log_phase_completed(
-            logger,
-            phase_name=inference_phase_name,
-            started_at=inference_started_at,
-            profile=profile,
-        )
-    return result
 
 
 __all__ = ["run_with_process_timeout"]

--- a/ser/runtime/medium_worker_operation.py
+++ b/ser/runtime/medium_worker_operation.py
@@ -336,6 +336,7 @@ def run_inference_operation(
     runtime_error_factory: Callable[[str], Exception],
 ) -> _ResultT:
     """Runs one medium inference attempt with phase/timing orchestration."""
+
     def _run_once_inprocess() -> _ResultT:
         if prepared_operation is None:
             raise runtime_error_factory(

--- a/ser/runtime/medium_worker_operation.py
+++ b/ser/runtime/medium_worker_operation.py
@@ -10,6 +10,15 @@ from typing import Generic, Protocol, TypeVar
 import numpy as np
 from numpy.typing import NDArray
 
+from ser._internal.runtime.retry_scaffold import (
+    finalize_in_process_setup as _finalize_in_process_setup_impl,
+)
+from ser._internal.runtime.retry_scaffold import (
+    prepare_retry_state as _prepare_retry_state_impl,
+)
+from ser._internal.runtime.retry_scaffold import (
+    run_retryable_operation as _run_retryable_operation_impl,
+)
 from ser.config import AppConfig, MediumRuntimeConfig
 
 _LoadedModelT = TypeVar("_LoadedModelT")
@@ -102,18 +111,15 @@ def prepare_retry_state(
 ]:
     """Builds initial retry state for medium runtime and performs untimed setup."""
     retry_state = MediumRetryOperationState[_PayloadT, _LoadedModelT, _BackendT]()
-    setup_started_at: float | None = None
-    if use_process_isolation:
-        retry_state.process_payload = build_process_payload()
-        return retry_state, setup_started_at
-
-    setup_started_at = log_phase_started(
-        logger,
-        phase_name=setup_phase_name,
+    process_payload, prepared_operation, setup_started_at = _prepare_retry_state_impl(
+        use_process_isolation=use_process_isolation,
+        logger=logger,
         profile=profile,
-    )
-    try:
-        retry_state.prepared_operation = prepare_in_process_operation(
+        setup_phase_name=setup_phase_name,
+        log_phase_started=log_phase_started,
+        log_phase_failed=log_phase_failed,
+        build_process_payload=build_process_payload,
+        prepare_in_process_operation=lambda: prepare_in_process_operation(
             request=request,
             settings=settings,
             loaded_model=loaded_model,
@@ -121,16 +127,10 @@ def prepare_retry_state(
             expected_backend_model_id=expected_backend_model_id,
             runtime_device=policy_device,
             runtime_dtype=policy_dtype,
-        )
-    except Exception:
-        if setup_started_at is not None:
-            log_phase_failed(
-                logger,
-                phase_name=setup_phase_name,
-                started_at=setup_started_at,
-                profile=profile,
-            )
-        raise
+        ),
+    )
+    retry_state.process_payload = process_payload
+    retry_state.prepared_operation = prepared_operation
     return retry_state, setup_started_at
 
 
@@ -148,30 +148,22 @@ def finalize_in_process_setup(
     runtime_error_factory: Callable[[str], Exception],
 ) -> None:
     """Prepares in-process backend runtime and emits setup phase diagnostics."""
-    if use_process_isolation:
-        return
-    if state.prepared_operation is None:
-        raise runtime_error_factory(
-            "Medium inference operation prerequisites are missing."
-        )
-    try:
-        prepare_medium_backend_runtime(state.prepared_operation.backend)
-    except Exception:
-        if setup_started_at is not None:
-            log_phase_failed(
-                logger,
-                phase_name=setup_phase_name,
-                started_at=setup_started_at,
-                profile=profile,
-            )
-        raise
-    if setup_started_at is not None:
-        log_phase_completed(
-            logger,
-            phase_name=setup_phase_name,
-            started_at=setup_started_at,
-            profile=profile,
-        )
+    prepared_backend = (
+        None if state.prepared_operation is None else state.prepared_operation.backend
+    )
+    _finalize_in_process_setup_impl(
+        use_process_isolation=use_process_isolation,
+        backend=prepared_backend,
+        setup_started_at=setup_started_at,
+        logger=logger,
+        profile=profile,
+        setup_phase_name=setup_phase_name,
+        prepare_backend_runtime=prepare_medium_backend_runtime,
+        log_phase_completed=log_phase_completed,
+        log_phase_failed=log_phase_failed,
+        missing_backend_message="Medium inference operation prerequisites are missing.",
+        runtime_error_factory=runtime_error_factory,
+    )
 
 
 def ensure_medium_compatible_model(
@@ -344,69 +336,40 @@ def run_inference_operation(
     runtime_error_factory: Callable[[str], Exception],
 ) -> _ResultT:
     """Runs one medium inference attempt with phase/timing orchestration."""
-    if enforce_timeout:
-        if use_process_isolation:
-            if process_payload is None:
-                raise runtime_error_factory(
-                    "Medium process payload is missing for isolated execution."
-                )
-            return run_with_process_timeout(process_payload, timeout_seconds)
-        inference_started_at = log_phase_started(
-            logger,
-            phase_name=inference_phase_name,
-            profile=profile,
-        )
-
-        def timeout_operation() -> _ResultT:
-            if prepared_operation is None:
-                raise runtime_error_factory(
-                    "Medium inference operation prerequisites are missing."
-                )
-            return run_process_operation(prepared_operation)
-
-        try:
-            result = run_with_timeout(timeout_operation, timeout_seconds)
-        except Exception:
-            log_phase_failed(
-                logger,
-                phase_name=inference_phase_name,
-                started_at=inference_started_at,
-                profile=profile,
+    def _run_once_inprocess() -> _ResultT:
+        if prepared_operation is None:
+            raise runtime_error_factory(
+                "Medium inference operation prerequisites are missing."
             )
-            raise
-        log_phase_completed(
-            logger,
-            phase_name=inference_phase_name,
-            started_at=inference_started_at,
-            profile=profile,
-        )
-        return result
-    if prepared_operation is None:
-        raise runtime_error_factory(
-            "Medium inference operation prerequisites are missing."
-        )
-    inference_started_at = log_phase_started(
-        logger,
-        phase_name=inference_phase_name,
+        return run_process_operation(prepared_operation)
+
+    return _run_retryable_operation_impl(
+        enforce_timeout=enforce_timeout,
+        use_process_isolation=use_process_isolation,
+        process_payload=process_payload,
+        timeout_seconds=timeout_seconds,
+        logger=logger,
         profile=profile,
-    )
-    try:
-        result = run_process_operation(prepared_operation)
-    except Exception:
-        log_phase_failed(
-            logger,
-            phase_name=inference_phase_name,
-            started_at=inference_started_at,
-            profile=profile,
-        )
-        raise
-    log_phase_completed(
-        logger,
         phase_name=inference_phase_name,
-        started_at=inference_started_at,
-        profile=profile,
+        log_phase_started=log_phase_started,
+        log_phase_completed=log_phase_completed,
+        log_phase_failed=log_phase_failed,
+        run_with_process_timeout=lambda payload: run_with_process_timeout(
+            payload,
+            timeout_seconds,
+        ),
+        run_once_inprocess=_run_once_inprocess,
+        run_with_timeout=lambda **kwargs: run_with_timeout(
+            kwargs["operation"],
+            kwargs["timeout_seconds"],
+        ),
+        timeout_error_factory=runtime_error_factory,
+        timeout_label="Medium inference",
+        missing_process_payload_message=(
+            "Medium process payload is missing for isolated execution."
+        ),
+        runtime_error_factory=runtime_error_factory,
     )
-    return result
 
 
 def run_process_operation(


### PR DESCRIPTION
## Summary

This PR consolidates the remaining duplicated worker-lifecycle orchestration in the runtime inference stack.

It introduces shared internal owners for:
- process timeout orchestration
- worker message/binding adapters
- retry/setup control flow

The fast, medium, and accurate runtime paths are then rebased onto those shared helpers. No public API or CLI behavior is intended to change.

## What Changed

- Added a shared internal process-timeout helper and moved the phase-aware setup/compute timeout flow behind a single owner.
- Replaced the duplicated medium/accurate timeout module logic with thin wrappers over that shared helper.
- Moved fast off its last bespoke process-timeout implementation so all runtime profiles now use the same timeout orchestration path.
- Added shared worker-binding helpers for worker message reads, setup-complete checks, completion parsing, worker entry envelopes, termination wiring, and worker error rehydration.
- Rebased the fast, medium, and accurate inference modules onto those worker binding helpers while preserving module-local wrapper names for compatibility and test/monkeypatch seams.
- Added a shared retry/setup scaffold for retry-state preparation, in-process setup finalization, and timeout-vs-in-process execution branching.
- Rebased the medium/accurate worker-operation and accurate retry helpers onto that shared scaffold.
- Intentionally kept medium/accurate CPU fallback handlers profile-local, because their eligibility rules, state mutation, and backend rebuild policy still differ materially.

## Why

- Removes the last bespoke fast worker timeout path.
- Eliminates similar medium/accurate timeout orchestration.
- Reduces repeated worker-lifecycle adapter boilerplate across runtime profiles.
- Makes timeout and retry behavior single-owned without flattening profile-specific backend policy.
- Preserves existing exception surfaces, phase logging semantics, and compatibility seams while reducing maintenance overhead.