### PR TITLE
feat: add timeline subtitle export

### DIFF
--- a/ser/__main__.py
+++ b/ser/__main__.py
@@ -30,11 +30,14 @@ from ser._internal.cli.runtime import (
 )
 from ser.config import AppConfig, reload_settings, settings_override
 from ser.profiles import ProfileName
+from ser.runtime.contracts import SubtitleFormat
 from ser.runtime.phase_timing import format_duration
 from ser.utils.logger import configure_logging, get_logger
+from ser.utils.subtitles import SUPPORTED_SUBTITLE_FORMATS
 
 logger: logging.Logger = get_logger("ser")
 type CliProfileName = ProfileName
+type CliSubtitleFormat = SubtitleFormat
 _PROFILE_CHOICES: tuple[CliProfileName, ...] = (
     "fast",
     "medium",
@@ -122,6 +125,24 @@ def main() -> None:
         "--save_transcript",
         action="store_true",
         help="Save the transcript to a CSV file",
+    )
+    parser.add_argument(
+        "--subtitle-output",
+        type=str,
+        default=None,
+        help=(
+            "Write timeline subtitles to the given path. "
+            "If --subtitle-format is omitted, the format is inferred from the file suffix."
+        ),
+    )
+    parser.add_argument(
+        "--subtitle-format",
+        choices=SUPPORTED_SUBTITLE_FORMATS,
+        default=None,
+        help=(
+            "Subtitle export format. When provided without --subtitle-output, the file is "
+            "written under the configured timeline folder using the source audio stem."
+        ),
     )
     parser.add_argument(
         "--no-transcript",
@@ -308,6 +329,13 @@ def main() -> None:
             language=str(args.language),
             save_transcript=bool(args.save_transcript),
             include_transcript=not bool(args.no_transcript),
+            subtitle_output_path=(
+                args.subtitle_output if isinstance(args.subtitle_output, str) else None
+            ),
+            subtitle_format=cast(
+                CliSubtitleFormat | None,
+                args.subtitle_format if isinstance(args.subtitle_format, str) else None,
+            ),
             pipeline_builder=build_runtime_pipeline,
         )
         if disposition is not None:
@@ -317,8 +345,12 @@ def main() -> None:
                 exc_info=disposition.include_traceback,
             )
             sys.exit(disposition.exit_code)
