### PR TITLE
ci: guard empty run args on darwin

### DIFF
--- a/scripts/workflows/run_profile_smoke.sh
+++ b/scripts/workflows/run_profile_smoke.sh
@@ -65,5 +65,13 @@ if [[ ${#uv_extras[@]} -gt 0 ]]; then
   done
 fi
 
-uv run "${uv_run_args[@]}" ser --train --profile "$profile"
-uv run "${uv_run_args[@]}" ser --file "$sample_file" --profile "$profile"
+run_uv() {
+  if [[ ${#uv_run_args[@]} -gt 0 ]]; then
+    uv run "${uv_run_args[@]}" "$@"
+    return 0
+  fi
+  uv run "$@"
+}
+
+run_uv ser --train --profile "$profile"
+run_uv ser --file "$sample_file" --profile "$profile"


### PR DESCRIPTION
## Summary\n- guard the workflow smoke helper when uv run has no extra arguments\n- keep the profile smoke path compatible with the older bash used on hosted Darwin runners\n\n## Testing\n- bash -n scripts/workflows/run_profile_smoke.sh\n- bash -uc 'uv_run_args=(); run_uv(){ if [[ 0 -gt 0 ]]; then printf "with args\n"; return 0; fi; printf "without args\n"; }; run_uv ser --train --profile fast'