### PR TITLE
test: organize config behavior suites

### DIFF
--- a/tests/suites/integration/test_config.py
+++ b/tests/suites/integration/test_config.py
@@ -1,6 +1,5 @@
 """Tests for typed configuration loading and environment refresh."""
 
-from collections.abc import Generator
 from pathlib import Path
 
 import pytest
@@ -9,13 +8,10 @@ import ser.config as config
 from ser._internal.config import bootstrap
 from ser._internal.config.settings_inputs import ResolvedSettingsInputs
 
-
-@pytest.fixture(autouse=True)
-def _reset_settings() -> Generator[None, None, None]:
-    """Keeps global settings stable across tests."""
-    config.reload_settings()
-    yield
-    config.reload_settings()
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.usefixtures("reset_ambient_settings"),
+]
 
 
 def test_reload_settings_reads_environment(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/suites/integration/test_config_feature_flags.py
+++ b/tests/suites/integration/test_config_feature_flags.py
@@ -2,7 +2,6 @@
 
 import importlib
 import os
-from collections.abc import Generator
 from dataclasses import replace
 from pathlib import Path
 
@@ -13,14 +12,10 @@ from ser._internal.config import bootstrap
 from ser._internal.config.schema import profile_artifact_file_names
 from ser.profiles import get_profile_catalog
 
-
-@pytest.fixture(autouse=True)
-def _reset_settings(monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, None]:
-    """Keeps global settings stable across tests."""
-    config.reload_settings()
-    yield
-    monkeypatch.delenv("WHISPER_BACKEND", raising=False)
-    config.reload_settings()
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.usefixtures("reset_ambient_settings"),
+]
 
 
 def test_runtime_flags_and_schema_defaults() -> None:

--- a/tests/suites/integration/test_license_gates.py
+++ b/tests/suites/integration/test_license_gates.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
 from pathlib import Path
 
 import pytest
@@ -20,13 +19,10 @@ from ser.license_check import (
 from ser.runtime.contracts import InferenceRequest
 from ser.runtime.schema import OUTPUT_SCHEMA_VERSION, InferenceResult
 
-
-@pytest.fixture(autouse=True)
-def _reset_settings() -> Generator[None]:
-    """Keeps runtime settings deterministic across tests."""
-    config.reload_settings()
-    yield
-    config.reload_settings()
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.usefixtures("reset_ambient_settings"),
+]
 
 
 def test_unrestricted_backend_allowed_without_restricted_opt_in() -> None:

--- a/tests/suites/integration/test_profile_resolution.py
+++ b/tests/suites/integration/test_profile_resolution.py
@@ -1,7 +1,5 @@
 """Tests for runtime profile resolution from rollout flags."""
 
-from collections.abc import Generator
-
 import pytest
 
 import ser.config as config
@@ -13,13 +11,10 @@ from ser.profiles import (
     resolve_profile_name,
 )
 
-
-@pytest.fixture(autouse=True)
-def _reset_settings() -> Generator[None, None, None]:
-    """Keeps global settings stable across tests."""
-    config.reload_settings()
-    yield
-    config.reload_settings()
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.usefixtures("reset_ambient_settings"),
+]
 
 
 def test_available_profiles_have_expected_identifiers() -> None:


### PR DESCRIPTION
## Summary
- move config/profile/license behavior tests into tests/suites/integration
- replace duplicated ambient settings reset fixtures with the shared fixture
- keep unrelated local files out of the change

## Validation
- uv run --frozen --extra dev pytest -q tests/suites/integration/test_config.py tests/suites/integration/test_config_feature_flags.py tests/suites/integration/test_profile_resolution.py tests/suites/integration/test_license_gates.py
- uv run --frozen --extra dev --extra medium pytest -q tests/suites
- make import-lint