### PR TITLE
ci: persist validation dataset consents

### DIFF
--- a/.github/workflows/darwin-x86_64-validation.yml
+++ b/.github/workflows/darwin-x86_64-validation.yml
@@ -60,6 +60,9 @@ jobs:
       - name: Build synthetic RAVDESS smoke dataset
         run: python ./scripts/build_synthetic_ravdess_dataset.py
 
+      - name: Persist validation dataset consents
+        run: ./scripts/configure_validation_dataset_consents.sh
+
       - name: Fast profile train and predict
         run: |
           uv run ser --train

--- a/.github/workflows/full-dataset-quality-gate-regression.yml
+++ b/.github/workflows/full-dataset-quality-gate-regression.yml
@@ -70,6 +70,12 @@ jobs:
           restore-keys: |
             uv-${{ runner.os }}-full-gate-
 
+      - name: Bootstrap synthetic RAVDESS dataset for hosted validation
+        run: python ./scripts/build_synthetic_ravdess_dataset.py
+
+      - name: Persist validation dataset consents
+        run: ./scripts/configure_validation_dataset_consents.sh
+
       - name: Run full-dataset quality gate suite (opt-in)
         env:
           SER_FULL_GATE_RUN_TRAINING: ${{ inputs.run_training && 'true' || 'false' }}

--- a/.github/workflows/linux-python-3_13-cli-validation.yml
+++ b/.github/workflows/linux-python-3_13-cli-validation.yml
@@ -95,6 +95,9 @@ jobs:
       - name: Build synthetic RAVDESS smoke dataset
         run: python ./scripts/build_synthetic_ravdess_dataset.py
 
+      - name: Persist validation dataset consents
+        run: ./scripts/configure_validation_dataset_consents.sh --python 3.13
+
       - name: Fast profile train and predict
         run: |
           uv run --python 3.13 ser --train --profile fast

--- a/.github/workflows/linux-selfhosted-gpu-validation.yml
+++ b/.github/workflows/linux-selfhosted-gpu-validation.yml
@@ -167,6 +167,9 @@ jobs:
       - name: Build synthetic RAVDESS smoke dataset
         run: python ./scripts/build_synthetic_ravdess_dataset.py
 
+      - name: Persist validation dataset consents
+        run: ./scripts/configure_validation_dataset_consents.sh --python ${{ inputs.python_version }}
+
       - name: Run CUDA-focused policy/runtime tests
         run: >
           uv run --python ${{ inputs.python_version }} --extra dev pytest -q

--- a/.github/workflows/macos15-mps-validation.yml
+++ b/.github/workflows/macos15-mps-validation.yml
@@ -125,6 +125,9 @@ jobs:
       - name: Build synthetic RAVDESS smoke dataset
         run: python ./scripts/build_synthetic_ravdess_dataset.py
 
+      - name: Persist validation dataset consents
+        run: ./scripts/configure_validation_dataset_consents.sh --python ${{ inputs.python_version }}
+
       - name: Run MPS-focused runtime policy tests
         run: >
           uv run --python ${{ inputs.python_version }} --extra dev pytest -q

--- a/scripts/configure_validation_dataset_consents.sh
+++ b/scripts/configure_validation_dataset_consents.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Validation workflows train against the synthetic RAVDESS dataset, so they must
+# persist the required dataset acknowledgements before invoking `ser --train`.
+uv run "$@" ser configure \
+  --accept-dataset-policy noncommercial \
+  --accept-dataset-license cc-by-nc-sa-4.0 \
+  --persist


### PR DESCRIPTION
## Summary
- add a shared helper to persist dataset consents for validation runs
- call it from hosted train/predict validation workflows
- bootstrap synthetic RAVDESS for the hosted full-dataset gate

## Validation
- bash -n scripts/configure_validation_dataset_consents.sh
- ruby -e 'require "yaml"; %w[.github/workflows/linux-python-3_13-cli-validation.yml .github/workflows/darwin-x86_64-validation.yml .github/workflows/macos15-mps-validation.yml .github/workflows/linux-selfhosted-gpu-validation.yml .github/workflows/full-dataset-quality-gate-regression.yml].each { |p| YAML.load_file(p) }'
- temp-file smoke run of scripts/configure_validation_dataset_consents.sh