### PR TITLE
ci: serialize full-dataset hosted workers

### DIFF
--- a/.github/workflows/full-dataset-quality-gate-regression.yml
+++ b/.github/workflows/full-dataset-quality-gate-regression.yml
@@ -59,6 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 180
     env:
+      SER_MAX_WORKERS: "1"
       SER_MODELS_DIR: ${{ github.workspace }}/.ser-models
       FAST_MODEL_FILE_NAME: ser_model_fast_full.pkl
       FAST_TRAINING_REPORT_FILE_NAME: training_report_fast_full.json
@@ -137,6 +138,7 @@ jobs:
     needs:
       - train_full_dataset_quality_gate_artifacts
     env:
+      SER_MAX_WORKERS: "1"
       SER_MODELS_DIR: ${{ github.workspace }}/.ser-models
       FAST_MODEL_FILE_NAME: ser_model_fast_full.pkl
       FAST_TRAINING_REPORT_FILE_NAME: training_report_fast_full.json


### PR DESCRIPTION
## Summary
- pin the hosted full-dataset regression workflow to a single worker in both jobs
- align it with the other hosted validation workflows that already force 
- reduce hosted runner hangs in the training step before the full gate runs

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/full-dataset-quality-gate-regression.yml"); puts "yaml ok"'
- git push pre-push hooks (pyupgrade, ruff, isort, black, mypy, pyright)