### PR TITLE
Fix publish workflow syntax

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -76,7 +76,6 @@ jobs:
 
   selfhosted-gpu-validation:
     needs: verify-ci
-    continue-on-error: true
     uses: ./.github/workflows/linux-selfhosted-gpu-validation.yml
     with:
       run_cuda: true
@@ -85,7 +84,6 @@ jobs:
 
   full-dataset-quality-gate:
     needs: verify-ci
-    continue-on-error: true
     uses: ./.github/workflows/full-dataset-quality-gate-regression.yml
     with:
       run_training: true


### PR DESCRIPTION
Summary:
- remove unsupported continue-on-error keys from reusable-workflow caller jobs in python-publish.yml
- restore workflow parsing for publish automation