### PR TITLE
CI: upgrade remaining GitHub Actions majors

### DIFF
--- a/.github/workflows/darwin-x86_64-validation.yml
+++ b/.github/workflows/darwin-x86_64-validation.yml
@@ -13,15 +13,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Configure runtime directories
         run: |
-          echo "SER_MAX_WORKERS=1" >> "$GITHUB_ENV"
-          echo "SER_MODELS_DIR=$RUNNER_TEMP/ser-models" >> "$GITHUB_ENV"
-          echo "SER_DATA_DIR=$RUNNER_TEMP/ser-data" >> "$GITHUB_ENV"
-          echo "SER_CACHE_DIR=$RUNNER_TEMP/ser-cache" >> "$GITHUB_ENV"
-          echo "SER_TRANSCRIPTS_DIR=$RUNNER_TEMP/ser-transcripts" >> "$GITHUB_ENV"
+          {
+            echo "SER_MAX_WORKERS=1"
+            echo "SER_MODELS_DIR=$RUNNER_TEMP/ser-models"
+            echo "SER_DATA_DIR=$RUNNER_TEMP/ser-data"
+            echo "SER_CACHE_DIR=$RUNNER_TEMP/ser-cache"
+            echo "SER_TRANSCRIPTS_DIR=$RUNNER_TEMP/ser-transcripts"
+          } >> "$GITHUB_ENV"
           mkdir -p \
             "$RUNNER_TEMP/ser-models" \
             "$RUNNER_TEMP/ser-data" \
@@ -29,7 +31,7 @@ jobs:
             "$RUNNER_TEMP/ser-transcripts"
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -44,7 +46,7 @@ jobs:
           ffmpeg -version
 
       - name: Cache uv
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/uv
           key: uv-${{ runner.os }}-darwin-intel-py3.12-${{ hashFiles('uv.lock') }}

--- a/.github/workflows/full-dataset-quality-gate-regression.yml
+++ b/.github/workflows/full-dataset-quality-gate-regression.yml
@@ -34,10 +34,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -45,7 +45,7 @@ jobs:
         run: python -m pip install --upgrade pip uv
 
       - name: Cache uv
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/uv
           key: uv-${{ runner.os }}-full-gate-${{ hashFiles('uv.lock') }}

--- a/.github/workflows/linux-python-3_13-cli-validation.yml
+++ b/.github/workflows/linux-python-3_13-cli-validation.yml
@@ -29,15 +29,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Configure runtime directories
         run: |
-          echo "SER_MAX_WORKERS=1" >> "$GITHUB_ENV"
-          echo "SER_MODELS_DIR=$RUNNER_TEMP/ser-models" >> "$GITHUB_ENV"
-          echo "SER_DATA_DIR=$RUNNER_TEMP/ser-data" >> "$GITHUB_ENV"
-          echo "SER_CACHE_DIR=$RUNNER_TEMP/ser-cache" >> "$GITHUB_ENV"
-          echo "SER_TRANSCRIPTS_DIR=$RUNNER_TEMP/ser-transcripts" >> "$GITHUB_ENV"
+          {
+            echo "SER_MAX_WORKERS=1"
+            echo "SER_MODELS_DIR=$RUNNER_TEMP/ser-models"
+            echo "SER_DATA_DIR=$RUNNER_TEMP/ser-data"
+            echo "SER_CACHE_DIR=$RUNNER_TEMP/ser-cache"
+            echo "SER_TRANSCRIPTS_DIR=$RUNNER_TEMP/ser-transcripts"
+          } >> "$GITHUB_ENV"
           mkdir -p \
             "$RUNNER_TEMP/ser-models" \
             "$RUNNER_TEMP/ser-data" \
@@ -45,7 +47,7 @@ jobs:
             "$RUNNER_TEMP/ser-transcripts"
 
       - name: Set up Python 3.13
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
@@ -61,7 +63,7 @@ jobs:
           ffmpeg -version
 
       - name: Cache uv
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/uv
           key: uv-${{ runner.os }}-linux-py313-cli-${{ hashFiles('uv.lock') }}

--- a/.github/workflows/linux-selfhosted-gpu-validation.yml
+++ b/.github/workflows/linux-selfhosted-gpu-validation.yml
@@ -66,15 +66,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Configure runtime directories
         run: |
-          echo "SER_MAX_WORKERS=1" >> "$GITHUB_ENV"
-          echo "SER_MODELS_DIR=$RUNNER_TEMP/ser-models" >> "$GITHUB_ENV"
-          echo "SER_DATA_DIR=$RUNNER_TEMP/ser-data" >> "$GITHUB_ENV"
-          echo "SER_CACHE_DIR=$RUNNER_TEMP/ser-cache" >> "$GITHUB_ENV"
-          echo "SER_TRANSCRIPTS_DIR=$RUNNER_TEMP/ser-transcripts" >> "$GITHUB_ENV"
+          {
+            echo "SER_MAX_WORKERS=1"
+            echo "SER_MODELS_DIR=$RUNNER_TEMP/ser-models"
+            echo "SER_DATA_DIR=$RUNNER_TEMP/ser-data"
+            echo "SER_CACHE_DIR=$RUNNER_TEMP/ser-cache"
+            echo "SER_TRANSCRIPTS_DIR=$RUNNER_TEMP/ser-transcripts"
+          } >> "$GITHUB_ENV"
           mkdir -p \
             "$RUNNER_TEMP/ser-models" \
             "$RUNNER_TEMP/ser-data" \
