### PR TITLE
fix: stabilize hosted validation training paths

### DIFF
--- a/.github/workflows/darwin-x86_64-validation.yml
+++ b/.github/workflows/darwin-x86_64-validation.yml
@@ -72,12 +72,20 @@ jobs:
         run: |
           SER_ENABLE_PROFILE_PIPELINE=true \
           SER_ENABLE_MEDIUM_PROFILE=true \
+          WHISPER_BACKEND=faster_whisper \
+          WHISPER_MODEL=tiny \
+          WHISPER_DEMUCS=false \
+          WHISPER_VAD=false \
           SER_MODEL_FILE_NAME=ser_model_medium_darwin_x86_64.pkl \
           SER_TRAINING_REPORT_FILE_NAME=training_report_medium_darwin_x86_64.json \
           uv run --extra medium ser --train
 
           SER_ENABLE_PROFILE_PIPELINE=true \
           SER_ENABLE_MEDIUM_PROFILE=true \
+          WHISPER_BACKEND=faster_whisper \
+          WHISPER_MODEL=tiny \
+          WHISPER_DEMUCS=false \
+          WHISPER_VAD=false \
           SER_MODEL_FILE_NAME=ser_model_medium_darwin_x86_64.pkl \
           SER_TRAINING_REPORT_FILE_NAME=training_report_medium_darwin_x86_64.json \
           uv run --extra medium ser --file sample.wav
@@ -86,6 +94,7 @@ jobs:
         run: |
           SER_ENABLE_PROFILE_PIPELINE=true \
           SER_ENABLE_ACCURATE_PROFILE=true \
+          WHISPER_BACKEND=faster_whisper \
           SER_ACCURATE_MODEL_ID=openai/whisper-tiny \
           WHISPER_MODEL=tiny \
           WHISPER_DEMUCS=false \
@@ -96,6 +105,7 @@ jobs:
 
           SER_ENABLE_PROFILE_PIPELINE=true \
           SER_ENABLE_ACCURATE_PROFILE=true \
+          WHISPER_BACKEND=faster_whisper \
           SER_ACCURATE_MODEL_ID=openai/whisper-tiny \
           WHISPER_MODEL=tiny \
           WHISPER_DEMUCS=false \

--- a/.github/workflows/macos15-mps-validation.yml
+++ b/.github/workflows/macos15-mps-validation.yml
@@ -143,12 +143,20 @@ jobs:
         run: |
           SER_TORCH_DEVICE=auto \
           SER_TORCH_DTYPE=auto \
+          WHISPER_BACKEND=faster_whisper \
+          WHISPER_MODEL=tiny \
+          WHISPER_DEMUCS=false \
+          WHISPER_VAD=false \
           SER_MODEL_FILE_NAME=ser_model_medium_macos15_mps.pkl \
           SER_TRAINING_REPORT_FILE_NAME=training_report_medium_macos15_mps.json \
           uv run --python ${{ inputs.python_version }} --extra medium ser --train --profile medium
 
           SER_TORCH_DEVICE=auto \
           SER_TORCH_DTYPE=auto \
+          WHISPER_BACKEND=faster_whisper \
+          WHISPER_MODEL=tiny \
+          WHISPER_DEMUCS=false \
+          WHISPER_VAD=false \
           SER_MODEL_FILE_NAME=ser_model_medium_macos15_mps.pkl \
           SER_TRAINING_REPORT_FILE_NAME=training_report_medium_macos15_mps.json \
           uv run --python ${{ inputs.python_version }} --extra medium ser --file sample.wav --profile medium
@@ -157,6 +165,7 @@ jobs:
         run: |
           SER_TORCH_DEVICE=auto \
           SER_TORCH_DTYPE=auto \
+          WHISPER_BACKEND=faster_whisper \
           SER_ACCURATE_MODEL_ID=${{ inputs.accurate_model_id }} \
           WHISPER_MODEL=tiny \
           WHISPER_DEMUCS=false \
@@ -167,6 +176,7 @@ jobs:
 
           SER_TORCH_DEVICE=auto \
           SER_TORCH_DTYPE=auto \
+          WHISPER_BACKEND=faster_whisper \
           SER_ACCURATE_MODEL_ID=${{ inputs.accurate_model_id }} \
           WHISPER_MODEL=tiny \
           WHISPER_DEMUCS=false \

--- a/ser/data/data_loader.py
+++ b/ser/data/data_loader.py
@@ -13,14 +13,14 @@ import numpy as np
 from numpy.typing import NDArray
 from sklearn.model_selection import train_test_split
 
-from ser.config import AppConfig, reload_settings
+from ser.config import AppConfig, AudioReadConfig, FeatureFlags, reload_settings
 from ser.data.adapters.ravdess import build_ravdess_utterances
 from ser.data.dataset_prepare import prepare_from_registry_entry
 from ser.data.dataset_registry import load_dataset_registry
 from ser.data.label_ontology import resolve_label_ontology
 from ser.data.manifest import Utterance
 from ser.data.manifest_jsonl import load_manifest_jsonl
-from ser.features import extract_feature
+from ser.features.feature_extractor import _extract_feature_for_settings
 from ser.utils.logger import get_logger
 
 logger: logging.Logger = get_logger(__name__)
