### PR TITLE
ci: extract workflow helper scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,18 +214,4 @@ jobs:
           twine check dist/*
 
       - name: Smoke-test wheel installation
-        run: |
-          python -m venv .pkg-smoke
-          . .pkg-smoke/bin/activate
-          python -m pip install --upgrade pip
-          pip install --no-deps dist/*.whl
-          tmp_dir="$(mktemp -d)"
-          cd "$tmp_dir"
-          python - <<'PY'
-          import importlib.metadata as md
-          import ser
-
-          print(f"Installed ser version: {md.version('ser')}")
-          print(f"Imported from: {ser.__file__}")
-          print(f"Exports: {', '.join(ser.__all__)}")
-          PY
+        run: ./scripts/workflows/smoke_test_wheel_install.sh

--- a/.github/workflows/darwin-x86_64-validation.yml
+++ b/.github/workflows/darwin-x86_64-validation.yml
@@ -17,19 +17,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Configure runtime directories
-        run: |
-          {
-            echo "SER_MAX_WORKERS=1"
-            echo "SER_MODELS_DIR=$RUNNER_TEMP/ser-models"
-            echo "SER_DATA_DIR=$RUNNER_TEMP/ser-data"
-            echo "SER_CACHE_DIR=$RUNNER_TEMP/ser-cache"
-            echo "SER_TRANSCRIPTS_DIR=$RUNNER_TEMP/ser-transcripts"
-          } >> "$GITHUB_ENV"
-          mkdir -p \
-            "$RUNNER_TEMP/ser-models" \
-            "$RUNNER_TEMP/ser-data" \
-            "$RUNNER_TEMP/ser-cache" \
-            "$RUNNER_TEMP/ser-transcripts"
+        run: ./scripts/workflows/configure_runtime_dirs.sh
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v6
@@ -40,11 +28,7 @@ jobs:
         run: python -m pip install --upgrade pip uv
 
       - name: Ensure ffmpeg is available
-        run: |
-          if ! command -v ffmpeg >/dev/null 2>&1; then
-            brew install ffmpeg
-          fi
-          ffmpeg -version
+        run: ./scripts/workflows/ensure_ffmpeg.sh --mode brew-install
 
       - name: Cache uv
         uses: actions/cache@v5
@@ -55,7 +39,7 @@ jobs:
             uv-${{ runner.os }}-darwin-intel-py3.12-
 
       - name: Setup compatible environment
-        run: ./scripts/setup_compatible_env.sh --python 3.12 --extra medium --no-dev --skip-git-hooks
+        run: ./scripts/workflows/setup_validation_environment.sh --python 3.12 --no-dev
 
       - name: Build synthetic RAVDESS smoke dataset
         run: python ./scripts/build_synthetic_ravdess_dataset.py
@@ -64,55 +48,32 @@ jobs:
         run: ./scripts/configure_validation_dataset_consents.sh
 
       - name: Fast profile train and predict
-        run: |
-          uv run ser --train
-          uv run ser --file sample.wav
+        run: ./scripts/workflows/run_profile_smoke.sh --profile fast
 
       - name: Medium profile train and predict
-        run: |
-          SER_ENABLE_PROFILE_PIPELINE=true \
-          SER_ENABLE_MEDIUM_PROFILE=true \
-          WHISPER_BACKEND=faster_whisper \
-          WHISPER_MODEL=tiny \
-          WHISPER_DEMUCS=false \
-          WHISPER_VAD=false \
-          SER_MODEL_FILE_NAME=ser_model_medium_darwin_x86_64.pkl \
-          SER_TRAINING_REPORT_FILE_NAME=training_report_medium_darwin_x86_64.json \
-          uv run --extra medium ser --train
-
-          SER_ENABLE_PROFILE_PIPELINE=true \
-          SER_ENABLE_MEDIUM_PROFILE=true \
-          WHISPER_BACKEND=faster_whisper \
-          WHISPER_MODEL=tiny \
-          WHISPER_DEMUCS=false \
-          WHISPER_VAD=false \
-          SER_MODEL_FILE_NAME=ser_model_medium_darwin_x86_64.pkl \
-          SER_TRAINING_REPORT_FILE_NAME=training_report_medium_darwin_x86_64.json \
-          uv run --extra medium ser --file sample.wav
+        env:
+          SER_ENABLE_PROFILE_PIPELINE: "true"
+          SER_ENABLE_MEDIUM_PROFILE: "true"
+          WHISPER_BACKEND: faster_whisper
+          WHISPER_MODEL: tiny
+          WHISPER_DEMUCS: "false"
+          WHISPER_VAD: "false"
+          SER_MODEL_FILE_NAME: ser_model_medium_darwin_x86_64.pkl
+          SER_TRAINING_REPORT_FILE_NAME: training_report_medium_darwin_x86_64.json
+        run: ./scripts/workflows/run_profile_smoke.sh --uv-extra medium --profile medium
 
       - name: Accurate profile train and predict (compatibility smoke)
-        run: |
-          SER_ENABLE_PROFILE_PIPELINE=true \
-          SER_ENABLE_ACCURATE_PROFILE=true \
-          WHISPER_BACKEND=faster_whisper \
-          SER_ACCURATE_MODEL_ID=openai/whisper-tiny \
-          WHISPER_MODEL=tiny \
-          WHISPER_DEMUCS=false \
-          WHISPER_VAD=false \
-          SER_MODEL_FILE_NAME=ser_model_accurate_darwin_x86_64.pkl \
-          SER_TRAINING_REPORT_FILE_NAME=training_report_accurate_darwin_x86_64.json \
-          uv run --extra medium ser --train
-
-          SER_ENABLE_PROFILE_PIPELINE=true \
-          SER_ENABLE_ACCURATE_PROFILE=true \
-          WHISPER_BACKEND=faster_whisper \
-          SER_ACCURATE_MODEL_ID=openai/whisper-tiny \
-          WHISPER_MODEL=tiny \
-          WHISPER_DEMUCS=false \
-          WHISPER_VAD=false \
-          SER_MODEL_FILE_NAME=ser_model_accurate_darwin_x86_64.pkl \
-          SER_TRAINING_REPORT_FILE_NAME=training_report_accurate_darwin_x86_64.json \
-          uv run --extra medium ser --file sample.wav
+        env:
+          SER_ENABLE_PROFILE_PIPELINE: "true"
+          SER_ENABLE_ACCURATE_PROFILE: "true"
+          WHISPER_BACKEND: faster_whisper
+          SER_ACCURATE_MODEL_ID: openai/whisper-tiny
+          WHISPER_MODEL: tiny
+          WHISPER_DEMUCS: "false"
+          WHISPER_VAD: "false"
+          SER_MODEL_FILE_NAME: ser_model_accurate_darwin_x86_64.pkl
+          SER_TRAINING_REPORT_FILE_NAME: training_report_accurate_darwin_x86_64.json
+        run: ./scripts/workflows/run_profile_smoke.sh --uv-extra medium --profile accurate
 
       - name: Upload validation artifacts
         if: always()

--- a/.github/workflows/full-dataset-quality-gate-regression.yml
+++ b/.github/workflows/full-dataset-quality-gate-regression.yml
@@ -92,8 +92,8 @@ jobs:
       - name: Persist validation dataset consents
         run: ./scripts/configure_validation_dataset_consents.sh
 
-      - name: Prepare artifact workspace
-        run: mkdir -p "${SER_MODELS_DIR}"
+      - name: Configure runtime directories
+        run: ./scripts/workflows/configure_runtime_dirs.sh --models-dir "${SER_MODELS_DIR}"
 
       - name: Require training artifacts on hosted runners
         if: ${{ !inputs.run_training }}
@@ -171,8 +171,8 @@ jobs:
       - name: Persist validation dataset consents
         run: ./scripts/configure_validation_dataset_consents.sh
 
-      - name: Prepare artifact workspace
-        run: mkdir -p "${SER_MODELS_DIR}"
+      - name: Configure runtime directories
+        run: ./scripts/workflows/configure_runtime_dirs.sh --models-dir "${SER_MODELS_DIR}"
 
       - name: Download full-gate training artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/linux-python-3_13-cli-validation.yml
+++ b/.github/workflows/linux-python-3_13-cli-validation.yml
@@ -46,19 +46,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Configure runtime directories
-        run: |
-          {
-            echo "SER_MAX_WORKERS=1"
-            echo "SER_MODELS_DIR=$RUNNER_TEMP/ser-models"
-            echo "SER_DATA_DIR=$RUNNER_TEMP/ser-data"
-            echo "SER_CACHE_DIR=$RUNNER_TEMP/ser-cache"
-            echo "SER_TRANSCRIPTS_DIR=$RUNNER_TEMP/ser-transcripts"
-          } >> "$GITHUB_ENV"
-          mkdir -p \
-            "$RUNNER_TEMP/ser-models" \
-            "$RUNNER_TEMP/ser-data" \
-            "$RUNNER_TEMP/ser-cache" \
-            "$RUNNER_TEMP/ser-transcripts"
+        run: ./scripts/workflows/configure_runtime_dirs.sh
 
       - name: Set up Python 3.13
         uses: actions/setup-python@v6
@@ -69,12 +57,7 @@ jobs:
         run: python -m pip install --upgrade pip uv
 
       - name: Ensure ffmpeg is available
-        run: |
-          if ! command -v ffmpeg >/dev/null 2>&1; then
-            sudo apt-get update
-            sudo apt-get install -y ffmpeg
-          fi
-          ffmpeg -version
+        run: ./scripts/workflows/ensure_ffmpeg.sh --mode apt-install
 
       - name: Cache uv
         uses: actions/cache@v5
@@ -85,12 +68,10 @@ jobs:
             uv-${{ runner.os }}-linux-py313-cli-
 
       - name: Sync validation dependencies (Python 3.13)
-        run: |
-          sync_args=(--frozen --python 3.13 --extra medium)
-          if [[ "${{ inputs.run_accurate_research }}" == "true" ]]; then
-            sync_args=(--frozen --python 3.13 --extra full)
-          fi
-          uv sync "${sync_args[@]}"
+        run: >
+          ./scripts/workflows/sync_validation_dependencies.sh
+          --python 3.13
+          ${{ inputs.run_accurate_research && '--accurate-research' || '' }}
 
       - name: Build synthetic RAVDESS smoke dataset
         run: python ./scripts/build_synthetic_ravdess_dataset.py
@@ -99,52 +80,44 @@ jobs:
         run: ./scripts/configure_validation_dataset_consents.sh --python 3.13
 
       - name: Fast profile train and predict
-        run: |
-          uv run --python 3.13 ser --train --profile fast
-          uv run --python 3.13 ser --file sample.wav --profile fast
+        run: ./scripts/workflows/run_profile_smoke.sh --python 3.13 --profile fast
 
       - name: Medium profile train and predict
-        run: |
-          SER_MODEL_FILE_NAME=ser_model_medium_linux_py313.pkl \
-          SER_TRAINING_REPORT_FILE_NAME=training_report_medium_linux_py313.json \
-          uv run --python 3.13 --extra medium ser --train --profile medium
-
-          SER_MODEL_FILE_NAME=ser_model_medium_linux_py313.pkl \
-          SER_TRAINING_REPORT_FILE_NAME=training_report_medium_linux_py313.json \
-          uv run --python 3.13 --extra medium ser --file sample.wav --profile medium
+        env:
+          SER_MODEL_FILE_NAME: ser_model_medium_linux_py313.pkl
+          SER_TRAINING_REPORT_FILE_NAME: training_report_medium_linux_py313.json
+        run: >
+          ./scripts/workflows/run_profile_smoke.sh
+          --python 3.13
+          --uv-extra medium
+          --profile medium
 
       - name: Accurate profile train and predict (compatibility smoke)
-        run: |
-          SER_ACCURATE_MODEL_ID=${{ inputs.accurate_model_id }} \
-          WHISPER_MODEL=tiny \
-          WHISPER_DEMUCS=false \
-          WHISPER_VAD=false \
-          SER_MODEL_FILE_NAME=ser_model_accurate_linux_py313.pkl \
-          SER_TRAINING_REPORT_FILE_NAME=training_report_accurate_linux_py313.json \
-          uv run --python 3.13 --extra medium ser --train --profile accurate
-
-          SER_ACCURATE_MODEL_ID=${{ inputs.accurate_model_id }} \
-          WHISPER_MODEL=tiny \
-          WHISPER_DEMUCS=false \
-          WHISPER_VAD=false \
-          SER_MODEL_FILE_NAME=ser_model_accurate_linux_py313.pkl \
-          SER_TRAINING_REPORT_FILE_NAME=training_report_accurate_linux_py313.json \
-          uv run --python 3.13 --extra medium ser --file sample.wav --profile accurate
+        env:
+          SER_ACCURATE_MODEL_ID: ${{ inputs.accurate_model_id }}
+          WHISPER_MODEL: tiny
+          WHISPER_DEMUCS: "false"
+          WHISPER_VAD: "false"
+          SER_MODEL_FILE_NAME: ser_model_accurate_linux_py313.pkl
+          SER_TRAINING_REPORT_FILE_NAME: training_report_accurate_linux_py313.json
+        run: >
+          ./scripts/workflows/run_profile_smoke.sh
+          --python 3.13
+          --uv-extra medium
+          --profile accurate
 
       - name: Accurate-research profile train and predict (compatibility smoke)
         if: ${{ inputs.run_accurate_research }}
-        run: |
-          SER_ENABLE_RESTRICTED_BACKENDS=true \
-          SER_ACCURATE_RESEARCH_MODEL_ID=${{ inputs.accurate_research_model_id }} \
-          SER_MODEL_FILE_NAME=ser_model_accurate_research_linux_py313.pkl \
-          SER_TRAINING_REPORT_FILE_NAME=training_report_accurate_research_linux_py313.json \
-          uv run --python 3.13 --extra full ser --train --profile accurate-research
-
-          SER_ENABLE_RESTRICTED_BACKENDS=true \
-          SER_ACCURATE_RESEARCH_MODEL_ID=${{ inputs.accurate_research_model_id }} \
-          SER_MODEL_FILE_NAME=ser_model_accurate_research_linux_py313.pkl \
-          SER_TRAINING_REPORT_FILE_NAME=training_report_accurate_research_linux_py313.json \
-          uv run --python 3.13 --extra full ser --file sample.wav --profile accurate-research
+        env:
+          SER_ENABLE_RESTRICTED_BACKENDS: "true"
+          SER_ACCURATE_RESEARCH_MODEL_ID: ${{ inputs.accurate_research_model_id }}
+          SER_MODEL_FILE_NAME: ser_model_accurate_research_linux_py313.pkl
+          SER_TRAINING_REPORT_FILE_NAME: training_report_accurate_research_linux_py313.json
+        run: >
+          ./scripts/workflows/run_profile_smoke.sh
+          --python 3.13
+          --uv-extra full
+          --profile accurate-research
 
       - name: Upload validation artifacts
         if: always()

--- a/.github/workflows/linux-selfhosted-gpu-validation.yml
+++ b/.github/workflows/linux-selfhosted-gpu-validation.yml
@@ -103,19 +103,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Configure runtime directories
-        run: |
-          {
-            echo "SER_MAX_WORKERS=1"
-            echo "SER_MODELS_DIR=$RUNNER_TEMP/ser-models"
-            echo "SER_DATA_DIR=$RUNNER_TEMP/ser-data"
-            echo "SER_CACHE_DIR=$RUNNER_TEMP/ser-cache"
-            echo "SER_TRANSCRIPTS_DIR=$RUNNER_TEMP/ser-transcripts"
-          } >> "$GITHUB_ENV"
-          mkdir -p \
-            "$RUNNER_TEMP/ser-models" \
-            "$RUNNER_TEMP/ser-data" \
-            "$RUNNER_TEMP/ser-cache" \
-            "$RUNNER_TEMP/ser-transcripts"
+        run: ./scripts/workflows/configure_runtime_dirs.sh
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -126,12 +114,7 @@ jobs:
         run: python -m pip install --upgrade pip uv
 
       - name: Verify ffmpeg availability on runner
-        run: |
-          if ! command -v ffmpeg >/dev/null 2>&1; then
-            echo "ffmpeg is required on self-hosted CUDA runners." >&2
-            exit 1
-          fi
-          ffmpeg -version
+        run: ./scripts/workflows/ensure_ffmpeg.sh --mode required
 
       - name: Cache uv
         uses: actions/cache@v5
@@ -142,27 +125,17 @@ jobs:
             uv-${{ runner.os }}-selfhosted-cuda-py${{ inputs.python_version }}-
 
       - name: Sync validation dependencies
-        run: |
-          sync_args=(--frozen --python "${{ inputs.python_version }}" --extra dev --extra medium)
-          if [[ "${{ inputs.run_accurate_research }}" == "true" ]]; then
-            sync_args=(--frozen --python "${{ inputs.python_version }}" --extra dev --extra full)
-          fi
-          uv sync "${sync_args[@]}"
+        run: >
+          ./scripts/workflows/sync_validation_dependencies.sh
+          --python ${{ inputs.python_version }}
+          --with-dev
+          ${{ inputs.run_accurate_research && '--accurate-research' || '' }}
 
       - name: Verify CUDA runtime availability
-        run: |
-          uv run --python ${{ inputs.python_version }} python - <<'PY'
-          import importlib
-
-          torch = importlib.import_module("torch")
-          cuda = getattr(torch, "cuda", None)
-          is_available = getattr(cuda, "is_available", None)
-          available = bool(is_available()) if callable(is_available) else False
-          if not available:
-              raise SystemExit("CUDA runtime unavailable on selected self-hosted runner.")
-          device_count = getattr(cuda, "device_count", lambda: "unknown")
-          print(f"cuda_available={available}, cuda_device_count={device_count()}")
-          PY
+        run: >
+          uv run --python ${{ inputs.python_version }} python
+          ./scripts/workflows/check_torch_runtime.py
+          --runtime cuda
 
       - name: Build synthetic RAVDESS smoke dataset
         run: python ./scripts/build_synthetic_ravdess_dataset.py
@@ -179,59 +152,47 @@ jobs:
           tests/suites/integration/test_transcript_extractor.py
 
       - name: Medium profile train and predict (CUDA lane)
-        run: |
-          SER_TORCH_DEVICE=cuda \
-          SER_TORCH_DTYPE=float16 \
-          SER_MODEL_FILE_NAME=ser_model_medium_cuda.pkl \
-          SER_TRAINING_REPORT_FILE_NAME=training_report_medium_cuda.json \
-          uv run --python ${{ inputs.python_version }} --extra medium ser --train --profile medium
-
-          SER_TORCH_DEVICE=cuda \
-          SER_TORCH_DTYPE=float16 \
-          SER_MODEL_FILE_NAME=ser_model_medium_cuda.pkl \
-          SER_TRAINING_REPORT_FILE_NAME=training_report_medium_cuda.json \
-          uv run --python ${{ inputs.python_version }} --extra medium ser --file sample.wav --profile medium
+        env:
+          SER_TORCH_DEVICE: cuda
+          SER_TORCH_DTYPE: float16
+          SER_MODEL_FILE_NAME: ser_model_medium_cuda.pkl
+          SER_TRAINING_REPORT_FILE_NAME: training_report_medium_cuda.json
+        run: >
+          ./scripts/workflows/run_profile_smoke.sh
+          --python ${{ inputs.python_version }}
+          --uv-extra medium
+          --profile medium
 
       - name: Accurate profile train and predict (CUDA lane)
-        run: |
-          SER_TORCH_DEVICE=cuda \
-          SER_TORCH_DTYPE=float16 \
-          SER_ACCURATE_MODEL_ID=${{ inputs.accurate_model_id }} \
-          WHISPER_MODEL=tiny \
-          WHISPER_DEMUCS=false \
-          WHISPER_VAD=false \
-          SER_MODEL_FILE_NAME=ser_model_accurate_cuda.pkl \
-          SER_TRAINING_REPORT_FILE_NAME=training_report_accurate_cuda.json \
-          uv run --python ${{ inputs.python_version }} --extra medium ser --train --profile accurate
-
-          SER_TORCH_DEVICE=cuda \
-          SER_TORCH_DTYPE=float16 \
-          SER_ACCURATE_MODEL_ID=${{ inputs.accurate_model_id }} \
-          WHISPER_MODEL=tiny \
-          WHISPER_DEMUCS=false \
-          WHISPER_VAD=false \
-          SER_MODEL_FILE_NAME=ser_model_accurate_cuda.pkl \
-          SER_TRAINING_REPORT_FILE_NAME=training_report_accurate_cuda.json \
-          uv run --python ${{ inputs.python_version }} --extra medium ser --file sample.wav --profile accurate
+        env:
+          SER_TORCH_DEVICE: cuda
+          SER_TORCH_DTYPE: float16
+          SER_ACCURATE_MODEL_ID: ${{ inputs.accurate_model_id }}
+          WHISPER_MODEL: tiny
+          WHISPER_DEMUCS: "false"
+          WHISPER_VAD: "false"
+          SER_MODEL_FILE_NAME: ser_model_accurate_cuda.pkl
+          SER_TRAINING_REPORT_FILE_NAME: training_report_accurate_cuda.json
+        run: >
+          ./scripts/workflows/run_profile_smoke.sh
+          --python ${{ inputs.python_version }}
+          --uv-extra medium
+          --profile accurate
 
       - name: Accurate-research profile train and predict (optional)
         if: ${{ inputs.run_accurate_research }}
-        run: |
-          SER_ENABLE_RESTRICTED_BACKENDS=true \
-          SER_TORCH_DEVICE=cuda \
-          SER_TORCH_DTYPE=float16 \
-          SER_ACCURATE_RESEARCH_MODEL_ID=${{ inputs.accurate_research_model_id }} \
-          SER_MODEL_FILE_NAME=ser_model_accurate_research_cuda.pkl \
-          SER_TRAINING_REPORT_FILE_NAME=training_report_accurate_research_cuda.json \
-          uv run --python ${{ inputs.python_version }} --extra full ser --train --profile accurate-research
-
-          SER_ENABLE_RESTRICTED_BACKENDS=true \
-          SER_TORCH_DEVICE=cuda \
-          SER_TORCH_DTYPE=float16 \
-          SER_ACCURATE_RESEARCH_MODEL_ID=${{ inputs.accurate_research_model_id }} \
-          SER_MODEL_FILE_NAME=ser_model_accurate_research_cuda.pkl \
-          SER_TRAINING_REPORT_FILE_NAME=training_report_accurate_research_cuda.json \
-          uv run --python ${{ inputs.python_version }} --extra full ser --file sample.wav --profile accurate-research
+        env:
+          SER_ENABLE_RESTRICTED_BACKENDS: "true"
+          SER_TORCH_DEVICE: cuda
+          SER_TORCH_DTYPE: float16
+          SER_ACCURATE_RESEARCH_MODEL_ID: ${{ inputs.accurate_research_model_id }}
+          SER_MODEL_FILE_NAME: ser_model_accurate_research_cuda.pkl
+          SER_TRAINING_REPORT_FILE_NAME: training_report_accurate_research_cuda.json
+        run: >
+          ./scripts/workflows/run_profile_smoke.sh
+          --python ${{ inputs.python_version }}
+          --uv-extra full
+          --profile accurate-research
 
       - name: Upload CUDA validation artifacts
         if: always()
@@ -253,19 +214,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Configure runtime directories
-        run: |
-          {
-            echo "SER_MAX_WORKERS=1"
-            echo "SER_MODELS_DIR=$RUNNER_TEMP/ser-models"
-            echo "SER_DATA_DIR=$RUNNER_TEMP/ser-data"
-            echo "SER_CACHE_DIR=$RUNNER_TEMP/ser-cache"
-            echo "SER_TRANSCRIPTS_DIR=$RUNNER_TEMP/ser-transcripts"
-          } >> "$GITHUB_ENV"
-          mkdir -p \
-            "$RUNNER_TEMP/ser-models" \
-            "$RUNNER_TEMP/ser-data" \
-            "$RUNNER_TEMP/ser-cache" \
-            "$RUNNER_TEMP/ser-transcripts"
+        run: ./scripts/workflows/configure_runtime_dirs.sh
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -276,12 +225,7 @@ jobs:
         run: python -m pip install --upgrade pip uv
 
       - name: Verify ffmpeg availability on runner
-        run: |
-          if ! command -v ffmpeg >/dev/null 2>&1; then
-            echo "ffmpeg is required on self-hosted XPU runners." >&2
-            exit 1
-          fi
-          ffmpeg -version
+        run: ./scripts/workflows/ensure_ffmpeg.sh --mode required
 
       - name: Cache uv
         uses: actions/cache@v5
@@ -292,26 +236,17 @@ jobs:
             uv-${{ runner.os }}-selfhosted-xpu-py${{ inputs.python_version }}-
 
       - name: Sync validation dependencies
-        run: |
-          sync_args=(--frozen --python "${{ inputs.python_version }}" --extra dev --extra medium)
-          if [[ "${{ inputs.run_accurate_research }}" == "true" ]]; then
-            sync_args=(--frozen --python "${{ inputs.python_version }}" --extra dev --extra full)
-          fi
-          uv sync "${sync_args[@]}"
+        run: >
+          ./scripts/workflows/sync_validation_dependencies.sh
+          --python ${{ inputs.python_version }}
+          --with-dev
+          ${{ inputs.run_accurate_research && '--accurate-research' || '' }}
 
       - name: Verify XPU runtime availability
-        run: |
-          uv run --python ${{ inputs.python_version }} python - <<'PY'
-          import importlib
-
-          torch = importlib.import_module("torch")
-          xpu = getattr(torch, "xpu", None)
-          is_available = getattr(xpu, "is_available", None)
-          available = bool(is_available()) if callable(is_available) else False
-          if not available:
-              raise SystemExit("XPU runtime unavailable on selected self-hosted runner.")
-          print(f"xpu_available={available}")
-          PY
+        run: >
+          uv run --python ${{ inputs.python_version }} python
+          ./scripts/workflows/check_torch_runtime.py
+          --runtime xpu
 
       - name: Build synthetic RAVDESS smoke dataset
         run: python ./scripts/build_synthetic_ravdess_dataset.py
@@ -326,59 +261,47 @@ jobs:
           tests/test_accurate_research_inference.py
 
       - name: Medium profile train and predict (XPU lane)
-        run: |
-          SER_TORCH_DEVICE=xpu \
-          SER_TORCH_DTYPE=float16 \
-          SER_MODEL_FILE_NAME=ser_model_medium_xpu.pkl \
-          SER_TRAINING_REPORT_FILE_NAME=training_report_medium_xpu.json \
-          uv run --python ${{ inputs.python_version }} --extra medium ser --train --profile medium
-
-          SER_TORCH_DEVICE=xpu \
-          SER_TORCH_DTYPE=float16 \
-          SER_MODEL_FILE_NAME=ser_model_medium_xpu.pkl \
-          SER_TRAINING_REPORT_FILE_NAME=training_report_medium_xpu.json \
-          uv run --python ${{ inputs.python_version }} --extra medium ser --file sample.wav --profile medium
+        env:
+          SER_TORCH_DEVICE: xpu
+          SER_TORCH_DTYPE: float16
+          SER_MODEL_FILE_NAME: ser_model_medium_xpu.pkl
+          SER_TRAINING_REPORT_FILE_NAME: training_report_medium_xpu.json
+        run: >
+          ./scripts/workflows/run_profile_smoke.sh
+          --python ${{ inputs.python_version }}
+          --uv-extra medium
+          --profile medium
 
       - name: Accurate profile train and predict (XPU lane)
-        run: |
-          SER_TORCH_DEVICE=xpu \
-          SER_TORCH_DTYPE=float16 \
-          SER_ACCURATE_MODEL_ID=${{ inputs.accurate_model_id }} \
-          WHISPER_MODEL=tiny \
-          WHISPER_DEMUCS=false \
-          WHISPER_VAD=false \
-          SER_MODEL_FILE_NAME=ser_model_accurate_xpu.pkl \
-          SER_TRAINING_REPORT_FILE_NAME=training_report_accurate_xpu.json \
-          uv run --python ${{ inputs.python_version }} --extra medium ser --train --profile accurate
-
-          SER_TORCH_DEVICE=xpu \
-          SER_TORCH_DTYPE=float16 \
-          SER_ACCURATE_MODEL_ID=${{ inputs.accurate_model_id }} \
-          WHISPER_MODEL=tiny \
-          WHISPER_DEMUCS=false \
-          WHISPER_VAD=false \
-          SER_MODEL_FILE_NAME=ser_model_accurate_xpu.pkl \
-          SER_TRAINING_REPORT_FILE_NAME=training_report_accurate_xpu.json \
-          uv run --python ${{ inputs.python_version }} --extra medium ser --file sample.wav --profile accurate
+        env:
+          SER_TORCH_DEVICE: xpu
+          SER_TORCH_DTYPE: float16
+          SER_ACCURATE_MODEL_ID: ${{ inputs.accurate_model_id }}
+          WHISPER_MODEL: tiny
+          WHISPER_DEMUCS: "false"
+          WHISPER_VAD: "false"
+          SER_MODEL_FILE_NAME: ser_model_accurate_xpu.pkl
+          SER_TRAINING_REPORT_FILE_NAME: training_report_accurate_xpu.json
+        run: >
+          ./scripts/workflows/run_profile_smoke.sh
+          --python ${{ inputs.python_version }}
+          --uv-extra medium
+          --profile accurate
 
       - name: Accurate-research profile train and predict (optional)
         if: ${{ inputs.run_accurate_research }}
-        run: |
-          SER_ENABLE_RESTRICTED_BACKENDS=true \
-          SER_TORCH_DEVICE=xpu \
-          SER_TORCH_DTYPE=float16 \
-          SER_ACCURATE_RESEARCH_MODEL_ID=${{ inputs.accurate_research_model_id }} \
-          SER_MODEL_FILE_NAME=ser_model_accurate_research_xpu.pkl \
-          SER_TRAINING_REPORT_FILE_NAME=training_report_accurate_research_xpu.json \
-          uv run --python ${{ inputs.python_version }} --extra full ser --train --profile accurate-research
-
-          SER_ENABLE_RESTRICTED_BACKENDS=true \
-          SER_TORCH_DEVICE=xpu \
-          SER_TORCH_DTYPE=float16 \
-          SER_ACCURATE_RESEARCH_MODEL_ID=${{ inputs.accurate_research_model_id }} \
-          SER_MODEL_FILE_NAME=ser_model_accurate_research_xpu.pkl \
-          SER_TRAINING_REPORT_FILE_NAME=training_report_accurate_research_xpu.json \
-          uv run --python ${{ inputs.python_version }} --extra full ser --file sample.wav --profile accurate-research
+        env:
+          SER_ENABLE_RESTRICTED_BACKENDS: "true"
+          SER_TORCH_DEVICE: xpu
+          SER_TORCH_DTYPE: float16
+          SER_ACCURATE_RESEARCH_MODEL_ID: ${{ inputs.accurate_research_model_id }}
+          SER_MODEL_FILE_NAME: ser_model_accurate_research_xpu.pkl
+          SER_TRAINING_REPORT_FILE_NAME: training_report_accurate_research_xpu.json
+        run: >
+          ./scripts/workflows/run_profile_smoke.sh
+          --python ${{ inputs.python_version }}
+          --uv-extra full
+          --profile accurate-research
 
       - name: Upload XPU validation artifacts
         if: always()

--- a/.github/workflows/macos15-mps-validation.yml
+++ b/.github/workflows/macos15-mps-validation.yml
@@ -55,19 +55,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Configure runtime directories
-        run: |
-          {
-            echo "SER_MAX_WORKERS=1"
-            echo "SER_MODELS_DIR=$RUNNER_TEMP/ser-models"
-            echo "SER_DATA_DIR=$RUNNER_TEMP/ser-data"
-            echo "SER_CACHE_DIR=$RUNNER_TEMP/ser-cache"
-            echo "SER_TRANSCRIPTS_DIR=$RUNNER_TEMP/ser-transcripts"
-          } >> "$GITHUB_ENV"
-          mkdir -p \
-            "$RUNNER_TEMP/ser-models" \
-            "$RUNNER_TEMP/ser-data" \
-            "$RUNNER_TEMP/ser-cache" \
-            "$RUNNER_TEMP/ser-transcripts"
+        run: ./scripts/workflows/configure_runtime_dirs.sh
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -78,11 +66,7 @@ jobs:
         run: python -m pip install --upgrade pip uv
 
       - name: Ensure ffmpeg is available
-        run: |
-          if ! command -v ffmpeg >/dev/null 2>&1; then
-            brew install ffmpeg
-          fi
-          ffmpeg -version
+        run: ./scripts/workflows/ensure_ffmpeg.sh --mode brew-install
 
       - name: Cache uv
         uses: actions/cache@v5
@@ -93,34 +77,16 @@ jobs:
             uv-${{ runner.os }}-macos15-mps-py${{ inputs.python_version }}-
 
       - name: Setup compatible environment
-        run: |
-          setup_args=(--python "${{ inputs.python_version }}" --extra medium --skip-git-hooks)
-          if [[ "${{ inputs.run_accurate_research }}" == "true" ]]; then
-            setup_args=(--python "${{ inputs.python_version }}" --extra full --skip-git-hooks)
-          fi
-          ./scripts/setup_compatible_env.sh "${setup_args[@]}"
+        run: >
+          ./scripts/workflows/setup_validation_environment.sh
+          --python ${{ inputs.python_version }}
+          ${{ inputs.run_accurate_research && '--accurate-research' || '' }}
 
       - name: Verify MPS runtime availability
-        run: |
-          uv run --python ${{ inputs.python_version }} python - <<'PY'
-          import importlib
-          import platform
-
-          torch = importlib.import_module("torch")
-          backends = getattr(torch, "backends", None)
-          mps = getattr(backends, "mps", None)
-          is_available = getattr(mps, "is_available", None)
-          is_built = getattr(mps, "is_built", None)
-          available = bool(is_available()) if callable(is_available) else False
-          built = bool(is_built()) if callable(is_built) else False
-          machine = platform.machine().lower()
-          print(f"platform.machine={machine}, mps_available={available}, mps_built={built}")
-          if not (available and built):
-              raise SystemExit(
-                  "MPS runtime is unavailable on this macOS 15 runner. "
-                  "Use an Apple Silicon macOS 15 runner."
-              )
-          PY
+        run: >
+          uv run --python ${{ inputs.python_version }} python
+          ./scripts/workflows/check_torch_runtime.py
+          --runtime mps
 
       - name: Build synthetic RAVDESS smoke dataset
         run: python ./scripts/build_synthetic_ravdess_dataset.py
@@ -140,69 +106,52 @@ jobs:
           tests/test_transcription_backends.py
 
       - name: Medium profile train and predict (MPS lane)
-        run: |
-          SER_TORCH_DEVICE=auto \
-          SER_TORCH_DTYPE=auto \
-          WHISPER_BACKEND=faster_whisper \
-          WHISPER_MODEL=tiny \
-          WHISPER_DEMUCS=false \
-          WHISPER_VAD=false \
-          SER_MODEL_FILE_NAME=ser_model_medium_macos15_mps.pkl \
-          SER_TRAINING_REPORT_FILE_NAME=training_report_medium_macos15_mps.json \
-          uv run --python ${{ inputs.python_version }} --extra medium ser --train --profile medium
-
-          SER_TORCH_DEVICE=auto \
-          SER_TORCH_DTYPE=auto \
-          WHISPER_BACKEND=faster_whisper \
-          WHISPER_MODEL=tiny \
-          WHISPER_DEMUCS=false \
-          WHISPER_VAD=false \
-          SER_MODEL_FILE_NAME=ser_model_medium_macos15_mps.pkl \
-          SER_TRAINING_REPORT_FILE_NAME=training_report_medium_macos15_mps.json \
-          uv run --python ${{ inputs.python_version }} --extra medium ser --file sample.wav --profile medium
+        env:
+          SER_TORCH_DEVICE: auto
+          SER_TORCH_DTYPE: auto
+          WHISPER_BACKEND: faster_whisper
+          WHISPER_MODEL: tiny
+          WHISPER_DEMUCS: "false"
+          WHISPER_VAD: "false"
+          SER_MODEL_FILE_NAME: ser_model_medium_macos15_mps.pkl
+          SER_TRAINING_REPORT_FILE_NAME: training_report_medium_macos15_mps.json
+        run: >
+          ./scripts/workflows/run_profile_smoke.sh
+          --python ${{ inputs.python_version }}
+          --uv-extra medium
+          --profile medium
 
       - name: Accurate profile train and predict (MPS lane)
-        run: |
-          SER_TORCH_DEVICE=auto \
-          SER_TORCH_DTYPE=auto \
-          WHISPER_BACKEND=faster_whisper \
-          SER_ACCURATE_MODEL_ID=${{ inputs.accurate_model_id }} \
-          WHISPER_MODEL=tiny \
-          WHISPER_DEMUCS=false \
-          WHISPER_VAD=false \
-          SER_MODEL_FILE_NAME=ser_model_accurate_macos15_mps.pkl \
-          SER_TRAINING_REPORT_FILE_NAME=training_report_accurate_macos15_mps.json \
-          uv run --python ${{ inputs.python_version }} --extra medium ser --train --profile accurate
-
-          SER_TORCH_DEVICE=auto \
-          SER_TORCH_DTYPE=auto \
-          WHISPER_BACKEND=faster_whisper \
-          SER_ACCURATE_MODEL_ID=${{ inputs.accurate_model_id }} \
-          WHISPER_MODEL=tiny \
-          WHISPER_DEMUCS=false \
-          WHISPER_VAD=false \
-          SER_MODEL_FILE_NAME=ser_model_accurate_macos15_mps.pkl \
-          SER_TRAINING_REPORT_FILE_NAME=training_report_accurate_macos15_mps.json \
-          uv run --python ${{ inputs.python_version }} --extra medium ser --file sample.wav --profile accurate
+        env:
+          SER_TORCH_DEVICE: auto
+          SER_TORCH_DTYPE: auto
+          WHISPER_BACKEND: faster_whisper
+          SER_ACCURATE_MODEL_ID: ${{ inputs.accurate_model_id }}
+          WHISPER_MODEL: tiny
+          WHISPER_DEMUCS: "false"
+          WHISPER_VAD: "false"
+          SER_MODEL_FILE_NAME: ser_model_accurate_macos15_mps.pkl
+          SER_TRAINING_REPORT_FILE_NAME: training_report_accurate_macos15_mps.json
+        run: >
+          ./scripts/workflows/run_profile_smoke.sh
+          --python ${{ inputs.python_version }}
+          --uv-extra medium
+          --profile accurate
 
       - name: Accurate-research profile train and predict (optional)
         if: ${{ inputs.run_accurate_research }}
-        run: |
-          SER_ENABLE_RESTRICTED_BACKENDS=true \
-          SER_TORCH_DEVICE=auto \
-          SER_TORCH_DTYPE=auto \
-          SER_ACCURATE_RESEARCH_MODEL_ID=${{ inputs.accurate_research_model_id }} \
-          SER_MODEL_FILE_NAME=ser_model_accurate_research_macos15_mps.pkl \
-          SER_TRAINING_REPORT_FILE_NAME=training_report_accurate_research_macos15_mps.json \
-          uv run --python ${{ inputs.python_version }} --extra full ser --train --profile accurate-research
-
-          SER_ENABLE_RESTRICTED_BACKENDS=true \
-          SER_TORCH_DEVICE=auto \
-          SER_TORCH_DTYPE=auto \
-          SER_ACCURATE_RESEARCH_MODEL_ID=${{ inputs.accurate_research_model_id }} \
-          SER_MODEL_FILE_NAME=ser_model_accurate_research_macos15_mps.pkl \
-          SER_TRAINING_REPORT_FILE_NAME=training_report_accurate_research_macos15_mps.json \
-          uv run --python ${{ inputs.python_version }} --extra full ser --file sample.wav --profile accurate-research
+        env:
+          SER_ENABLE_RESTRICTED_BACKENDS: "true"
+          SER_TORCH_DEVICE: auto
+          SER_TORCH_DTYPE: auto
+          SER_ACCURATE_RESEARCH_MODEL_ID: ${{ inputs.accurate_research_model_id }}
+          SER_MODEL_FILE_NAME: ser_model_accurate_research_macos15_mps.pkl
+          SER_TRAINING_REPORT_FILE_NAME: training_report_accurate_research_macos15_mps.json
+        run: >
+          ./scripts/workflows/run_profile_smoke.sh
+          --python ${{ inputs.python_version }}
+          --uv-extra full
+          --profile accurate-research
 
       - name: Upload validation artifacts
         if: always()

--- a/.github/workflows/python-publish-testpypi.yml
+++ b/.github/workflows/python-publish-testpypi.yml
@@ -31,32 +31,10 @@ jobs:
         id: sha
         run: echo "head_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
       - name: Verify CI passed for release commit
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const sha = "${{ steps.sha.outputs.head_sha }}";
-            const runs = await github.rest.actions.listWorkflowRuns({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: "ci.yml",
-              head_sha: sha,
-              per_page: 20
-            });
-
-            const ok = runs.data.workflow_runs.find(
-              (run) => run.conclusion === "success"
-            );
-
-            if (!ok) {
-              core.setFailed(
-                `No successful CI workflow run found for commit ${sha}.`
-              );
-              return;
-            }
-
-            core.info(
-              `CI verified for commit ${sha} via run #${ok.run_number}.`
-            );
+        env:
+          CI_HEAD_SHA: ${{ steps.sha.outputs.head_sha }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: python ./scripts/workflows/verify_ci_release.py
 
   linux-cli-validation:
     needs: verify-ci

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -31,32 +31,10 @@ jobs:
         id: sha
         run: echo "head_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
       - name: Verify CI passed for release commit
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const sha = "${{ steps.sha.outputs.head_sha }}";
-            const runs = await github.rest.actions.listWorkflowRuns({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: "ci.yml",
-              head_sha: sha,
-              per_page: 20
-            });
-
-            const ok = runs.data.workflow_runs.find(
-              (run) => run.conclusion === "success"
-            );
-
-            if (!ok) {
-              core.setFailed(
-                `No successful CI workflow run found for commit ${sha}.`
-              );
-              return;
-            }
-
-            core.info(
-              `CI verified for commit ${sha} via run #${ok.run_number}.`
-            );
+        env:
+          CI_HEAD_SHA: ${{ steps.sha.outputs.head_sha }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: python ./scripts/workflows/verify_ci_release.py
 
   linux-cli-validation:
     needs: verify-ci

--- a/scripts/workflows/check_torch_runtime.py
+++ b/scripts/workflows/check_torch_runtime.py
@@ -1,0 +1,57 @@
+"""Validate a torch runtime lane for GitHub workflow runners."""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import platform
+import sys
+
+
+def _is_available(attribute: object) -> bool:
+    """Return a normalized availability result for torch runtime probes."""
+    if callable(attribute):
+        return bool(attribute())
+    return False
+
+
+def main() -> int:
+    """Run the requested torch runtime validation."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--runtime", choices=("mps", "cuda", "xpu"), required=True)
+    args = parser.parse_args()
+
+    torch = importlib.import_module("torch")
+
+    if args.runtime == "mps":
+        backends = getattr(torch, "backends", None)
+        mps = getattr(backends, "mps", None)
+        is_available = getattr(mps, "is_available", None)
+        is_built = getattr(mps, "is_built", None)
+        available = _is_available(is_available)
+        built = _is_available(is_built)
+        machine = platform.machine().lower()
+        print(f"platform.machine={machine}, mps_available={available}, mps_built={built}")
+        if not (available and built):
+            raise SystemExit(
+                "MPS runtime is unavailable on this runner. Use an Apple Silicon macOS runner."
+            )
+        return 0
+
+    runtime_module = getattr(torch, args.runtime, None)
+    is_available = getattr(runtime_module, "is_available", None)
+    available = _is_available(is_available)
+    if not available:
+        raise SystemExit(f"{args.runtime.upper()} runtime unavailable on the selected runner.")
+
+    details = [f"{args.runtime}_available={available}"]
+    if args.runtime == "cuda":
+        device_count = getattr(runtime_module, "device_count", None)
+        if callable(device_count):
+            details.append(f"cuda_device_count={device_count()}")
+    print(", ".join(details))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/workflows/configure_runtime_dirs.sh
+++ b/scripts/workflows/configure_runtime_dirs.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: ./scripts/workflows/configure_runtime_dirs.sh [options]
+
+Options:
+  --max-workers <count>      Value exported as SER_MAX_WORKERS (default: 1).
+  --models-dir <path>        Directory exported as SER_MODELS_DIR.
+  --data-dir <path>          Directory exported as SER_DATA_DIR.
+  --cache-dir <path>         Directory exported as SER_CACHE_DIR.
+  --transcripts-dir <path>   Directory exported as SER_TRANSCRIPTS_DIR.
+  -h, --help                 Show this help text.
+EOF
+}
+
+if [[ -z "${GITHUB_ENV:-}" ]]; then
+  printf 'GITHUB_ENV must be set when configuring workflow runtime directories.\n' >&2
+  exit 2
+fi
+
+runner_temp="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
+max_workers="1"
+models_dir="$runner_temp/ser-models"
+data_dir="$runner_temp/ser-data"
+cache_dir="$runner_temp/ser-cache"
+transcripts_dir="$runner_temp/ser-transcripts"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --max-workers)
+      max_workers="$2"
+      shift 2
+      ;;
+    --models-dir)
+      models_dir="$2"
+      shift 2
+      ;;
+    --data-dir)
+      data_dir="$2"
+      shift 2
+      ;;
+    --cache-dir)
+      cache_dir="$2"
+      shift 2
+      ;;
+    --transcripts-dir)
+      transcripts_dir="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      printf 'Unknown option: %s\n' "$1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+mkdir -p "$models_dir" "$data_dir" "$cache_dir" "$transcripts_dir"
+
+{
+  printf 'SER_MAX_WORKERS=%s\n' "$max_workers"
+  printf 'SER_MODELS_DIR=%s\n' "$models_dir"
+  printf 'SER_DATA_DIR=%s\n' "$data_dir"
+  printf 'SER_CACHE_DIR=%s\n' "$cache_dir"
+  printf 'SER_TRANSCRIPTS_DIR=%s\n' "$transcripts_dir"
+} >> "$GITHUB_ENV"
+

--- a/scripts/workflows/ensure_ffmpeg.sh
+++ b/scripts/workflows/ensure_ffmpeg.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: ./scripts/workflows/ensure_ffmpeg.sh --mode <apt-install|brew-install|required>
+EOF
+}
+
+mode=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mode)
+      mode="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      printf 'Unknown option: %s\n' "$1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$mode" ]]; then
+  printf 'Missing required --mode option.\n' >&2
+  usage >&2
+  exit 2
+fi
+
+if ! command -v ffmpeg >/dev/null 2>&1; then
+  case "$mode" in
+    apt-install)
+      sudo apt-get update
+      sudo apt-get install -y ffmpeg
+      ;;
+    brew-install)
+      brew install ffmpeg
+      ;;
+    required)
+      printf 'ffmpeg is required on this runner.\n' >&2
+      exit 1
+      ;;
+    *)
+      printf 'Unsupported ffmpeg mode: %s\n' "$mode" >&2
+      exit 2
+      ;;
+  esac
+fi
+
+ffmpeg -version
+

--- a/scripts/workflows/run_profile_smoke.sh
+++ b/scripts/workflows/run_profile_smoke.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: ./scripts/workflows/run_profile_smoke.sh --profile <name> [options]
+
+Options:
+  --profile <name>          Profile passed to `ser --train` and `ser --file`.
+  --python <version>        Optional Python version passed to uv run.
+  --uv-extra <group>        Optional uv extra; repeatable.
+  --sample-file <path>      Sample file used for prediction (default: sample.wav).
+  -h, --help                Show this help text.
+EOF
+}
+
+profile=""
+python_version=""
+sample_file="sample.wav"
+uv_extras=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --profile)
+      profile="$2"
+      shift 2
+      ;;
+    --python)
+      python_version="$2"
+      shift 2
+      ;;
+    --uv-extra)
+      uv_extras+=("$2")
+      shift 2
+      ;;
+    --sample-file)
+      sample_file="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      printf 'Unknown option: %s\n' "$1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$profile" ]]; then
+  printf 'Missing required --profile option.\n' >&2
+  usage >&2
+  exit 2
+fi
+
+uv_run_args=()
+if [[ -n "$python_version" ]]; then
+  uv_run_args+=(--python "$python_version")
+fi
+for extra in "${uv_extras[@]}"; do
+  uv_run_args+=(--extra "$extra")
+done
+
+uv run "${uv_run_args[@]}" ser --train --profile "$profile"
+uv run "${uv_run_args[@]}" ser --file "$sample_file" --profile "$profile"
+

--- a/scripts/workflows/setup_validation_environment.sh
+++ b/scripts/workflows/setup_validation_environment.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: ./scripts/workflows/setup_validation_environment.sh --python <version> [options]
+
+Options:
+  --python <version>        Python version passed to setup_compatible_env.sh.
+  --accurate-research       Include the full extra instead of medium.
+  --no-dev                  Skip development dependencies.
+  -h, --help                Show this help text.
+EOF
+}
+
+python_version=""
+run_accurate_research="false"
+include_dev="true"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --python)
+      python_version="$2"
+      shift 2
+      ;;
+    --accurate-research)
+      run_accurate_research="true"
+      shift
+      ;;
+    --no-dev)
+      include_dev="false"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      printf 'Unknown option: %s\n' "$1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$python_version" ]]; then
+  printf 'Missing required --python option.\n' >&2
+  usage >&2
+  exit 2
+fi
+
+setup_args=(--python "$python_version" --skip-git-hooks)
+if [[ "$run_accurate_research" == "true" ]]; then
+  setup_args+=(--extra full)
+else
+  setup_args+=(--extra medium)
+fi
+if [[ "$include_dev" == "false" ]]; then
+  setup_args+=(--no-dev)
+fi
+
+./scripts/setup_compatible_env.sh "${setup_args[@]}"
+

--- a/scripts/workflows/smoke_test_wheel_install.sh
+++ b/scripts/workflows/smoke_test_wheel_install.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+wheel_glob="${1:-dist/*.whl}"
+shopt -s nullglob
+wheels=($wheel_glob)
+shopt -u nullglob
+
+if [[ ${#wheels[@]} -eq 0 ]]; then
+  printf 'No wheels matched %s\n' "$wheel_glob" >&2
+  exit 2
+fi
+
+python -m venv .pkg-smoke
+. .pkg-smoke/bin/activate
+python -m pip install --upgrade pip
+pip install --no-deps "${wheels[@]}"
+
+tmp_dir="$(mktemp -d)"
+cd "$tmp_dir"
+
+python - <<'PY'
+import importlib.metadata as md
+import ser
+
+print(f"Installed ser version: {md.version('ser')}")
+print(f"Imported from: {ser.__file__}")
+print(f"Exports: {', '.join(ser.__all__)}")
+PY

--- a/scripts/workflows/sync_validation_dependencies.sh
+++ b/scripts/workflows/sync_validation_dependencies.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: ./scripts/workflows/sync_validation_dependencies.sh --python <version> [options]
+
+Options:
+  --python <version>        Python version passed to uv sync.
+  --accurate-research       Include the full extra instead of medium.
+  --with-dev                Include the dev extra.
+  -h, --help                Show this help text.
+EOF
+}
+
+python_version=""
+run_accurate_research="false"
+include_dev="false"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --python)
+      python_version="$2"
+      shift 2
+      ;;
+    --accurate-research)
+      run_accurate_research="true"
+      shift
+      ;;
+    --with-dev)
+      include_dev="true"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      printf 'Unknown option: %s\n' "$1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$python_version" ]]; then
+  printf 'Missing required --python option.\n' >&2
+  usage >&2
+  exit 2
+fi
+
+sync_args=(--frozen --python "$python_version")
+if [[ "$include_dev" == "true" ]]; then
+  sync_args+=(--extra dev)
+fi
+if [[ "$run_accurate_research" == "true" ]]; then
+  sync_args+=(--extra full)
+else
+  sync_args+=(--extra medium)
+fi
+
+uv sync "${sync_args[@]}"
+

--- a/scripts/workflows/verify_ci_release.py
+++ b/scripts/workflows/verify_ci_release.py
@@ -1,0 +1,61 @@
+"""Verify that CI succeeded for a release commit."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+
+def _required_env(name: str) -> str:
+    """Return a required environment variable or exit with a clear error."""
+    value = os.environ.get(name)
+    if not value:
+        raise SystemExit(f"Missing required environment variable: {name}")
+    return value
+
+
+def main() -> int:
+    """Check whether ci.yml has a successful run for the requested commit."""
+    api_url = os.environ.get("GITHUB_API_URL", "https://api.github.com")
+    repository = _required_env("GITHUB_REPOSITORY")
+    token = _required_env("GITHUB_TOKEN")
+    head_sha = _required_env("CI_HEAD_SHA")
+
+    encoded_query = urllib.parse.urlencode({"head_sha": head_sha, "per_page": 20})
+    url = f"{api_url}/repos/{repository}/actions/workflows/ci.yml/runs?{encoded_query}"
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+
+    try:
+        with urllib.request.urlopen(request) as response:
+            payload = json.load(response)
+    except urllib.error.HTTPError as exc:
+        raise SystemExit(f"Failed to query GitHub Actions API: {exc}") from exc
+
+    workflow_runs = payload.get("workflow_runs", [])
+    successful_run = next(
+        (run for run in workflow_runs if run.get("conclusion") == "success"),
+        None,
+    )
+    if successful_run is None:
+        raise SystemExit(f"No successful CI workflow run found for commit {head_sha}.")
+
+    print(
+        "CI verified for commit "
+        f"{head_sha} via run #{successful_run.get('run_number', 'unknown')}."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- move repeated workflow shell logic into reusable scripts under `scripts/workflows`
- replace embedded workflow runtime probes and release-CI verification logic with checked-in helpers
- keep workflow YAMLs focused on job structure and arguments instead of inline implementation details

## Validation
- `uv run --frozen --extra dev ruff check scripts/workflows`
- `uv run --frozen --extra dev black --check scripts/workflows`
- `uv run --frozen --extra dev pyright scripts/workflows/check_torch_runtime.py scripts/workflows/verify_ci_release.py`
- `bash -n scripts/workflows/*.sh scripts/*.sh`
- `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].sort.each { |path| YAML.load_file(path) }; puts "yaml ok"'`
- push pre-push hooks
