### PR TITLE
ci: guard empty smoke extras on darwin

### DIFF
--- a/scripts/workflows/run_profile_smoke.sh
+++ b/scripts/workflows/run_profile_smoke.sh
@@ -59,10 +59,11 @@ uv_run_args=()
 if [[ -n "$python_version" ]]; then
   uv_run_args+=(--python "$python_version")
 fi
-for extra in "${uv_extras[@]}"; do
-  uv_run_args+=(--extra "$extra")
-done
+if [[ ${#uv_extras[@]} -gt 0 ]]; then
+  for extra in "${uv_extras[@]}"; do
+    uv_run_args+=(--extra "$extra")
+  done
+fi
 
 uv run "${uv_run_args[@]}" ser --train --profile "$profile"
 uv run "${uv_run_args[@]}" ser --file "$sample_file" --profile "$profile"
-


### PR DESCRIPTION
## Summary
- fix `scripts/workflows/run_profile_smoke.sh` for empty `--uv-extra` usage under macOS bash with `set -u`
- preserve the extracted workflow structure while restoring the Darwin fast-profile lane

## Validation
- `bash -n scripts/workflows/run_profile_smoke.sh`
- `bash -uc 'uv_extras=(); uv_run_args=(); if [[ ${#uv_extras[@]} -gt 0 ]]; then for extra in "${uv_extras[@]}"; do uv_run_args+=(--extra "$extra"); done; fi; printf "array guard ok\n"'`
- push pre-push hooks