@@ -82,7 +84,7 @@ jobs:
             "$RUNNER_TEMP/ser-transcripts"
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ inputs.python_version }}
 
@@ -98,7 +100,7 @@ jobs:
           ffmpeg -version
 
       - name: Cache uv
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/uv
           key: uv-${{ runner.os }}-selfhosted-cuda-py${{ inputs.python_version }}-${{ hashFiles('uv.lock') }}
@@ -211,15 +213,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Configure runtime directories
         run: |
-          echo "SER_MAX_WORKERS=1" >> "$GITHUB_ENV"
-          echo "SER_MODELS_DIR=$RUNNER_TEMP/ser-models" >> "$GITHUB_ENV"
-          echo "SER_DATA_DIR=$RUNNER_TEMP/ser-data" >> "$GITHUB_ENV"
-          echo "SER_CACHE_DIR=$RUNNER_TEMP/ser-cache" >> "$GITHUB_ENV"
-          echo "SER_TRANSCRIPTS_DIR=$RUNNER_TEMP/ser-transcripts" >> "$GITHUB_ENV"
+          {
+            echo "SER_MAX_WORKERS=1"
+            echo "SER_MODELS_DIR=$RUNNER_TEMP/ser-models"
+            echo "SER_DATA_DIR=$RUNNER_TEMP/ser-data"
+            echo "SER_CACHE_DIR=$RUNNER_TEMP/ser-cache"
+            echo "SER_TRANSCRIPTS_DIR=$RUNNER_TEMP/ser-transcripts"
+          } >> "$GITHUB_ENV"
           mkdir -p \
             "$RUNNER_TEMP/ser-models" \
             "$RUNNER_TEMP/ser-data" \
@@ -227,7 +231,7 @@ jobs:
             "$RUNNER_TEMP/ser-transcripts"
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ inputs.python_version }}
 
@@ -243,7 +247,7 @@ jobs:
           ffmpeg -version
 
       - name: Cache uv
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/uv
           key: uv-${{ runner.os }}-selfhosted-xpu-py${{ inputs.python_version }}-${{ hashFiles('uv.lock') }}

--- a/.github/workflows/macos15-mps-validation.yml
+++ b/.github/workflows/macos15-mps-validation.yml
@@ -34,15 +34,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Configure runtime directories
         run: |
-          echo "SER_MAX_WORKERS=1" >> "$GITHUB_ENV"
-          echo "SER_MODELS_DIR=$RUNNER_TEMP/ser-models" >> "$GITHUB_ENV"
-          echo "SER_DATA_DIR=$RUNNER_TEMP/ser-data" >> "$GITHUB_ENV"
-          echo "SER_CACHE_DIR=$RUNNER_TEMP/ser-cache" >> "$GITHUB_ENV"
-          echo "SER_TRANSCRIPTS_DIR=$RUNNER_TEMP/ser-transcripts" >> "$GITHUB_ENV"
+          {
+            echo "SER_MAX_WORKERS=1"
+            echo "SER_MODELS_DIR=$RUNNER_TEMP/ser-models"
+            echo "SER_DATA_DIR=$RUNNER_TEMP/ser-data"
+            echo "SER_CACHE_DIR=$RUNNER_TEMP/ser-cache"
+            echo "SER_TRANSCRIPTS_DIR=$RUNNER_TEMP/ser-transcripts"
+          } >> "$GITHUB_ENV"
           mkdir -p \
             "$RUNNER_TEMP/ser-models" \
             "$RUNNER_TEMP/ser-data" \
@@ -50,7 +52,7 @@ jobs:
             "$RUNNER_TEMP/ser-transcripts"
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ inputs.python_version }}
 
@@ -65,7 +67,7 @@ jobs:
           ffmpeg -version
 
       - name: Cache uv
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/uv
           key: uv-${{ runner.os }}-macos15-mps-py${{ inputs.python_version }}-${{ hashFiles('uv.lock') }}

--- a/.github/workflows/python-publish-testpypi.yml
+++ b/.github/workflows/python-publish-testpypi.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout release tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.release.tag_name }}
       - name: Resolve release commit SHA
@@ -64,11 +64,11 @@ jobs:
 
     steps:
       - name: Checkout release commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ needs.verify-ci.outputs.head_sha }}
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Build distributions

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout release tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.release.tag_name }}
       - name: Resolve release commit SHA
@@ -64,11 +64,11 @@ jobs:
 
     steps:
       - name: Checkout release commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ needs.verify-ci.outputs.head_sha }}
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Build distributions


### PR DESCRIPTION
## Summary
- upgrade the remaining workflow files off the Node 20 deprecation path
- move `actions/checkout` to `v5`, `actions/cache` to `v5`, and `actions/setup-python` to `v6` where they were still pinned
- fold the repeated `GITHUB_ENV` writes into grouped redirects so `actionlint` stays clean

## Validation
- `actionlint`
- `make prepush-check`

## Notes
- these action releases require Actions Runner `v2.327.1` or newer; hosted runners satisfy this, and self-hosted lanes should already be on or above that version