-        if execution is not None and execution.timeline_csv_path is not None:
-            logger.info(msg=f"Timeline saved to {execution.timeline_csv_path}")
+        timeline_csv_path = getattr(execution, "timeline_csv_path", None) if execution else None
+        subtitle_path = getattr(execution, "subtitle_path", None) if execution else None
+        if timeline_csv_path is not None:
+            logger.info(msg=f"Timeline saved to {timeline_csv_path}")
+        if subtitle_path is not None:
+            logger.info("Timeline subtitles saved to %s", subtitle_path)
         logger.info(
             "SER workflow completed in %s.",
             format_duration(time.perf_counter() - start_time),

--- a/ser/_internal/api/runtime.py
+++ b/ser/_internal/api/runtime.py
@@ -48,7 +48,7 @@ from ser.utils.logger import get_logger
 logger = get_logger(__name__)
 
 if TYPE_CHECKING:
-    from ser.runtime.contracts import InferenceExecution, InferenceRequest
+    from ser.runtime.contracts import InferenceExecution, InferenceRequest, SubtitleFormat
     from ser.transcript.profiling import RuntimeCalibrationResult
 
 
@@ -297,6 +297,8 @@ def run_inference_workflow(
     language: str,
     save_transcript: bool,
     include_transcript: bool,
+    subtitle_output_path: str | None = None,
+    subtitle_format: SubtitleFormat | None = None,
     pipeline_builder: _RuntimePipelineBuilder | None = None,
 ) -> InferenceExecution:
     """Runs CLI-equivalent inference workflow through one API boundary."""
@@ -308,6 +310,8 @@ def run_inference_workflow(
         language=language,
         save_transcript=save_transcript,
         include_transcript=include_transcript,
+        subtitle_output_path=subtitle_output_path,
+        subtitle_format=subtitle_format,
     )
     return builder(settings).run_inference(request)
 
@@ -319,6 +323,8 @@ def infer(
     language: str | None = None,
     save_transcript: bool = False,
     include_transcript: bool = True,
+    subtitle_output_path: str | None = None,
+    subtitle_format: SubtitleFormat | None = None,
     settings: AppConfig,
     pipeline_builder: _RuntimePipelineBuilder | None = None,
 ) -> InferenceExecution:
@@ -335,6 +341,8 @@ def infer(
         language=resolved_language,
         save_transcript=save_transcript,
         include_transcript=include_transcript,
+        subtitle_output_path=subtitle_output_path,
+        subtitle_format=subtitle_format,
         pipeline_builder=pipeline_builder,
     )
 
@@ -386,6 +394,8 @@ def run_inference_command(
     language: str,
     save_transcript: bool,
     include_transcript: bool,
+    subtitle_output_path: str | None = None,
+    subtitle_format: SubtitleFormat | None = None,
     pipeline_builder: _RuntimePipelineBuilder | None = None,
 ) -> tuple[InferenceExecution | None, WorkflowErrorDisposition | None]:
     """Runs inference command and returns execution plus optional failure disposition."""
@@ -395,6 +405,8 @@ def run_inference_command(
         language=language,
         save_transcript=save_transcript,
         include_transcript=include_transcript,
+        subtitle_output_path=subtitle_output_path,
+        subtitle_format=subtitle_format,
         pipeline_builder=pipeline_builder,
         run_inference_workflow=run_inference_workflow,
         classify_inference_error=classify_inference_exception,

--- a/ser/_internal/runtime/commands.py
+++ b/ser/_internal/runtime/commands.py
@@ -8,9 +8,10 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ser.config import AppConfig
+from ser.utils.subtitles import resolve_subtitle_export_request
 
 if TYPE_CHECKING:
-    from ser.runtime.contracts import InferenceExecution
+    from ser.runtime.contracts import InferenceExecution, SubtitleFormat
     from ser.transcript.profiling import RuntimeCalibrationResult
 
 type _TrainingWorkflow = Callable[..., None]
@@ -143,6 +144,8 @@ def run_inference_command(
     language: str,
     save_transcript: bool,
     include_transcript: bool,
+    subtitle_output_path: str | None = None,
+    subtitle_format: SubtitleFormat | None = None,
     pipeline_builder: object | None,
     run_inference_workflow: _InferenceWorkflow,
     classify_inference_error: _InferenceErrorClassifier,
@@ -157,12 +160,36 @@ def run_inference_command(
             ),
         )
     try:
+        subtitle_export = resolve_subtitle_export_request(
+            output_path=subtitle_output_path,
+            subtitle_format=subtitle_format,
+        )
+    except ValueError as err:
+        return (None, WorkflowErrorDisposition(exit_code=2, message=str(err)))
+    if subtitle_export is not None and not include_transcript:
+        return (
+            None,
+            WorkflowErrorDisposition(
+                exit_code=2,
+                message="Subtitle export requires transcript extraction; remove --no-transcript.",
+            ),
+        )
+    resolved_subtitle_format: SubtitleFormat | None
+    resolved_subtitle_output_path: str | None
+    if subtitle_export is None:
+        resolved_subtitle_format = None
+        resolved_subtitle_output_path = None
+    else:
+        resolved_subtitle_format, resolved_subtitle_output_path = subtitle_export
+    try:
         execution = run_inference_workflow(
             settings=settings,
             file_path=file_path,
             language=language,
             save_transcript=save_transcript,
             include_transcript=include_transcript,
+            subtitle_output_path=resolved_subtitle_output_path,
+            subtitle_format=resolved_subtitle_format,
             pipeline_builder=pipeline_builder,
         )
     except Exception as err:

--- a/ser/api.py
+++ b/ser/api.py
@@ -14,7 +14,7 @@ from ser.profiles import ProfileName
 
 if TYPE_CHECKING:
     from ser.diagnostics.domain import DiagnosticReport
-    from ser.runtime.contracts import InferenceExecution, InferenceRequest
+    from ser.runtime.contracts import InferenceExecution, InferenceRequest, SubtitleFormat
 
 ComplianceMode = _data_api.ComplianceMode
 DatasetPrepareResult = _data_api.DatasetPrepareResult
@@ -161,6 +161,8 @@ def infer(
     language: str | None = None,
     save_transcript: bool = False,
     include_transcript: bool = True,
+    subtitle_output_path: str | None = None,
+    subtitle_format: SubtitleFormat | None = None,
     settings: AppConfig | None = None,
     pipeline_builder: RuntimePipelineBuilder | None = None,
 ) -> InferenceExecution:
@@ -171,6 +173,8 @@ def infer(
         language=language,
         save_transcript=save_transcript,
         include_transcript=include_transcript,
+        subtitle_output_path=subtitle_output_path,
+        subtitle_format=subtitle_format,
         settings=_resolve_boundary_settings(settings),
         pipeline_builder=pipeline_builder,
     )

--- a/ser/runtime/contracts.py
+++ b/ser/runtime/contracts.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from typing import Literal
 
 from ser.domain import EmotionSegment, TimelineEntry, TranscriptWord
 from ser.profiles import ProfileName
 from ser.runtime.schema import InferenceResult
+
+type SubtitleFormat = Literal["ass", "srt", "vtt"]
 
 
 @dataclass(frozen=True)
@@ -18,6 +21,8 @@ class InferenceRequest:
     language: str
     save_transcript: bool = False
     include_transcript: bool = True
+    subtitle_output_path: str | None = None
+    subtitle_format: SubtitleFormat | None = None
 
 
 @dataclass(frozen=True)
@@ -32,6 +37,7 @@ class InferenceExecution:
     timeline: list[TimelineEntry]
     used_backend_path: bool = False
     timeline_csv_path: str | None = None
+    subtitle_path: str | None = None
     detailed_result: InferenceResult | None = None
     phase_timings_seconds: dict[str, float] = field(default_factory=dict)
 

--- a/ser/runtime/pipeline.py
+++ b/ser/runtime/pipeline.py
@@ -20,6 +20,7 @@ from ser.runtime.contracts import (
     BackendInferenceCallable,
     InferenceExecution,
     InferenceRequest,
+    SubtitleFormat,
 )
 from ser.runtime.phase_contract import (
     PHASE_TIMELINE_BUILD,
@@ -37,6 +38,7 @@ from ser.runtime.registry import (
 )
 from ser.runtime.schema import InferenceResult, to_legacy_emotion_segments
 from ser.utils.logger import get_logger
+from ser.utils.subtitles import resolve_subtitle_export_request
 from ser.utils.transcription_compat import (
     has_known_faster_whisper_openmp_runtime_conflict,
 )
@@ -51,6 +53,10 @@ type BuildTimelineCallable = Callable[
 ]
 type PrintTimelineCallable = Callable[[list[TimelineEntry]], None]
 type SaveTimelineCallable = Callable[[list[TimelineEntry], str], str]
+type SaveSubtitleCallable = Callable[
+    [list[TimelineEntry], str, SubtitleFormat, str | None],
+    str,
+]
 
 logger = get_logger(__name__)
 
@@ -130,6 +136,7 @@ class RuntimePipeline:
     build_timeline: BuildTimelineCallable
     print_timeline: PrintTimelineCallable
     save_timeline_to_csv: SaveTimelineCallable
+    save_timeline_to_subtitles: SaveSubtitleCallable | None = None
     backend_inference: BackendInferenceCallable | None = None
 
     def run_training(self) -> None:
@@ -145,6 +152,15 @@ class RuntimePipeline:
     def run_inference(self, request: InferenceRequest) -> InferenceExecution:
         """Runs inference and timeline generation for one audio file."""
         ensure_profile_supported(self.capability)
+        subtitle_export = resolve_subtitle_export_request(
+            output_path=request.subtitle_output_path,
+            subtitle_format=request.subtitle_format,
+        )
+        if subtitle_export is not None and not request.include_transcript:
+            raise ValueError(
+                "Subtitle export requires transcript extraction; disable subtitle export or "
+                "remove the no-transcript option."
+            )
         runtime_environment = build_runtime_environment_plan(self.settings)
         with (
             settings_override(self.settings),
@@ -214,8 +230,19 @@ class RuntimePipeline:
                 )
                 raise
             timeline_csv_path: str | None = None
+            subtitle_path: str | None = None
             if request.save_transcript:
                 timeline_csv_path = self.save_timeline_to_csv(timeline, request.file_path)
+            if subtitle_export is not None:
+                if self.save_timeline_to_subtitles is None:
+                    raise RuntimeError("Subtitle export is unavailable for the active runtime.")
+                resolved_subtitle_format, resolved_subtitle_output_path = subtitle_export
+                subtitle_path = self.save_timeline_to_subtitles(
+                    timeline,
+                    request.file_path,
+                    resolved_subtitle_format,
+                    resolved_subtitle_output_path,
+                )
             phase_timings[PHASE_TIMELINE_OUTPUT] = log_phase_completed(
                 logger,
                 phase_name=PHASE_TIMELINE_OUTPUT,
@@ -231,6 +258,7 @@ class RuntimePipeline:
                 timeline=timeline,
                 used_backend_path=used_backend_path,
                 timeline_csv_path=timeline_csv_path,
+                subtitle_path=subtitle_path,
                 detailed_result=detailed_result,
                 phase_timings_seconds=phase_timings,
             )
@@ -256,6 +284,7 @@ def create_runtime_pipeline(settings: AppConfig) -> RuntimePipeline:
         train_model,
     )
     from ser.transcript import TranscriptionProfile, extract_transcript
+    from ser.utils.subtitles import save_timeline_to_subtitles
     from ser.utils.timeline_utils import (
         build_timeline,
         print_timeline,
@@ -314,6 +343,19 @@ def create_runtime_pipeline(settings: AppConfig) -> RuntimePipeline:
     def predict_emotions_detailed_for_settings(file_path: str) -> InferenceResult:
         return predict_emotions_detailed(file_path, settings=settings)
 
+    def save_timeline_to_subtitles_for_settings(
+        timeline: list[TimelineEntry],
+        file_path: str,
+        subtitle_format: SubtitleFormat,
+        output_path: str | None,
+    ) -> str:
+        return save_timeline_to_subtitles(
+            timeline,
+            file_path,
+            subtitle_format=subtitle_format,
+            output_path=output_path,
+        )
+
     return RuntimePipeline(
         settings=settings,
         profile=profile,
@@ -326,4 +368,5 @@ def create_runtime_pipeline(settings: AppConfig) -> RuntimePipeline:
         build_timeline=build_timeline,
         print_timeline=print_timeline,
         save_timeline_to_csv=save_timeline_to_csv,
+        save_timeline_to_subtitles=save_timeline_to_subtitles_for_settings,
     )

--- a/ser/utils/subtitles.py
+++ b/ser/utils/subtitles.py
@@ -1,0 +1,213 @@
+"""Helpers for exporting timeline rows as subtitle artifacts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, cast
+
+from ser.config import TimelineConfig
+from ser.domain import TimelineEntry
+from ser.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+type SubtitleFormat = Literal["ass", "srt", "vtt"]
+SUPPORTED_SUBTITLE_FORMATS: tuple[SubtitleFormat, ...] = ("ass", "srt", "vtt")
+DEFAULT_SUBTITLE_DURATION_SECONDS = 1.0
+
+
+@dataclass(frozen=True, slots=True)
+class SubtitleCue:
+    """One rendered subtitle cue."""
+
+    start_seconds: float
+    end_seconds: float
+    text: str
+    emotion: str
+
+
+def infer_subtitle_format(output_path: str) -> SubtitleFormat | None:
+    """Infers subtitle format from one output-path suffix."""
+    suffix = Path(output_path).suffix.lower().lstrip(".")
+    if suffix in SUPPORTED_SUBTITLE_FORMATS:
+        return cast(SubtitleFormat, suffix)
+    return None
+
+
+def resolve_subtitle_export_request(
+    *,
+    output_path: str | None,
+    subtitle_format: SubtitleFormat | None,
+) -> tuple[SubtitleFormat, str | None] | None:
+    """Validates one requested subtitle export and normalizes format resolution."""
+    normalized_output_path = output_path.strip() if isinstance(output_path, str) else None
+    if isinstance(normalized_output_path, str) and not normalized_output_path:
+        raise ValueError("Subtitle output path cannot be empty.")
+    if subtitle_format is not None and subtitle_format not in SUPPORTED_SUBTITLE_FORMATS:
+        raise ValueError(
+            f"Unsupported subtitle format '{subtitle_format}'. " "Expected one of: ass, srt, vtt."
+        )
+    if subtitle_format is None and normalized_output_path is None:
+        return None
+    if subtitle_format is not None:
+        return subtitle_format, normalized_output_path
+    assert isinstance(normalized_output_path, str)
+    inferred_format = infer_subtitle_format(normalized_output_path)
+    if inferred_format is None:
+        raise ValueError(
+            "Subtitle export requires --subtitle-format or an output path ending in "
+            ".ass, .srt, or .vtt."
+        )
+    return inferred_format, normalized_output_path
+
+
+def timeline_to_subtitle_cues(
+    timeline: list[TimelineEntry],
+    *,
+    default_duration_seconds: float = DEFAULT_SUBTITLE_DURATION_SECONDS,
+) -> list[SubtitleCue]:
+    """Builds subtitle cues from timeline rows with speech content."""
+    if default_duration_seconds <= 0.0:
+        raise ValueError("default_duration_seconds must be greater than zero.")
+    if not timeline:
+        return []
+
+    ordered_timeline = sorted(timeline, key=lambda entry: float(entry.timestamp_seconds))
+    cues: list[SubtitleCue] = []
+    for index, entry in enumerate(ordered_timeline):
+        normalized_text = entry.speech.strip()
+        if not normalized_text:
+            continue
+        next_timestamp: float | None = None
+        if index + 1 < len(ordered_timeline):
+            next_timestamp = float(ordered_timeline[index + 1].timestamp_seconds)
+        start_seconds = float(entry.timestamp_seconds)
+        if next_timestamp is None or next_timestamp <= start_seconds:
+            end_seconds = start_seconds + default_duration_seconds
+        else:
+            end_seconds = next_timestamp
+        cues.append(
+            SubtitleCue(
+                start_seconds=start_seconds,
+                end_seconds=end_seconds,
+                text=normalized_text,
+                emotion=entry.emotion,
+            )
+        )
+    return cues
+
+
+def save_timeline_to_subtitles(
+    timeline: list[TimelineEntry],
+    file_name: str,
+    *,
+    subtitle_format: SubtitleFormat,
+    output_path: str | None = None,
+    timeline_config: TimelineConfig | None = None,
+) -> str:
+    """Writes timeline subtitles and returns the generated artifact path."""
+    cues = timeline_to_subtitle_cues(timeline)
+    active_config = timeline_config if timeline_config is not None else TimelineConfig()
+    target_path = (
+        Path(output_path)
+        if isinstance(output_path, str) and output_path
+        else active_config.folder / f"{Path(file_name).stem}.{subtitle_format}"
+    )
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    target_path.write_text(_render_subtitles(cues, subtitle_format), encoding="utf-8")
+    logger.info("Timeline subtitles saved to %s", target_path)
+    return str(target_path)
+
+
+def _render_subtitles(cues: list[SubtitleCue], subtitle_format: SubtitleFormat) -> str:
+    """Renders subtitle cues using the requested subtitle format."""
+    if subtitle_format == "ass":
+        body = "\n".join(_render_ass_entry(cue) for cue in cues)
+        return f"{_ASS_HEADER}{body}\n" if body else _ASS_HEADER
+    if subtitle_format == "srt":
+        body = "\n".join(
+            _render_srt_entry(index=index, cue=cue) for index, cue in enumerate(cues, start=1)
+        )
+        return f"{body}\n" if body else ""
+    if subtitle_format == "vtt":
+        body = "\n".join(_render_vtt_entry(cue) for cue in cues)
+        return f"WEBVTT\n\n{body}\n" if body else "WEBVTT\n"
+    raise ValueError(f"Unsupported subtitle format: {subtitle_format}")
+
+
+def _render_ass_entry(cue: SubtitleCue) -> str:
+    """Renders one ASS subtitle line."""
+    return (
+        "Dialogue: 0,"
+        f"{_format_ass_time(cue.start_seconds)},{_format_ass_time(cue.end_seconds)},"
+        f"Default,,0,0,0,,{_compose_caption_text(cue)}"
+    )
+
+
+def _render_srt_entry(*, index: int, cue: SubtitleCue) -> str:
+    """Renders one SRT subtitle block."""
+    return (
+        f"{index}\n"
+        f"{_format_srt_time(cue.start_seconds)} --> {_format_srt_time(cue.end_seconds)}\n"
+        f"{_compose_caption_text(cue)}\n"
+    )
+
+
+def _render_vtt_entry(cue: SubtitleCue) -> str:
+    """Renders one WebVTT subtitle block."""
+    return (
+        f"{_format_vtt_time(cue.start_seconds)} --> {_format_vtt_time(cue.end_seconds)}\n"
+        f"{_compose_caption_text(cue)}\n"
+    )
+
+
+def _compose_caption_text(cue: SubtitleCue) -> str:
+    """Builds one displayed subtitle payload."""
+    normalized_text = cue.text.replace("\r", " ").replace("\n", " ").strip()
+    normalized_emotion = cue.emotion.strip()
+    if not normalized_emotion:
+        return normalized_text
+    return f"{normalized_text} ({normalized_emotion})"
+
+
+def _format_ass_time(seconds: float) -> str:
+    """Formats one timestamp for ASS output."""
+    total_centiseconds = max(int(round(seconds * 100)), 0)
+    hours, remainder = divmod(total_centiseconds, 360000)
+    minutes, remainder = divmod(remainder, 6000)
+    secs, centiseconds = divmod(remainder, 100)
+    return f"{hours}:{minutes:02d}:{secs:02d}.{centiseconds:02d}"
+
+
+def _format_srt_time(seconds: float) -> str:
+    """Formats one timestamp for SRT output."""
+    total_milliseconds = max(int(round(seconds * 1000)), 0)
+    hours, remainder = divmod(total_milliseconds, 3_600_000)
+    minutes, remainder = divmod(remainder, 60_000)
+    secs, milliseconds = divmod(remainder, 1000)
+    return f"{hours:02d}:{minutes:02d}:{secs:02d},{milliseconds:03d}"
+
+
+def _format_vtt_time(seconds: float) -> str:
+    """Formats one timestamp for WebVTT output."""
+    total_milliseconds = max(int(round(seconds * 1000)), 0)
+    hours, remainder = divmod(total_milliseconds, 3_600_000)
+    minutes, remainder = divmod(remainder, 60_000)
+    secs, milliseconds = divmod(remainder, 1000)
+    return f"{hours:02d}:{minutes:02d}:{secs:02d}.{milliseconds:03d}"
+
+
+_ASS_HEADER = """[Script Info]
+Title: SER Timeline Export
+ScriptType: v4.00+
+Collisions: Normal
+PlayDepth: 0
+
+[V4+ Styles]
+Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
+Style: Default,Arial,20,&H00FFFFFF,&H000000FF,&H00000000,&H64000000,-1,0,0,0,100,100,0,0.00,1,1.00,0.00,2,10,10,10,1
+
+[Events]
+Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
+"""

--- a/tests/suites/integration/test_runtime_pipeline.py
+++ b/tests/suites/integration/test_runtime_pipeline.py
@@ -33,6 +33,7 @@ type BuildTimelineCallable = Callable[
 ]
 type PrintTimelineCallable = Callable[[list[TimelineEntry]], None]
 type SaveTimelineCallable = Callable[[list[TimelineEntry], str], str]
+type SaveSubtitleCallable = Callable[[list[TimelineEntry], str, str, str | None], str]
 
 pytestmark = [pytest.mark.integration, pytest.mark.usefixtures("reset_ambient_settings")]
 
@@ -46,6 +47,7 @@ def _build_test_pipeline(
     build_timeline: BuildTimelineCallable,
     print_timeline: PrintTimelineCallable,
     save_timeline_to_csv: SaveTimelineCallable,
+    save_timeline_to_subtitles: SaveSubtitleCallable | None = None,
     backend_inference: Callable[[InferenceRequest], InferenceResult] | None = None,
     settings: AppConfig | None = None,
 ) -> RuntimePipeline:
@@ -70,6 +72,7 @@ def _build_test_pipeline(
         build_timeline=build_timeline,
         print_timeline=print_timeline,
         save_timeline_to_csv=save_timeline_to_csv,
+        save_timeline_to_subtitles=save_timeline_to_subtitles,
     )
 
 
@@ -194,6 +197,53 @@ def test_run_inference_with_save_transcript_enabled() -> None:
     assert calls["save"] == (timeline, "sample.wav")
 
 
+def test_run_inference_with_subtitle_export_enabled() -> None:
+    """Pipeline inference should export subtitles when requested."""
+    calls: dict[str, object] = {}
+    emotions = [EmotionSegment("happy", 0.0, 1.0)]
+    transcript = [TranscriptWord("ola", 0.0, 0.5)]
+    timeline = [TimelineEntry(0.0, "happy", "ola")]
+
+    def fake_save_subtitles(
+        timeline_rows: list[TimelineEntry],
+        file_path: str,
+        subtitle_format: str,
+        output_path: str | None,
+    ) -> str:
+        calls["save_subtitles"] = (timeline_rows, file_path, subtitle_format, output_path)
+        return "timeline.vtt"
+
+    pipeline = _build_test_pipeline(
+        train_model=lambda: None,
+        predict_emotions=lambda _file_path: emotions,
+        predict_emotions_detailed=lambda _file_path: (_ for _ in ()).throw(
+            AssertionError("Detailed path should not run when schema flag is disabled.")
+        ),
+        extract_transcript=lambda _file_path, _language: transcript,
+        build_timeline=lambda _transcript, _emotions: timeline,
+        print_timeline=lambda _timeline: None,
+        save_timeline_to_csv=lambda _timeline, _file_path: "unused.csv",
+        save_timeline_to_subtitles=fake_save_subtitles,
+    )
+
+    execution = pipeline.run_inference(
+        InferenceRequest(
+            file_path="sample.wav",
+            language="pt",
+            subtitle_output_path="exports/sample.vtt",
+        )
+    )
+
+    assert execution.subtitle_path == "timeline.vtt"
+    assert execution.timeline_csv_path is None
+    assert calls["save_subtitles"] == (
+        timeline,
+        "sample.wav",
+        "vtt",
+        "exports/sample.vtt",
+    )
+
+
 def test_run_inference_scopes_pipeline_settings_for_dependencies() -> None:
     """Inference dependencies should observe the pipeline's explicit settings snapshot."""
     ambient_settings = config.reload_settings()
@@ -256,6 +306,35 @@ def test_run_inference_skips_save_when_flag_is_disabled() -> None:
     assert execution.backend_id == "handcrafted"
     assert execution.used_backend_path is False
     assert execution.timeline_csv_path is None
+    assert execution.subtitle_path is None
+
+
+def test_run_inference_rejects_subtitle_export_without_transcript() -> None:
+    """Subtitle export requires transcript content and should fail when disabled."""
+    pipeline = _build_test_pipeline(
+        train_model=lambda: None,
+        predict_emotions=lambda _file_path: [EmotionSegment("calm", 0.0, 1.0)],
+        predict_emotions_detailed=lambda _file_path: (_ for _ in ()).throw(
+            AssertionError("Detailed path should not run when schema flag is disabled.")
+        ),
+        extract_transcript=lambda _file_path, _language: [TranscriptWord("oi", 0.0, 0.4)],
+        build_timeline=lambda _transcript, _emotions: [TimelineEntry(0.0, "calm", "oi")],
+        print_timeline=lambda _timeline: None,
+        save_timeline_to_csv=lambda _timeline, _file_path: "unused.csv",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Subtitle export requires transcript extraction",
+    ):
+        pipeline.run_inference(
+            InferenceRequest(
+                file_path="sample.wav",
+                language="en",
+                include_transcript=False,
+                subtitle_format="srt",
+            )
+        )
 
 
 def test_run_inference_skips_transcript_extraction_when_disabled() -> None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -252,6 +252,27 @@ def test_run_inference_command_validates_missing_file_path() -> None:
     assert disposition.include_traceback is False
 
 
+def test_run_inference_command_rejects_subtitle_export_without_transcript() -> None:
+    """Subtitle export should fail fast when transcript extraction is disabled."""
+    execution, disposition = api_runtime_module.run_inference_command(
+        settings=config_module.reload_settings(),
+        file_path="sample.wav",
+        language="en",
+        save_transcript=False,
+        include_transcript=False,
+        subtitle_format="vtt",
+        pipeline_builder=None,
+    )
+
+    assert execution is None
+    assert disposition is not None
+    assert disposition.exit_code == 2
+    assert disposition.message == (
+        "Subtitle export requires transcript extraction; remove --no-transcript."
+    )
+    assert disposition.include_traceback is False
+
+
 def test_run_inference_command_delegates_arguments_on_success(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -286,7 +307,9 @@ def test_run_inference_command_delegates_arguments_on_success(
         file_path="sample.wav",
         language="en",
         save_transcript=True,
-        include_transcript=False,
+        include_transcript=True,
+        subtitle_output_path="exports/sample.vtt",
+        subtitle_format="vtt",
         pipeline_builder=_pipeline_builder,
     )
 
@@ -297,7 +320,9 @@ def test_run_inference_command_delegates_arguments_on_success(
     assert kwargs["file_path"] == "sample.wav"
     assert kwargs["language"] == "en"
     assert kwargs["save_transcript"] is True
-    assert kwargs["include_transcript"] is False
+    assert kwargs["include_transcript"] is True
+    assert kwargs["subtitle_output_path"] == "exports/sample.vtt"
+    assert kwargs["subtitle_format"] == "vtt"
     assert kwargs["pipeline_builder"] is _pipeline_builder
 
 
@@ -743,6 +768,8 @@ def test_infer_builds_inference_request(
         language="en",
         save_transcript=True,
         include_transcript=False,
+        subtitle_output_path="exports/sample.vtt",
+        subtitle_format="vtt",
         pipeline_builder=lambda _settings: _FakePipeline(),
     )
 
@@ -752,6 +779,8 @@ def test_infer_builds_inference_request(
     assert request.language == "en"
     assert request.save_transcript is True
     assert request.include_transcript is False
+    assert request.subtitle_output_path == "exports/sample.vtt"
+    assert request.subtitle_format == "vtt"
 
 
 def test_classify_inference_exception_for_unsupported_profile() -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -237,6 +237,77 @@ def test_cli_prediction_does_not_save_when_flag_is_absent(
     assert request.include_transcript is True
 
 
+def test_cli_prediction_passes_subtitle_export_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Prediction path should pass normalized subtitle export settings to pipeline."""
+    _patch_common_cli_dependencies(monkeypatch)
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        ["ser", "--file", "sample.wav", "--subtitle-output", "exports/sample.vtt"],
+    )
+    calls: dict[str, object] = {}
+
+    class FakePipeline:
+        def run_inference(self, request: object) -> object:
+            calls["request"] = request
+            return SimpleNamespace(timeline_csv_path=None, subtitle_path="exports/sample.vtt")
+
+    monkeypatch.setattr(cli, "build_runtime_pipeline", lambda _settings: FakePipeline())
+
+    cli.main()
+
+    request = cast(InferenceRequest, calls["request"])
+    assert request.file_path == "sample.wav"
+    assert request.subtitle_output_path == "exports/sample.vtt"
+    assert request.subtitle_format == "vtt"
+    assert request.include_transcript is True
+
+
+def test_cli_prediction_allows_default_subtitle_path_when_format_is_explicit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Explicit subtitle format alone should request default subtitle placement."""
+    _patch_common_cli_dependencies(monkeypatch)
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        ["ser", "--file", "sample.wav", "--subtitle-format", "ass"],
+    )
+    calls: dict[str, object] = {}
+
+    class FakePipeline:
+        def run_inference(self, request: object) -> object:
+            calls["request"] = request
+            return SimpleNamespace(timeline_csv_path=None, subtitle_path="sample.ass")
+
+    monkeypatch.setattr(cli, "build_runtime_pipeline", lambda _settings: FakePipeline())
+
+    cli.main()
+
+    request = cast(InferenceRequest, calls["request"])
+    assert request.subtitle_output_path is None
+    assert request.subtitle_format == "ass"
+
+
+def test_cli_prediction_rejects_subtitle_export_without_transcript(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Subtitle export should fail fast when transcript extraction is disabled."""
+    _patch_common_cli_dependencies(monkeypatch)
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        ["ser", "--file", "sample.wav", "--no-transcript", "--subtitle-format", "srt"],
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main()
+
+    assert exc_info.value.code == 2
+
+
 def test_cli_train_option_uses_runtime_pipeline_when_enabled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_subtitles.py
+++ b/tests/test_subtitles.py
@@ -1,0 +1,109 @@
+"""Tests for subtitle export helpers."""
+
+from pathlib import Path
+
+import pytest
+
+from ser.config import TimelineConfig
+from ser.domain import TimelineEntry
+from ser.utils.subtitles import (
+    infer_subtitle_format,
+    resolve_subtitle_export_request,
+    save_timeline_to_subtitles,
+    timeline_to_subtitle_cues,
+)
+
+
+def test_resolve_subtitle_export_request_infers_format_from_output_path() -> None:
+    """Output-path suffix should infer one missing subtitle format."""
+    resolved = resolve_subtitle_export_request(
+        output_path="exports/sample.vtt",
+        subtitle_format=None,
+    )
+
+    assert resolved == ("vtt", "exports/sample.vtt")
+
+
+def test_resolve_subtitle_export_request_rejects_unknown_suffix_without_format() -> None:
+    """Unknown subtitle suffix should fail fast without explicit format."""
+    with pytest.raises(ValueError, match="Subtitle export requires"):
+        resolve_subtitle_export_request(
+            output_path="exports/sample.txt",
+            subtitle_format=None,
+        )
+
+
+def test_infer_subtitle_format_returns_none_for_unknown_suffix() -> None:
+    """Suffix inference should return None for unsupported formats."""
+    assert infer_subtitle_format("sample.txt") is None
+
+
+def test_timeline_to_subtitle_cues_sorts_and_computes_durations() -> None:
+    """Cue generation should sort timeline rows and derive end times from neighbors."""
+    timeline = [
+        TimelineEntry(5.0, "happy", "Third"),
+        TimelineEntry(1.0, "neutral", "First"),
+        TimelineEntry(3.0, "sad", "Second"),
+    ]
+
+    cues = timeline_to_subtitle_cues(timeline, default_duration_seconds=2.0)
+
+    assert [(cue.start_seconds, cue.end_seconds) for cue in cues] == [
+        (1.0, 3.0),
+        (3.0, 5.0),
+        (5.0, 7.0),
+    ]
+
+
+def test_timeline_to_subtitle_cues_skips_blank_text() -> None:
+    """Rows without visible speech should not emit subtitle cues."""
+    timeline = [
+        TimelineEntry(0.0, "happy", "  Hello "),
+        TimelineEntry(1.0, "sad", "   "),
+        TimelineEntry(2.0, "angry", "World"),
+    ]
+
+    cues = timeline_to_subtitle_cues(timeline)
+
+    assert [(cue.start_seconds, cue.text, cue.emotion) for cue in cues] == [
+        (0.0, "Hello", "happy"),
+        (2.0, "World", "angry"),
+    ]
+
+
+def test_save_timeline_to_subtitles_writes_default_vtt_path(tmp_path: Path) -> None:
+    """Subtitle save helper should derive default artifact path from timeline config."""
+    timeline = [TimelineEntry(0.0, "happy", "Hello world")]
+
+    subtitle_path = save_timeline_to_subtitles(
+        timeline,
+        "sample.wav",
+        subtitle_format="vtt",
+        timeline_config=TimelineConfig(folder=tmp_path),
+    )
+
+    written = Path(subtitle_path)
+    assert written == tmp_path / "sample.vtt"
+    content = written.read_text(encoding="utf-8")
+    assert content.startswith("WEBVTT\n")
+    assert "00:00:00.000 --> 00:00:01.000" in content
+    assert "Hello world (happy)" in content
+
+
+def test_save_timeline_to_subtitles_honors_explicit_output_path(tmp_path: Path) -> None:
+    """Explicit output path should override default timeline folder placement."""
+    timeline = [TimelineEntry(0.0, "calm", "Hello")]
+    output_path = tmp_path / "nested" / "custom.srt"
+
+    subtitle_path = save_timeline_to_subtitles(
+        timeline,
+        "sample.wav",
+        subtitle_format="srt",
+        output_path=output_path.as_posix(),
+    )
+
+    written = Path(subtitle_path)
+    assert written == output_path
+    content = written.read_text(encoding="utf-8")
+    assert "00:00:00,000 --> 00:00:01,000" in content
+    assert "Hello (calm)" in content


### PR DESCRIPTION
## Summary
- add optional timeline subtitle export through the runtime, API, and CLI paths
- validate subtitle export requests and keep transcript-free inference behavior unchanged unless export is requested
- cover the feature with subtitle utility, API, CLI, and runtime pipeline tests

## Testing
- uv run --frozen --extra dev pre-commit run --all-files --hook-stage pre-push
- uv run --extra dev pytest