@@ -169,7 +169,10 @@ def process_file(
     file: str,
     observed_emotions: Collection[str],
     emotion_map: dict[str, str],
-    settings: AppConfig,
+    *,
+    settings: AppConfig | None = None,
+    feature_flags: FeatureFlags | None = None,
+    audio_read_config: AudioReadConfig | None = None,
 ) -> ProcessFileResult:
     """Extracts features for a file when its label is in the target emotion set.
 
@@ -177,6 +180,9 @@ def process_file(
         file: Path to an audio file.
         observed_emotions: Emotion labels accepted for training.
         emotion_map: Mapping from dataset emotion codes to labels.
+        settings: Optional full settings snapshot for direct callers.
+        feature_flags: Explicit feature flag snapshot for worker-safe extraction.
+        audio_read_config: Explicit audio-read settings for worker-safe extraction.
 
     Returns:
         A result object containing the extracted `(feature_vector, emotion_label)` or
@@ -198,8 +204,19 @@ def process_file(
 
         if not emotion or emotion not in observed_emotions:
             return ProcessFileResult(sample=None, error=None)
+        if settings is not None:
+            feature_flags = settings.feature_flags
+            audio_read_config = settings.audio_read
+        if feature_flags is None or audio_read_config is None:
+            raise ValueError(
+                "process_file requires either settings or explicit feature extraction config."
+            )
         features: FeatureVector = np.asarray(
-            extract_feature(file, settings=settings),
+            _extract_feature_for_settings(
+                file,
+                feature_flags=feature_flags,
+                audio_read_config=audio_read_config,
+            ),
             dtype=np.float64,
         )
 
@@ -271,7 +288,8 @@ def _load_data_for_settings(
         process_file,
         observed_emotions=observed_emotions,
         emotion_map=dict(settings.emotions),
-        settings=settings,
+        feature_flags=settings.feature_flags,
+        audio_read_config=settings.audio_read,
     )
     worker_count: int = _resolve_worker_count(
         max_cores=settings.models.num_cores,

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -1,5 +1,7 @@
 """Behavior tests for resilient dataset loading."""
 
+import pickle
+from functools import partial
 from pathlib import Path
 from types import SimpleNamespace
 from typing import cast
@@ -7,6 +9,7 @@ from typing import cast
 import numpy as np
 import pytest
 
+import ser.config as config
 from ser.config import AppConfig
 from ser.data import data_loader as dl
 from ser.data.manifest import MANIFEST_SCHEMA_VERSION
@@ -16,6 +19,8 @@ def _build_settings(max_failed_file_ratio: float = 0.5) -> SimpleNamespace:
     """Returns a minimal settings object for data-loader tests."""
     return SimpleNamespace(
         emotions={"03": "happy", "04": "sad"},
+        feature_flags=config.FeatureFlags(),
+        audio_read=config.AudioReadConfig(),
         dataset=SimpleNamespace(
             glob_pattern="unused",
             folder=Path("unused"),
@@ -113,11 +118,15 @@ def test_load_data_aborts_when_failure_ratio_exceeds_threshold(
         file: str,
         observed_emotions: set[str],
         emotion_map: dict[str, str],
-        settings: object,
+        *,
+        feature_flags: object | None = None,
+        audio_read_config: object | None = None,
+        settings: object | None = None,
     ) -> dl.ProcessFileResult:
         assert observed_emotions
         assert emotion_map
-        assert settings is not None
+        assert feature_flags is not None or settings is not None
+        assert audio_read_config is not None or settings is not None
         if file == "a.wav":
             return dl.ProcessFileResult(
                 sample=(np.asarray([1.0, 2.0], dtype=np.float64), "happy"),
@@ -149,11 +158,15 @@ def test_load_data_returns_split_for_valid_samples(
         file: str,
         observed_emotions: set[str],
         emotion_map: dict[str, str],
-        settings: object,
+        *,
+        feature_flags: object | None = None,
+        audio_read_config: object | None = None,
+        settings: object | None = None,
     ) -> dl.ProcessFileResult:
         assert observed_emotions
         assert emotion_map
-        assert settings is not None
+        assert feature_flags is not None or settings is not None
+        assert audio_read_config is not None or settings is not None
         return dl.ProcessFileResult(sample=sample_map[file], error=None)
 
     monkeypatch.setattr(dl, "process_file", fake_process_file)
@@ -165,6 +178,20 @@ def test_load_data_returns_split_for_valid_samples(
     assert x_train.shape[1] == 2
     assert x_test.shape[1] == 2
     assert len(y_train) + len(y_test) == 4
+
+
+def test_process_file_worker_partial_is_picklable_with_runtime_settings() -> None:
+    """Runtime settings snapshots should produce a picklable worker partial."""
+    settings = config.reload_settings()
+    process_fn = partial(
+        dl.process_file,
+        observed_emotions=set(settings.emotions.values()),
+        emotion_map=dict(settings.emotions),
+        feature_flags=settings.feature_flags,
+        audio_read_config=settings.audio_read,
+    )
+
+    pickle.dumps(process_fn)
 
 
 def test_load_utterances_prefers_manifest_when_configured(


### PR DESCRIPTION
## Summary
- avoid pickling the full AppConfig in the data-loader multiprocessing worker path
- add a regression test that asserts the worker partial is picklable with real settings
- switch hosted Darwin/macOS medium and accurate smoke lanes to the safer faster-whisper path

## Validation
- uv run --frozen --extra dev pytest -q tests/test_data_loader.py
- uv run ruff check ser/data/data_loader.py tests/test_data_loader.py
- uv run pyright --pythonversion 3.12 ser/data/data_loader.py tests/test_data_loader.py
- ruby -e 'require "yaml"; %w[.github/workflows/darwin-x86_64-validation.yml .github/workflows/macos15-mps-validation.yml].each { |p| YAML.load_file(p) }'