### PR TITLE
Refactor runtime hotspots and add coverage gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,34 @@ jobs:
           uv run --frozen --python ${{ matrix.python-version }} --extra dev --extra medium pytest -q
           tests/suites
 
+  coverage:
+    needs: [changes]
+    if: needs.changes.outputs.run_full == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        run: python -m pip install --upgrade pip uv
+
+      - name: Cache uv
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/uv
+          key: uv-${{ runner.os }}-coverage-py3.12-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            uv-${{ runner.os }}-coverage-py3.12-
+
+      - name: Enforce branch coverage threshold
+        run: make test-cov
+
   contract-gates:
     runs-on: ubuntu-latest
     needs: [changes, code-quality, resolve]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help setup setup-runtime fmt lint type test check ci train predict optin-all-restricted quality-gate-full prepush prepush-check prepush-hook import-lint clean
+.PHONY: help setup setup-runtime fmt lint type test test-cov check ci train predict optin-all-restricted quality-gate-full prepush prepush-check prepush-hook import-lint clean
 
 .DEFAULT_GOAL := help
 
@@ -12,6 +12,7 @@ help:
 	@echo "  lint     - run linters"
 	@echo "  type     - run type checks"
 	@echo "  test     - run tests"
+	@echo "  test-cov - run tests with branch coverage gating"
 	@echo "  check    - lint + type + test"
 	@echo "  prepush  - run local pre-push quality gates (autofix + verify)"
 	@echo "  prepush-check - run canonical pre-push hook command (check-only)"
@@ -46,6 +47,9 @@ type:
 
 test:
 	uv run pytest -q
+
+test-cov:
+	uv run --frozen --extra dev pytest -q --cov=ser --cov-report=term-missing --cov-report=xml
 
 check: lint type test
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,9 @@ dependencies = [
 dev = [
   "pre-commit>=4.0.0,<5.0.0",
   "pytest>=8.0.0,<9.0.0",
+  "pytest-cov>=6.0.0,<7.0.0",
+  "coverage[toml]>=7.6.0,<8.0.0",
+  "hypothesis>=6.130.0,<7.0.0",
   "ruff>=0.9.0,<1.0.0",
   "black>=24.10.0,<26.0.0",
   "isort>=5.13.0,<7.0.0",
@@ -178,6 +181,20 @@ include = ["ser", "tests"]
 exclude = ["**/__pycache__", "dist", "build", ".venv", ".*"]
 reportMissingImports = "warning"
 reportMissingTypeStubs = "none"
+
+[tool.coverage.run]
+branch = true
+relative_files = true
+source = ["ser"]
+
+[tool.coverage.report]
+show_missing = true
+skip_covered = true
+precision = 2
+fail_under = 78.00
+exclude_also = [
+  "if TYPE_CHECKING:",
+]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/ser/__main__.py
+++ b/ser/__main__.py
@@ -6,7 +6,8 @@ import argparse
 import logging
 import sys
 import time
-from contextlib import nullcontext
+from collections.abc import Sequence
+from contextlib import AbstractContextManager, nullcontext
 from typing import cast
 
 from dotenv import load_dotenv
@@ -29,6 +30,7 @@ from ser._internal.cli.runtime import (
     run_transcription_runtime_calibration_command,
 )
 from ser.config import AppConfig, reload_settings, settings_override
+from ser.diagnostics.domain import PreflightMode
 from ser.profiles import ProfileName
 from ser.runtime.contracts import SubtitleFormat
 from ser.runtime.phase_timing import format_duration
@@ -66,31 +68,52 @@ _DATASET_COMMAND_HELP = (
 )
 
 
-def main() -> None:
-    """Parses CLI arguments and runs training or inference workflows."""
-    load_dotenv()
+def _build_pre_parser() -> argparse.ArgumentParser:
+    """Builds the minimal parser used for early logging configuration."""
     pre_parser = argparse.ArgumentParser(add_help=False)
     pre_parser.add_argument("--log-level", type=str, default=None)
-    pre_args, pre_remaining = pre_parser.parse_known_args()
-    configure_logging(pre_args.log_level)
-    settings: AppConfig = reload_settings()
+    return pre_parser
 
-    # Subcommand dispatch for dataset and diagnostics workflows.
-    if pre_remaining and pre_remaining[0] in {"configure", "data", "doctor"}:
-        command = pre_remaining[0]
-        command_argv = pre_remaining[1:]
-        try:
-            if command == "configure":
-                raise SystemExit(run_configure_command(command_argv, settings=settings))
-            if command == "data":
-                raise SystemExit(run_data_command(command_argv, settings=settings))
-            raise SystemExit(run_doctor_command(command_argv, settings=settings))
-        except SystemExit:
-            raise
-        except Exception as err:
-            logger.error("Command '%s' failed: %s", command, err)
-            raise SystemExit(1) from err
 
+def _command_file_path(value: object) -> str | None:
+    """Returns the CLI file-path argument when present."""
+    return value if isinstance(value, str) else None
+
+
+def _log_cli_records(records: Sequence[tuple[str, str]]) -> None:
+    """Emits structured CLI gate logs through the top-level logger."""
+    for level, message in records:
+        if level == "error":
+            logger.error("%s", message)
+            continue
+        logger.info("%s", message)
+
+
+def _dispatch_subcommand(command: str, command_argv: Sequence[str], *, settings: AppConfig) -> None:
+    """Runs one CLI subcommand and exits with its return code."""
+    try:
+        if command == "configure":
+            raise SystemExit(run_configure_command(list(command_argv), settings=settings))
+        if command == "data":
+            raise SystemExit(run_data_command(list(command_argv), settings=settings))
+        raise SystemExit(run_doctor_command(list(command_argv), settings=settings))
+    except SystemExit:
+        raise
+    except Exception as err:
+        logger.error("Command '%s' failed: %s", command, err)
+        raise SystemExit(1) from err
+
+
+def _maybe_dispatch_subcommand(pre_remaining: Sequence[str], *, settings: AppConfig) -> bool:
+    """Runs subcommand flow when one CLI subcommand is requested."""
+    if not pre_remaining or pre_remaining[0] not in {"configure", "data", "doctor"}:
+        return False
+    _dispatch_subcommand(pre_remaining[0], pre_remaining[1:], settings=settings)
+    return True
+
+
+def _build_main_parser(settings: AppConfig) -> argparse.ArgumentParser:
+    """Builds the main CLI parser for inference, training, and maintenance flows."""
     parser: argparse.ArgumentParser = argparse.ArgumentParser(
         description="Speech Emotion Recognition Tool",
         epilog=_DATASET_COMMAND_HELP,
@@ -213,6 +236,163 @@ def main() -> None:
             "(fast,medium,accurate,accurate-research)."
         ),
     )
+    return parser
+
+
+def _settings_scope(active_settings: object) -> AbstractContextManager[object]:
+    """Returns the scoped settings context when one concrete config is active."""
+    if isinstance(active_settings, AppConfig):
+        return settings_override(active_settings)
+    return nullcontext()
+
+
+def _run_restricted_backend_gate(
+    args: argparse.Namespace, *, active_settings: object
+) -> int | None:
+    """Runs restricted-backend CLI gating and returns an optional exit code."""
+    restricted_logs, restricted_exit_code = run_restricted_backend_cli_gate(
+        settings=cast(AppConfig, active_settings),
+        use_profile_pipeline=profile_pipeline_enabled(cast(AppConfig, active_settings)),
+        train_requested=bool(args.train),
+        file_path=_command_file_path(args.file),
+        accept_restricted_backends=bool(args.accept_restricted_backends),
+        accept_all_restricted_backends=bool(args.accept_all_restricted_backends),
+        is_interactive=bool(sys.stdin.isatty() and sys.stdout.isatty()),
+    )
+    _log_cli_records(restricted_logs)
+    return restricted_exit_code
+
+
+def _run_preflight_gate(
+    args: argparse.Namespace,
+    *,
+    active_settings: object,
+    preflight_mode: PreflightMode,
+) -> int | None:
+    """Runs startup preflight gate when a concrete config is available."""
+    if not isinstance(active_settings, AppConfig):
+        return None
+    preflight_logs, preflight_exit_code = run_startup_preflight_cli_gate(
+        settings=active_settings,
+        mode=preflight_mode,
+        profile=args.profile if isinstance(args.profile, str) else None,
+        train_requested=bool(args.train),
+        file_path=_command_file_path(args.file),
+        no_transcript=bool(args.no_transcript),
+        calibrate_transcription_runtime=bool(args.calibrate_transcription_runtime),
+    )
+    _log_cli_records(preflight_logs)
+    return preflight_exit_code
+
+
+def _run_calibration_or_exit(args: argparse.Namespace) -> None:
+    """Runs calibration workflow and exits with success or failure disposition."""
+    calibration_result, calibration_error = run_transcription_runtime_calibration_command(
+        file_path=_command_file_path(args.file),
+        language=str(args.language),
+        calibration_iterations=int(args.calibration_iterations),
+        calibration_profiles=str(args.calibration_profiles),
+    )
+    if calibration_error is not None:
+        logger.error(
+            "%s",
+            calibration_error.message,
+            exc_info=calibration_error.include_traceback,
+        )
+        sys.exit(calibration_error.exit_code)
+    if calibration_result is None:
+        logger.error("Calibration command returned no result.")
+        sys.exit(1)
+
+    logger.info(
+        "Transcription runtime calibration completed. Report: %s",
+        calibration_result.report_path,
+    )
+    for recommendation in calibration_result.recommendations:
+        logger.info(
+            "Calibration recommendation (%s/%s): %s (confidence=%s, reason=%s).",
+            recommendation.profile.source_profile,
+            recommendation.profile.model_name,
+            recommendation.recommendation,
+            recommendation.confidence,
+            recommendation.reason,
+        )
+    sys.exit(0)
+
+
+def _run_training_or_exit(*, active_settings: object, use_profile_pipeline: bool) -> None:
+    """Runs training flow and exits with the appropriate status code."""
+    logger.info("Starting model training...")
+    start_time = time.perf_counter()
+    disposition = run_training_command(
+        settings=cast(AppConfig, active_settings),
+        use_profile_pipeline=use_profile_pipeline,
+        pipeline_builder=build_runtime_pipeline,
+    )
+    if disposition is not None:
+        logger.error(
+            "%s",
+            disposition.message,
+            exc_info=disposition.include_traceback,
+        )
+        sys.exit(disposition.exit_code)
+    logger.info(
+        "Training completed in %s.",
+        format_duration(time.perf_counter() - start_time),
+    )
+    sys.exit(0)
+
+
+def _run_inference_or_exit(args: argparse.Namespace, *, active_settings: object) -> None:
+    """Runs inference flow and exits on any workflow disposition."""
+    workflow_profile = resolve_cli_workflow_profile(cast(AppConfig, active_settings))
+    logger.info("SER workflow started (profile=%s).", workflow_profile)
+    start_time = time.perf_counter()
+    execution, disposition = run_inference_command(
+        settings=cast(AppConfig, active_settings),
+        file_path=_command_file_path(args.file),
+        language=str(args.language),
+        save_transcript=bool(args.save_transcript),
+        include_transcript=not bool(args.no_transcript),
+        subtitle_output_path=(
+            args.subtitle_output if isinstance(args.subtitle_output, str) else None
+        ),
+        subtitle_format=cast(
+            CliSubtitleFormat | None,
+            args.subtitle_format if isinstance(args.subtitle_format, str) else None,
+        ),
+        pipeline_builder=build_runtime_pipeline,
+    )
+    if disposition is not None:
+        logger.error(
+            "%s",
+            disposition.message,
+            exc_info=disposition.include_traceback,
+        )
+        sys.exit(disposition.exit_code)
+    timeline_csv_path = getattr(execution, "timeline_csv_path", None) if execution else None
+    subtitle_path = getattr(execution, "subtitle_path", None) if execution else None
+    if timeline_csv_path is not None:
+        logger.info(msg=f"Timeline saved to {timeline_csv_path}")
+    if subtitle_path is not None:
+        logger.info("Timeline subtitles saved to %s", subtitle_path)
+    logger.info(
+        "SER workflow completed in %s.",
+        format_duration(time.perf_counter() - start_time),
+    )
+
+
+def main() -> None:
+    """Parses CLI arguments and runs training or inference workflows."""
+    load_dotenv()
+    pre_parser = _build_pre_parser()
+    pre_args, pre_remaining = pre_parser.parse_known_args()
+    configure_logging(pre_args.log_level)
+    settings: AppConfig = reload_settings()
+    if _maybe_dispatch_subcommand(pre_remaining, settings=settings):
+        return
+
+    parser = _build_main_parser(settings)
     args: argparse.Namespace = parser.parse_args()
     configure_logging(args.log_level)
     active_settings = apply_cli_profile_override(
@@ -224,137 +404,33 @@ def main() -> None:
         disable_timeouts=bool(args.disable_timeouts),
     )
     preflight_mode = parse_preflight_mode(str(args.preflight))
-    settings_scope = (
-        settings_override(active_settings)
-        if isinstance(active_settings, AppConfig)
-        else nullcontext()
-    )
-    with settings_scope:
-        use_profile_pipeline: bool = profile_pipeline_enabled(active_settings)
-        restricted_logs, restricted_exit_code = run_restricted_backend_cli_gate(
-            settings=active_settings,
-            use_profile_pipeline=use_profile_pipeline,
-            train_requested=bool(args.train),
-            file_path=args.file if isinstance(args.file, str) else None,
-            accept_restricted_backends=bool(args.accept_restricted_backends),
-            accept_all_restricted_backends=bool(args.accept_all_restricted_backends),
-            is_interactive=bool(sys.stdin.isatty() and sys.stdout.isatty()),
+    with _settings_scope(active_settings):
+        restricted_exit_code = _run_restricted_backend_gate(
+            args,
+            active_settings=active_settings,
         )
-        for level, message in restricted_logs:
-            if level == "error":
-                logger.error("%s", message)
-            else:
-                logger.info("%s", message)
         if restricted_exit_code is not None:
             sys.exit(restricted_exit_code)
 
-        if isinstance(active_settings, AppConfig):
-            preflight_logs, preflight_exit_code = run_startup_preflight_cli_gate(
-                settings=active_settings,
-                mode=preflight_mode,
-                profile=args.profile if isinstance(args.profile, str) else None,
-                train_requested=bool(args.train),
-                file_path=args.file if isinstance(args.file, str) else None,
-                no_transcript=bool(args.no_transcript),
-                calibrate_transcription_runtime=bool(args.calibrate_transcription_runtime),
-            )
-            for level, message in preflight_logs:
-                if level == "error":
-                    logger.error("%s", message)
-                else:
-                    logger.info("%s", message)
-            if preflight_exit_code is not None:
-                sys.exit(preflight_exit_code)
+        preflight_exit_code = _run_preflight_gate(
+            args,
+            active_settings=active_settings,
+            preflight_mode=preflight_mode,
+        )
+        if preflight_exit_code is not None:
+            sys.exit(preflight_exit_code)
 
         if args.calibrate_transcription_runtime:
-            calibration_result, calibration_error = run_transcription_runtime_calibration_command(
-                file_path=args.file if isinstance(args.file, str) else None,
-                language=args.language,
-                calibration_iterations=args.calibration_iterations,
-                calibration_profiles=args.calibration_profiles,
-            )
-            if calibration_error is not None:
-                logger.error(
-                    "%s",
-                    calibration_error.message,
-                    exc_info=calibration_error.include_traceback,
-                )
-                sys.exit(calibration_error.exit_code)
-            if calibration_result is None:
-                logger.error("Calibration command returned no result.")
-                sys.exit(1)
+            _run_calibration_or_exit(args)
 
-            logger.info(
-                "Transcription runtime calibration completed. Report: %s",
-                calibration_result.report_path,
-            )
-            for recommendation in calibration_result.recommendations:
-                logger.info(
-                    "Calibration recommendation (%s/%s): %s (confidence=%s, reason=%s).",
-                    recommendation.profile.source_profile,
-                    recommendation.profile.model_name,
-                    recommendation.recommendation,
-                    recommendation.confidence,
-                    recommendation.reason,
-                )
-            sys.exit(0)
-
+        use_profile_pipeline = profile_pipeline_enabled(active_settings)
         if args.train:
-            logger.info("Starting model training...")
-            start_time: float = time.perf_counter()
-            disposition = run_training_command(
-                settings=active_settings,
+            _run_training_or_exit(
+                active_settings=active_settings,
                 use_profile_pipeline=use_profile_pipeline,
-                pipeline_builder=build_runtime_pipeline,
             )
-            if disposition is not None:
-                logger.error(
-                    "%s",
-                    disposition.message,
-                    exc_info=disposition.include_traceback,
-                )
-                sys.exit(disposition.exit_code)
-            logger.info(
-                "Training completed in %s.",
-                format_duration(time.perf_counter() - start_time),
-            )
-            sys.exit(0)
 
-        workflow_profile = resolve_cli_workflow_profile(active_settings)
-        logger.info("SER workflow started (profile=%s).", workflow_profile)
-        start_time = time.perf_counter()
-        execution, disposition = run_inference_command(
-            settings=active_settings,
-            file_path=args.file if isinstance(args.file, str) else None,
-            language=str(args.language),
-            save_transcript=bool(args.save_transcript),
-            include_transcript=not bool(args.no_transcript),
-            subtitle_output_path=(
-                args.subtitle_output if isinstance(args.subtitle_output, str) else None
-            ),
-            subtitle_format=cast(
-                CliSubtitleFormat | None,
-                args.subtitle_format if isinstance(args.subtitle_format, str) else None,
-            ),
-            pipeline_builder=build_runtime_pipeline,
-        )
-        if disposition is not None:
-            logger.error(
-                "%s",
-                disposition.message,
-                exc_info=disposition.include_traceback,
-            )
-            sys.exit(disposition.exit_code)
-        timeline_csv_path = getattr(execution, "timeline_csv_path", None) if execution else None
-        subtitle_path = getattr(execution, "subtitle_path", None) if execution else None
-        if timeline_csv_path is not None:
-            logger.info(msg=f"Timeline saved to {timeline_csv_path}")
-        if subtitle_path is not None:
-            logger.info("Timeline subtitles saved to %s", subtitle_path)
-        logger.info(
-            "SER workflow completed in %s.",
-            format_duration(time.perf_counter() - start_time),
-        )
+        _run_inference_or_exit(args, active_settings=active_settings)
 
 
 if __name__ == "__main__":

--- a/ser/_internal/runtime/accurate_public_boundary.py
+++ b/ser/_internal/runtime/accurate_public_boundary.py
@@ -180,6 +180,23 @@ class AccurateTransientBackendError(RuntimeError):
     """Spawn-safe accurate worker error marker for transient backend failures."""
 
 
+@dataclass(frozen=True)
+class _AccurateBoundaryDependencies:
+    """Precomputed collaborators and execution plan for accurate boundary orchestration."""
+
+    runtime_config: ProfileRuntimeConfig
+    resolved_expected_backend_model_id: str | None
+    use_process_isolation: bool
+    process_payload: AccurateProcessPayload | None
+    cpu_backend_builder: Callable[[], FeatureBackend]
+    prepare_in_process_operation: Callable[
+        ...,
+        PreparedAccurateOperation[_AccurateLoadedModel, FeatureBackend],
+    ]
+    run_with_process_timeout: Callable[..., InferenceResult]
+    run_inference_once: Callable[..., InferenceResult]
+
+
 def _build_backend_for_worker_profile(
     *,
     expected_backend_id: str,
@@ -293,17 +310,16 @@ def run_accurate_inference_once(
     )
 
 
-def run_accurate_inference_from_public_boundary(
+def _build_accurate_boundary_dependencies(
+    *,
     request: InferenceRequest,
     settings: AppConfig,
-    *,
-    loaded_model: _AccurateLoadedModel | None = None,
-    backend: FeatureBackend | None = None,
-    enforce_timeout: bool = True,
-    allow_retries: bool = True,
-    expected_backend_id: str = "hf_whisper",
-    expected_profile: str = "accurate",
-    expected_backend_model_id: str | None = None,
+    loaded_model: _AccurateLoadedModel | None,
+    backend: FeatureBackend | None,
+    enforce_timeout: bool,
+    expected_backend_id: str,
+    expected_profile: str,
+    expected_backend_model_id: str | None,
     logger: logging.Logger,
     model_unavailable_error_type: type[Exception],
     runtime_dependency_error_type: type[Exception],
@@ -311,9 +327,8 @@ def run_accurate_inference_from_public_boundary(
     timeout_error_type: type[Exception],
     inference_execution_error_type: type[Exception],
     transient_backend_error_type: type[Exception],
-) -> InferenceResult:
-    """Runs accurate inference through the internal public-boundary owner."""
-
+) -> _AccurateBoundaryDependencies:
+    """Builds accurate boundary collaborators and execution plan once per invocation."""
     worker_error_factories: dict[str, Callable[[str], Exception]] = {
         "ValueError": ValueError,
         runtime_dependency_error_type.__name__: runtime_dependency_error_type,
@@ -373,6 +388,24 @@ def run_accurate_inference_from_public_boundary(
             error_factory=inference_execution_error_type,
         )
 
+    def _terminate_worker_process(process: BaseProcess) -> None:
+        _terminate_worker_process_binding(
+            process=process,
+            impl=_terminate_worker_process_impl,
+            terminate_grace_seconds=_TERMINATE_GRACE_SECONDS,
+            kill_grace_seconds=_KILL_GRACE_SECONDS,
+        )
+
+    def _raise_worker_error(error_type: str, message: str) -> None:
+        _raise_worker_error_binding(
+            error_type=error_type,
+            message=message,
+            impl=_raise_worker_error_impl,
+            known_error_factories=worker_error_factories,
+            unknown_error_factory=inference_execution_error_type,
+            worker_label="Accurate inference",
+        )
+
     def _parse_worker_completion_message(worker_message: WorkerMessage) -> InferenceResult:
         return _parse_worker_completion_message_binding(
             worker_message=worker_message,
@@ -381,6 +414,50 @@ def run_accurate_inference_from_public_boundary(
             error_factory=inference_execution_error_type,
             raise_worker_error=_raise_worker_error,
             result_type=InferenceResult,
+        )
+
+    runtime_config = _runtime_config_for_profile_impl(
+        settings=settings,
+        expected_profile=expected_profile,
+        unsupported_profile_error=model_unavailable_error_type,
+    )
+    resolved_expected_backend_model_id = expected_backend_model_id
+    if resolved_expected_backend_model_id is None and expected_backend_id == "hf_whisper":
+        resolved_expected_backend_model_id = resolve_accurate_model_id(settings)
+    use_process_isolation = (
+        enforce_timeout
+        and loaded_model is None
+        and backend is None
+        and settings.runtime_flags.profile_pipeline
+        and runtime_config.process_isolation
+    )
+    process_payload = (
+        AccurateProcessPayload(
+            request=request,
+            settings=_build_process_settings_snapshot_impl(settings),
+            expected_backend_id=expected_backend_id,
+            expected_profile=expected_profile,
+            expected_backend_model_id=resolved_expected_backend_model_id,
+        )
+        if use_process_isolation
+        else None
+    )
+
+    def _build_backend_for_profile(
+        *,
+        expected_backend_id: str,
+        expected_backend_model_id: str | None,
+        settings: AppConfig,
+        expected_profile: str | None = None,
+    ) -> FeatureBackend:
+        del expected_profile
+        return build_backend_for_profile(
+            expected_backend_id=expected_backend_id,
+            expected_backend_model_id=expected_backend_model_id,
+            settings=settings,
+            whisper_backend_factory=WhisperBackend,
+            emotion2vec_backend_factory=Emotion2VecBackend,
+            unsupported_backend_error=model_unavailable_error_type,
         )
 
     def _prepare_in_process_accurate_operation(
@@ -430,65 +507,6 @@ def run_accurate_inference_from_public_boundary(
             transient_error_factory=transient_backend_error_type,
         )
 
-    def _build_backend_for_profile(
-        *,
-        expected_backend_id: str,
-        expected_backend_model_id: str | None,
-        settings: AppConfig,
-        expected_profile: str | None = None,
-    ) -> FeatureBackend:
-        del expected_profile
-        return build_backend_for_profile(
-            expected_backend_id=expected_backend_id,
-            expected_backend_model_id=expected_backend_model_id,
-            settings=settings,
-            whisper_backend_factory=WhisperBackend,
-            emotion2vec_backend_factory=Emotion2VecBackend,
-            unsupported_backend_error=model_unavailable_error_type,
-        )
-
-    def _terminate_worker_process(process: BaseProcess) -> None:
-        _terminate_worker_process_binding(
-            process=process,
-            impl=_terminate_worker_process_impl,
-            terminate_grace_seconds=_TERMINATE_GRACE_SECONDS,
-            kill_grace_seconds=_KILL_GRACE_SECONDS,
-        )
-
-    def _raise_worker_error(error_type: str, message: str) -> None:
-        _raise_worker_error_binding(
-            error_type=error_type,
-            message=message,
-            impl=_raise_worker_error_impl,
-            known_error_factories=worker_error_factories,
-            unknown_error_factory=inference_execution_error_type,
-            worker_label="Accurate inference",
-        )
-
-    runtime_config = _runtime_config_for_profile_impl(
-        settings=settings,
-        expected_profile=expected_profile,
-        unsupported_profile_error=model_unavailable_error_type,
-    )
-    resolved_expected_backend_model_id = expected_backend_model_id
-    if resolved_expected_backend_model_id is None and expected_backend_id == "hf_whisper":
-        resolved_expected_backend_model_id = resolve_accurate_model_id(settings)
-    use_process_isolation = (
-        enforce_timeout
-        and loaded_model is None
-        and backend is None
-        and settings.runtime_flags.profile_pipeline
-        and runtime_config.process_isolation
-    )
-    process_payload: AccurateProcessPayload | None = None
-    if use_process_isolation:
-        process_payload = AccurateProcessPayload(
-            request=request,
-            settings=_build_process_settings_snapshot_impl(settings),
-            expected_backend_id=expected_backend_id,
-            expected_profile=expected_profile,
-            expected_backend_model_id=resolved_expected_backend_model_id,
-        )
     cpu_settings = _build_cpu_settings_snapshot_impl(settings)
     cpu_backend_builder: Callable[[], FeatureBackend] = partial(
         _build_backend_for_profile,
@@ -497,12 +515,61 @@ def run_accurate_inference_from_public_boundary(
         settings=cpu_settings,
         expected_profile=expected_profile,
     )
-
-    retry_state, prepared_operation, setup_started_at = _prepare_retry_state_impl(
+    return _AccurateBoundaryDependencies(
+        runtime_config=runtime_config,
+        resolved_expected_backend_model_id=resolved_expected_backend_model_id,
         use_process_isolation=use_process_isolation,
+        process_payload=process_payload,
+        cpu_backend_builder=cpu_backend_builder,
+        prepare_in_process_operation=_prepare_in_process_accurate_operation,
+        run_with_process_timeout=_run_with_process_timeout,
+        run_inference_once=_run_accurate_inference_once,
+    )
+
+
+def run_accurate_inference_from_public_boundary(
+    request: InferenceRequest,
+    settings: AppConfig,
+    *,
+    loaded_model: _AccurateLoadedModel | None = None,
+    backend: FeatureBackend | None = None,
+    enforce_timeout: bool = True,
+    allow_retries: bool = True,
+    expected_backend_id: str = "hf_whisper",
+    expected_profile: str = "accurate",
+    expected_backend_model_id: str | None = None,
+    logger: logging.Logger,
+    model_unavailable_error_type: type[Exception],
+    runtime_dependency_error_type: type[Exception],
+    model_load_error_type: type[Exception],
+    timeout_error_type: type[Exception],
+    inference_execution_error_type: type[Exception],
+    transient_backend_error_type: type[Exception],
+) -> InferenceResult:
+    """Runs accurate inference through the internal public-boundary owner."""
+    dependencies = _build_accurate_boundary_dependencies(
         request=request,
         settings=settings,
-        runtime_config=runtime_config,
+        loaded_model=loaded_model,
+        backend=backend,
+        enforce_timeout=enforce_timeout,
+        expected_backend_id=expected_backend_id,
+        expected_profile=expected_profile,
+        expected_backend_model_id=expected_backend_model_id,
+        logger=logger,
+        model_unavailable_error_type=model_unavailable_error_type,
+        runtime_dependency_error_type=runtime_dependency_error_type,
+        model_load_error_type=model_load_error_type,
+        timeout_error_type=timeout_error_type,
+        inference_execution_error_type=inference_execution_error_type,
+        transient_backend_error_type=transient_backend_error_type,
+    )
+
+    retry_state, prepared_operation, setup_started_at = _prepare_retry_state_impl(
+        use_process_isolation=dependencies.use_process_isolation,
+        request=request,
+        settings=settings,
+        runtime_config=dependencies.runtime_config,
         loaded_model=loaded_model,
         backend=backend,
         logger=logger,
@@ -510,20 +577,20 @@ def run_accurate_inference_from_public_boundary(
         setup_phase_name=PHASE_EMOTION_SETUP,
         log_phase_started=log_phase_started,
         log_phase_failed=log_phase_failed,
-        process_payload=process_payload,
+        process_payload=dependencies.process_payload,
         prepare_in_process_operation=partial(
-            _prepare_in_process_accurate_operation,
+            dependencies.prepare_in_process_operation,
             expected_backend_id=expected_backend_id,
             expected_profile=expected_profile,
-            expected_backend_model_id=resolved_expected_backend_model_id,
+            expected_backend_model_id=dependencies.resolved_expected_backend_model_id,
         ),
     )
     with _SINGLE_FLIGHT_REGISTRY.lock(
         profile=expected_profile,
-        backend_model_id=resolved_expected_backend_model_id,
+        backend_model_id=dependencies.resolved_expected_backend_model_id,
     ):
         return execute_accurate_inference_with_retry(
-            use_process_isolation=use_process_isolation,
+            use_process_isolation=dependencies.use_process_isolation,
             retry_state=retry_state,
             prepared_operation=prepared_operation,
             setup_started_at=setup_started_at,
@@ -533,12 +600,12 @@ def run_accurate_inference_from_public_boundary(
             expected_profile=expected_profile,
             allow_retries=allow_retries,
             enforce_timeout=enforce_timeout,
-            cpu_backend_builder=cpu_backend_builder,
+            cpu_backend_builder=dependencies.cpu_backend_builder,
             logger=logger,
             run_accurate_retryable_operation=lambda **kwargs: run_accurate_retryable_operation(
                 logger=logger,
-                run_with_process_timeout=_run_with_process_timeout,
-                run_accurate_inference_once=_run_accurate_inference_once,
+                run_with_process_timeout=dependencies.run_with_process_timeout,
+                run_accurate_inference_once=dependencies.run_inference_once,
                 run_with_timeout=_run_with_timeout_impl,
                 run_inference_operation=_run_inference_operation_impl,
                 timeout_error_factory=timeout_error_type,

--- a/ser/_internal/runtime/medium_public_boundary.py
+++ b/ser/_internal/runtime/medium_public_boundary.py
@@ -160,6 +160,17 @@ class MediumTransientBackendError(RuntimeError):
     """Spawn-safe medium worker error marker for transient backend failures."""
 
 
+@dataclass(frozen=True)
+class _MediumBoundaryDependencies:
+    """Precomputed collaborators and execution plan for medium boundary orchestration."""
+
+    execution_context: MediumExecutionContext[MediumProcessPayload, _MediumLoadedModel, XLSRBackend]
+    expected_backend_model_id: str
+    run_with_timeout: Callable[..., InferenceResult]
+    run_with_process_timeout: Callable[..., InferenceResult]
+    run_inference_once: Callable[..., InferenceResult]
+
+
 def _prepare_medium_process_operation(
     payload: MediumProcessPayload,
 ) -> medium_worker_operation_helpers.PreparedMediumOperation[EmotionLoadedModel, XLSRBackend]:
@@ -265,14 +276,13 @@ def run_medium_inference_once(
     )
 
 
-def run_medium_inference_from_public_boundary(
+def _build_medium_boundary_dependencies(
+    *,
     request: InferenceRequest,
     settings: AppConfig,
-    *,
-    loaded_model: _MediumLoadedModel | None = None,
-    backend: XLSRBackend | None = None,
-    enforce_timeout: bool = True,
-    allow_retries: bool = True,
+    loaded_model: _MediumLoadedModel | None,
+    backend: XLSRBackend | None,
+    enforce_timeout: bool,
     logger: logging.Logger,
     model_unavailable_error_type: type[Exception],
     runtime_dependency_error_type: type[Exception],
@@ -280,9 +290,8 @@ def run_medium_inference_from_public_boundary(
     timeout_error_type: type[Exception],
     execution_error_type: type[Exception],
     transient_error_type: type[Exception],
-) -> InferenceResult:
-    """Runs medium inference through the internal public-boundary owner."""
-
+) -> _MediumBoundaryDependencies:
+    """Builds medium boundary collaborators and execution plan once per invocation."""
     worker_error_factories: dict[str, Callable[[str], Exception]] = {
         "ValueError": ValueError,
         runtime_dependency_error_type.__name__: runtime_dependency_error_type,
@@ -302,26 +311,6 @@ def run_medium_inference_from_public_boundary(
             timeout_seconds=timeout_seconds,
             timeout_error_factory=timeout_error_type,
             timeout_label="Medium inference",
-        )
-
-    def _run_medium_inference_once(
-        *,
-        loaded_model: _MediumLoadedModel,
-        backend: XLSRBackend,
-        audio: NDArray[np.float32],
-        sample_rate: int,
-        runtime_config: MediumRuntimeConfig,
-    ) -> InferenceResult:
-        return run_medium_inference_once(
-            loaded_model=loaded_model,
-            backend=backend,
-            audio=audio,
-            sample_rate=sample_rate,
-            runtime_config=runtime_config,
-            logger=logger,
-            is_dependency_error=is_dependency_error,
-            dependency_error_factory=runtime_dependency_error_type,
-            transient_error_factory=transient_error_type,
         )
 
     def _run_with_process_timeout(
@@ -370,6 +359,24 @@ def run_medium_inference_from_public_boundary(
             impl=_is_setup_complete_message_impl,
             worker_label="Medium inference",
             error_factory=execution_error_type,
+        )
+
+    def _terminate_worker_process(process: BaseProcess) -> None:
+        _terminate_worker_process_binding(
+            process=process,
+            impl=_terminate_worker_process_impl,
+            terminate_grace_seconds=_TERMINATE_GRACE_SECONDS,
+            kill_grace_seconds=_KILL_GRACE_SECONDS,
+        )
+
+    def _raise_worker_error(error_type: str, message: str) -> None:
+        _raise_worker_error_binding(
+            error_type=error_type,
+            message=message,
+            impl=_raise_worker_error_impl,
+            known_error_factories=worker_error_factories,
+            unknown_error_factory=execution_error_type,
+            worker_label="Medium inference",
         )
 
     def _parse_worker_completion_message(worker_message: WorkerMessage) -> InferenceResult:
@@ -442,22 +449,24 @@ def run_medium_inference_from_public_boundary(
             logger=logger,
         )
 
-    def _terminate_worker_process(process: BaseProcess) -> None:
-        _terminate_worker_process_binding(
-            process=process,
-            impl=_terminate_worker_process_impl,
-            terminate_grace_seconds=_TERMINATE_GRACE_SECONDS,
-            kill_grace_seconds=_KILL_GRACE_SECONDS,
-        )
-
-    def _raise_worker_error(error_type: str, message: str) -> None:
-        _raise_worker_error_binding(
-            error_type=error_type,
-            message=message,
-            impl=_raise_worker_error_impl,
-            known_error_factories=worker_error_factories,
-            unknown_error_factory=execution_error_type,
-            worker_label="Medium inference",
+    def _run_medium_inference_once(
+        *,
+        loaded_model: _MediumLoadedModel,
+        backend: XLSRBackend,
+        audio: NDArray[np.float32],
+        sample_rate: int,
+        runtime_config: MediumRuntimeConfig,
+    ) -> InferenceResult:
+        return run_medium_inference_once(
+            loaded_model=loaded_model,
+            backend=backend,
+            audio=audio,
+            sample_rate=sample_rate,
+            runtime_config=runtime_config,
+            logger=logger,
+            is_dependency_error=is_dependency_error,
+            dependency_error_factory=runtime_dependency_error_type,
+            transient_error_factory=transient_error_type,
         )
 
     execution_context = _prepare_execution_context(
@@ -467,26 +476,65 @@ def run_medium_inference_from_public_boundary(
         backend=backend,
         enforce_timeout=enforce_timeout,
     )
-    expected_backend_model_id = execution_context.expected_backend_model_id
+    return _MediumBoundaryDependencies(
+        execution_context=execution_context,
+        expected_backend_model_id=execution_context.expected_backend_model_id,
+        run_with_timeout=_run_with_timeout,
+        run_with_process_timeout=_run_with_process_timeout,
+        run_inference_once=_run_medium_inference_once,
+    )
+
+
+def run_medium_inference_from_public_boundary(
+    request: InferenceRequest,
+    settings: AppConfig,
+    *,
+    loaded_model: _MediumLoadedModel | None = None,
+    backend: XLSRBackend | None = None,
+    enforce_timeout: bool = True,
+    allow_retries: bool = True,
+    logger: logging.Logger,
+    model_unavailable_error_type: type[Exception],
+    runtime_dependency_error_type: type[Exception],
+    model_load_error_type: type[Exception],
+    timeout_error_type: type[Exception],
+    execution_error_type: type[Exception],
+    transient_error_type: type[Exception],
+) -> InferenceResult:
+    """Runs medium inference through the internal public-boundary owner."""
+    dependencies = _build_medium_boundary_dependencies(
+        request=request,
+        settings=settings,
+        loaded_model=loaded_model,
+        backend=backend,
+        enforce_timeout=enforce_timeout,
+        logger=logger,
+        model_unavailable_error_type=model_unavailable_error_type,
+        runtime_dependency_error_type=runtime_dependency_error_type,
+        model_load_error_type=model_load_error_type,
+        timeout_error_type=timeout_error_type,
+        execution_error_type=execution_error_type,
+        transient_error_type=transient_error_type,
+    )
 
     with _SINGLE_FLIGHT_REGISTRY.lock(
         profile="medium",
-        backend_model_id=expected_backend_model_id,
+        backend_model_id=dependencies.expected_backend_model_id,
     ):
         return execute_medium_inference_with_retry(
-            execution_context=execution_context,
+            execution_context=dependencies.execution_context,
             settings=settings,
             injected_backend=backend,
             enforce_timeout=enforce_timeout,
             allow_retries=allow_retries,
-            expected_backend_model_id=expected_backend_model_id,
+            expected_backend_model_id=dependencies.expected_backend_model_id,
             logger=logger,
-            run_with_process_timeout=_run_with_process_timeout,
+            run_with_process_timeout=dependencies.run_with_process_timeout,
             run_process_operation=lambda prepared: run_process_operation(
                 prepared,
-                run_medium_inference_once=_run_medium_inference_once,
+                run_medium_inference_once=dependencies.run_inference_once,
             ),
-            run_with_timeout=_run_with_timeout,
+            run_with_timeout=dependencies.run_with_timeout,
             prepare_medium_backend_runtime=lambda active_backend: prepare_medium_backend_runtime(
                 backend=active_backend,
                 is_dependency_error=is_dependency_error,
@@ -495,7 +543,7 @@ def run_medium_inference_from_public_boundary(
             ),
             cpu_backend_builder=lambda: _build_medium_backend_for_settings_impl(
                 settings=_build_cpu_settings_snapshot_impl(settings),
-                expected_backend_model_id=expected_backend_model_id,
+                expected_backend_model_id=dependencies.expected_backend_model_id,
                 runtime_device="cpu",
                 runtime_dtype="float32",
                 backend_factory=XLSRBackend,

--- a/ser/transcript/backends/stable_whisper.py
+++ b/ser/transcript/backends/stable_whisper.py
@@ -80,6 +80,8 @@ from ser.utils.transcription_compat import (
 if TYPE_CHECKING:
     from ser.config import AppConfig
 
+type SummarizeRuntimeErrorWithLimit = Callable[[Exception, int], str]
+
 _INVALID_ESCAPE_POLICY_ID = "stable_whisper.invalid_escape_sequence"
 _INVALID_ESCAPE_MESSAGE_REGEX = r"^invalid escape sequence '\\,'$"
 _INVALID_ESCAPE_MODULE_REGEX = r"^stable_whisper\.result$"
@@ -144,6 +146,453 @@ _STABLE_WHISPER_TRANSCRIBE_POLICY = DependencyLogPolicy(
 )
 
 
+def _default_stable_whisper_noise_issues() -> list[CompatibilityIssue]:
+    """Returns baseline non-blocking noise issues for stable-whisper environments."""
+    return [
+        CompatibilityIssue(
+            code="stable_whisper_invalid_escape_sequence",
+            message=(
+                "stable-whisper may emit SyntaxWarning invalid escape sequence "
+                "during module import; scoped warning policy is required."
+            ),
+            impact="informational",
+        ),
+        CompatibilityIssue(
+            code="stable_whisper_fp16_cpu_fallback_warning",
+            message=(
+                "stable-whisper may emit a CPU fp16 fallback UserWarning "
+                "during transcription; adapter resolves device-aware precision "
+                "and uses a "
+                "scoped warning policy fallback."
+            ),
+            impact="informational",
+        ),
+        CompatibilityIssue(
+            code="stable_whisper_demucs_deprecated_warning",
+            message=(
+                "stable-whisper may emit a demucs deprecation UserWarning "
+                "when legacy demucs argument is used; adapter prefers "
+                "denoiser='demucs' and keeps a scoped warning policy fallback."
+            ),
+            impact="informational",
+        ),
+    ]
+
+
+def _torio_ffmpeg_probe_noise_issue() -> CompatibilityIssue:
+    """Returns the informational torio FFmpeg probe noise issue."""
+    return CompatibilityIssue(
+        code="torio_ffmpeg_probe_debug_traceback",
+        message=(
+            "torio may emit DEBUG traceback probe logs while checking "
+            "FFmpeg extension availability; adapter applies scoped "
+            "suppression to keep dependency noise bounded."
+        ),
+        impact="informational",
+    )
+
+
+def _check_stable_whisper_compatibility(
+    *, backend_id: TranscriptionBackendId
+) -> CompatibilityReport:
+    """Builds one stable-whisper compatibility report using scoped dependency policies."""
+    functional_issues: list[CompatibilityIssue] = []
+    operational_issues: list[CompatibilityIssue] = []
+    noise_issues = _default_stable_whisper_noise_issues()
+    with scoped_dependency_log_policy(
+        policy=_STABLE_WHISPER_IMPORT_POLICY,
+        context=DependencyPolicyContext(
+            backend_id=backend_id,
+            phase_name=PHASE_TRANSCRIPTION_MODEL_LOAD,
+            op_tag="stable_whisper.compatibility",
+        ),
+        keep_demoted=False,
+    ):
+        torio_issue = stable_whisper_torio_probe.detect_default_torio_ffmpeg_operational_issue()
+    if torio_issue is not None:
+        operational_issues.append(torio_issue)
+        noise_issues.append(_torio_ffmpeg_probe_noise_issue())
+    if not stable_whisper_torio_probe.is_module_available("stable_whisper"):
+        functional_issues.append(
+            CompatibilityIssue(
+                code="missing_dependency_stable_whisper",
+                message=(
+                    "Missing stable-whisper dependencies. Ensure project dependencies "
+                    "are installed."
+                ),
+                impact="blocking",
+            )
+        )
+    return CompatibilityReport(
+        backend_id="stable_whisper",
+        functional_issues=tuple(functional_issues),
+        operational_issues=tuple(operational_issues),
+        noise_issues=tuple(noise_issues),
+        policy_ids=(
+            _INVALID_ESCAPE_POLICY_ID,
+            _FP16_CPU_WARNING_POLICY_ID,
+            _DEMUCS_DEPRECATED_POLICY_ID,
+            _TORIO_FFMPEG_PROBE_POLICY_ID,
+        ),
+    )
+
+
+def _prepare_stable_whisper_assets(
+    *,
+    runtime_request: BackendRuntimeRequest,
+    settings: AppConfig,
+    resolve_download_target: Callable[..., Path | None],
+) -> None:
+    """Downloads stable-whisper checkpoint assets when registry metadata resolves cleanly."""
+    target_path = resolve_download_target(
+        model_name=runtime_request.model_name,
+        settings=settings,
+    )
+    if target_path is None or target_path.is_file():
+        return
+    try:
+        whisper_module = importlib.import_module("whisper")
+    except ModuleNotFoundError:
+        return
+    model_registry = getattr(whisper_module, "_MODELS", None)
+    download_fn = getattr(whisper_module, "_download", None)
+    if not isinstance(model_registry, dict) or not callable(download_fn):
+        return
+    model_url = model_registry.get(runtime_request.model_name)
+    if not isinstance(model_url, str):
+        return
+    os.makedirs(settings.models.whisper_download_root, exist_ok=True)
+    download_fn(
+        model_url,
+        str(settings.models.whisper_download_root),
+        False,
+    )
+
+
+def _load_stable_whisper_mps_model(
+    *,
+    runtime_request: BackendRuntimeRequest,
+    settings: AppConfig,
+    load_model: Callable[..., object],
+    download_root: Path,
+    resolve_mps_admission_decision: Callable[..., MpsAdmissionDecision | None],
+    log_mps_admission_control_fallback: Callable[..., None],
+    mps_compatibility_fallback_reason: Callable[[Exception], str | None],
+    release_torch_runtime_memory_for_retry: Callable[[], None],
+    move_model_to_cpu_runtime: Callable[[object], bool],
+    summarize_runtime_error: SummarizeRuntimeErrorWithLimit,
+) -> object:
+    """Loads a stable-whisper model while handling MPS admission and fallback policy."""
+    load_admission = resolve_mps_admission_decision(
+        settings=settings,
+        runtime_request=runtime_request,
+        phase="model_load",
+    )
+    if load_admission is not None and not load_admission.allow_mps:
+        log_mps_admission_control_fallback(
+            phase="model_load",
+            decision=load_admission,
+        )
+        model = load_model(
+            name=runtime_request.model_name,
+            device="cpu",
+            dq=False,
+            download_root=str(download_root),
+            in_memory=True,
+        )
+        set_stable_whisper_mps_compatibility_enabled(
+            model,
+            enabled=False,
+        )
+        set_stable_whisper_runtime_device(model, device_type="cpu")
+        return model
+
+    model = load_model(
+        name=runtime_request.model_name,
+        device="cpu",
+        dq=False,
+        download_root=str(download_root),
+        in_memory=True,
+    )
+    set_stable_whisper_runtime_device(model, device_type="cpu")
+    try:
+        model = enable_stable_whisper_mps_compatibility(model)
+    except Exception as err:
+        fallback_reason = mps_compatibility_fallback_reason(err)
+        if fallback_reason is None:
+            raise
+        if fallback_reason == "retryable_runtime_error":
+            release_torch_runtime_memory_for_retry()
+        move_model_to_cpu_runtime(model)
+        error_summary = summarize_runtime_error(err, 180)
+        logging.getLogger(__name__).warning(
+            "MPS compatibility mode unavailable; using cpu runtime " "(reason=%s, error=%s).",
+            fallback_reason,
+            error_summary,
+        )
+        set_stable_whisper_mps_compatibility_enabled(
+            model,
+            enabled=False,
+        )
+        set_stable_whisper_runtime_device(model, device_type="cpu")
+    else:
+        set_stable_whisper_runtime_device(model, device_type="mps")
+        if has_known_stable_whisper_sparse_mps_incompatibility():
+            logging.getLogger(__name__).info(
+                "MPS compatibility mode enabled " "(sparse_mps_operator_gap_detected)."
+            )
+        else:
+            logging.getLogger(__name__).info("MPS compatibility mode enabled.")
+    return model
+
+
+def _load_stable_whisper_device_model(
+    *,
+    runtime_request: BackendRuntimeRequest,
+    load_model: Callable[..., object],
+    download_root: Path,
+    is_retryable_precision_failure: Callable[[Exception], bool],
+    release_torch_runtime_memory_for_retry: Callable[[], None],
+    summarize_runtime_error: SummarizeRuntimeErrorWithLimit,
+) -> object:
+    """Loads a stable-whisper model on the requested device with CPU retry fallback."""
+    try:
+        model = load_model(
+            name=runtime_request.model_name,
+            device=runtime_request.device_spec,
+            dq=False,
+            download_root=str(download_root),
+            in_memory=True,
+        )
+        set_stable_whisper_runtime_device(
+            model,
+            device_type=runtime_request.device_type,
+        )
+        return model
+    except Exception as err:
+        should_retry_on_cpu = runtime_request.device_type in {
+            "mps",
+            "cuda",
+        } and is_retryable_precision_failure(err)
+        if not should_retry_on_cpu:
+            raise
+        release_torch_runtime_memory_for_retry()
+        error_summary = summarize_runtime_error(err, 180)
+        logging.getLogger(__name__).warning(
+            "Model load failed on %s due to retryable runtime " "error; retrying on cpu (%s).",
+            runtime_request.device_spec,
+            error_summary,
+        )
+        model = load_model(
+            name=runtime_request.model_name,
+            device="cpu",
+            dq=False,
+            download_root=str(download_root),
+            in_memory=True,
+        )
+        set_stable_whisper_mps_compatibility_enabled(
+            model,
+            enabled=False,
+        )
+        set_stable_whisper_runtime_device(model, device_type="cpu")
+        return model
+
+
+def _load_stable_whisper_runtime_model(
+    *,
+    backend_id: TranscriptionBackendId,
+    runtime_request: BackendRuntimeRequest,
+    settings: AppConfig,
+    resolve_mps_admission_decision: Callable[..., MpsAdmissionDecision | None],
+    log_mps_admission_control_fallback: Callable[..., None],
+    is_retryable_precision_failure: Callable[[Exception], bool],
+    mps_compatibility_fallback_reason: Callable[[Exception], str | None],
+    release_torch_runtime_memory_for_retry: Callable[[], None],
+    move_model_to_cpu_runtime: Callable[[object], bool],
+    summarize_runtime_error: SummarizeRuntimeErrorWithLimit,
+) -> object:
+    """Loads one stable-whisper model for the requested runtime path."""
+    with scoped_dependency_log_policy(
+        policy=_STABLE_WHISPER_IMPORT_POLICY,
+        context=DependencyPolicyContext(
+            backend_id=backend_id,
+            phase_name=PHASE_TRANSCRIPTION_MODEL_LOAD,
+            op_tag="stable_whisper.import",
+        ),
+        keep_demoted=False,
+    ):
+        download_root: Path = settings.models.whisper_download_root
+        torch_cache_root: Path = settings.models.torch_cache_root
+        os.makedirs(download_root, exist_ok=True)
+        os.makedirs(torch_cache_root, exist_ok=True)
+        runtime_environment = build_runtime_environment_plan(settings)
+        with temporary_process_env(
+            runtime_environment.torch_runtime.merged(runtime_environment.stable_whisper)
+        ):
+            try:
+                stable_whisper = importlib.import_module("stable_whisper")
+            except ModuleNotFoundError as err:
+                raise RuntimeError(
+                    "Missing stable-whisper dependencies. Ensure project dependencies "
+                    "are installed."
+                ) from err
+
+            load_model = getattr(stable_whisper, "load_model", None)
+            if not callable(load_model):
+                raise RuntimeError(
+                    "stable-whisper package does not expose a callable load_model()."
+                )
+            if runtime_request.device_type == "mps":
+                model = _load_stable_whisper_mps_model(
+                    runtime_request=runtime_request,
+                    settings=settings,
+                    load_model=load_model,
+                    download_root=download_root,
+                    resolve_mps_admission_decision=resolve_mps_admission_decision,
+                    log_mps_admission_control_fallback=log_mps_admission_control_fallback,
+                    mps_compatibility_fallback_reason=mps_compatibility_fallback_reason,
+                    release_torch_runtime_memory_for_retry=release_torch_runtime_memory_for_retry,
+                    move_model_to_cpu_runtime=move_model_to_cpu_runtime,
+                    summarize_runtime_error=summarize_runtime_error,
+                )
+            else:
+                model = _load_stable_whisper_device_model(
+                    runtime_request=runtime_request,
+                    load_model=load_model,
+                    download_root=download_root,
+                    is_retryable_precision_failure=is_retryable_precision_failure,
+                    release_torch_runtime_memory_for_retry=release_torch_runtime_memory_for_retry,
+                    summarize_runtime_error=summarize_runtime_error,
+                )
+    resolved_device_type = get_stable_whisper_runtime_device(
+        model,
+        default_device_type=runtime_request.device_type,
+    )
+    logging.getLogger(__name__).info(
+        "Runtime device ready (%s).",
+        resolved_device_type,
+    )
+    return model
+
+
+def _transcribe_with_stable_whisper_model(
+    *,
+    backend_id: TranscriptionBackendId,
+    model: object,
+    runtime_request: BackendRuntimeRequest,
+    file_path: str,
+    language: str,
+    settings: AppConfig,
+    build_transcribe_kwargs: Callable[..., dict[str, object]],
+    resolve_mps_admission_decision: Callable[..., MpsAdmissionDecision | None],
+    should_enforce_transcribe_admission: Callable[[MpsAdmissionDecision], bool],
+    log_mps_admission_control_fallback: Callable[..., None],
+    move_model_to_cpu_runtime: Callable[[object], bool],
+    effective_precision_candidates_fn: Callable[..., tuple[str, ...]],
+    classify_transcription_failure: Callable[..., TranscriptionFailureClassification],
+    release_runtime_memory_for_retry: Callable[[], None],
+    summarize_runtime_error: SummarizeRuntimeErrorWithLimit,
+    normalize_result: Callable[[object], object],
+    format_transcript: Callable[[object], list[TranscriptWord]],
+) -> list[TranscriptWord]:
+    """Runs one stable-whisper transcription call and formats word timings."""
+    transcribe = getattr(model, "transcribe", None)
+    if not callable(transcribe):
+        raise RuntimeError("Loaded stable-whisper model does not expose a callable transcribe().")
+    typed_transcribe = cast(Callable[..., object], transcribe)
+    logger = logging.getLogger(__name__)
+    runtime_device_type = get_stable_whisper_runtime_device(
+        model,
+        default_device_type=runtime_request.device_type,
+    )
+    runtime_device_type = resolve_stable_whisper_transcribe_runtime_device(
+        model=model,
+        runtime_request=runtime_request,
+        settings=settings,
+        runtime_device_type=runtime_device_type,
+        resolve_mps_admission_decision=resolve_mps_admission_decision,
+        should_enforce_transcribe_admission=should_enforce_transcribe_admission,
+        log_mps_admission_control_fallback=log_mps_admission_control_fallback,
+        move_model_to_cpu_runtime=move_model_to_cpu_runtime,
+        set_mps_compatibility_enabled=set_stable_whisper_mps_compatibility_enabled,
+        set_runtime_device=set_stable_whisper_runtime_device,
+        logger=logger,
+    )
+    precision_candidates = effective_precision_candidates_fn(
+        runtime_request=runtime_request,
+        runtime_device_type=runtime_device_type,
+    )
+
+    def _build_transcribe_kwargs_for_runtime(
+        request: BackendRuntimeRequest,
+        precision: str,
+    ) -> dict[str, object]:
+        return build_transcribe_kwargs(
+            transcribe_callable=typed_transcribe,
+            runtime_request=request,
+            file_path=file_path,
+            language=language,
+            precision=precision,
+        )
+
+    def _invoke_runtime_transcribe(
+        transcribe_kwargs: dict[str, object],
+        runtime_device: str,
+    ) -> object:
+        with scoped_dependency_log_policy(
+            policy=_STABLE_WHISPER_TRANSCRIBE_POLICY,
+            context=DependencyPolicyContext(
+                backend_id=backend_id,
+                phase_name=PHASE_TRANSCRIPTION,
+                op_tag="stable_whisper.transcribe",
+            ),
+        ):
+            mps_compat_context = (
+                stable_whisper_mps_timing_compatibility_context()
+                if (runtime_device == "mps" and is_stable_whisper_mps_compatibility_enabled(model))
+                else nullcontext()
+            )
+            with mps_compat_context:
+                return typed_transcribe(**transcribe_kwargs)
+
+    return run_stable_whisper_transcribe_with_retry(
+        model=model,
+        runtime_request=runtime_request,
+        settings=settings,
+        runtime_device_type=runtime_device_type,
+        precision_candidates=precision_candidates,
+        typed_transcribe=typed_transcribe,
+        build_transcribe_kwargs=_build_transcribe_kwargs_for_runtime,
+        invoke_runtime_transcribe=_invoke_runtime_transcribe,
+        classify_failure=(
+            lambda err, precision, current_settings: classify_transcription_failure(
+                err=err,
+                runtime_device_type=runtime_device_type,
+                precision=precision,
+                settings=current_settings,
+            )
+        ),
+        release_runtime_memory_for_retry=release_runtime_memory_for_retry,
+        summarize_runtime_error=lambda err: summarize_runtime_error(err, 180),
+        move_model_to_cpu_runtime=move_model_to_cpu_runtime,
+        set_mps_compatibility_disabled=(
+            lambda runtime_model: set_stable_whisper_mps_compatibility_enabled(
+                runtime_model,
+                enabled=False,
+            )
+        ),
+        set_runtime_device_cpu=(
+            lambda runtime_model: set_stable_whisper_runtime_device(
+                runtime_model,
+                device_type="cpu",
+            )
+        ),
+        normalize_result=normalize_result,
+        format_transcript=format_transcript,
+        logger=logger,
+    )
+
+
 class StableWhisperAdapter(TranscriptionBackendAdapter):
     """Adapter for stable-whisper backend behavior and compatibility checks."""
 
@@ -161,82 +610,8 @@ class StableWhisperAdapter(TranscriptionBackendAdapter):
         """Checks stable-whisper dependency/runtime compatibility."""
         del runtime_request
         del settings
-        functional_issues: list[CompatibilityIssue] = []
-        operational_issues: list[CompatibilityIssue] = []
-        noise_issues: list[CompatibilityIssue] = [
-            CompatibilityIssue(
-                code="stable_whisper_invalid_escape_sequence",
-                message=(
-                    "stable-whisper may emit SyntaxWarning invalid escape sequence "
-                    "during module import; scoped warning policy is required."
-                ),
-                impact="informational",
-            ),
-            CompatibilityIssue(
-                code="stable_whisper_fp16_cpu_fallback_warning",
-                message=(
-                    "stable-whisper may emit a CPU fp16 fallback UserWarning "
-                    "during transcription; adapter resolves device-aware precision "
-                    "and uses a "
-                    "scoped warning policy fallback."
-                ),
-                impact="informational",
-            ),
-            CompatibilityIssue(
-                code="stable_whisper_demucs_deprecated_warning",
-                message=(
-                    "stable-whisper may emit a demucs deprecation UserWarning "
-                    "when legacy demucs argument is used; adapter prefers "
-                    "denoiser='demucs' and keeps a scoped warning policy fallback."
-                ),
-                impact="informational",
-            ),
-        ]
-        with scoped_dependency_log_policy(
-            policy=_STABLE_WHISPER_IMPORT_POLICY,
-            context=DependencyPolicyContext(
-                backend_id=self.backend_id,
-                phase_name=PHASE_TRANSCRIPTION_MODEL_LOAD,
-                op_tag="stable_whisper.compatibility",
-            ),
-            keep_demoted=False,
-        ):
-            torio_issue = stable_whisper_torio_probe.detect_default_torio_ffmpeg_operational_issue()
-        if torio_issue is not None:
-            operational_issues.append(torio_issue)
-            noise_issues.append(
-                CompatibilityIssue(
-                    code="torio_ffmpeg_probe_debug_traceback",
-                    message=(
-                        "torio may emit DEBUG traceback probe logs while checking "
-                        "FFmpeg extension availability; adapter applies scoped "
-                        "suppression to keep dependency noise bounded."
-                    ),
-                    impact="informational",
-                )
-            )
-        if not stable_whisper_torio_probe.is_module_available("stable_whisper"):
-            functional_issues.append(
-                CompatibilityIssue(
-                    code="missing_dependency_stable_whisper",
-                    message=(
-                        "Missing stable-whisper dependencies. Ensure project dependencies "
-                        "are installed."
-                    ),
-                    impact="blocking",
-                )
-            )
-        return CompatibilityReport(
-            backend_id="stable_whisper",
-            functional_issues=tuple(functional_issues),
-            operational_issues=tuple(operational_issues),
-            noise_issues=tuple(noise_issues),
-            policy_ids=(
-                _INVALID_ESCAPE_POLICY_ID,
-                _FP16_CPU_WARNING_POLICY_ID,
-                _DEMUCS_DEPRECATED_POLICY_ID,
-                _TORIO_FFMPEG_PROBE_POLICY_ID,
-            ),
+        return _check_stable_whisper_compatibility(
+            backend_id=self.backend_id,
         )
 
     def setup_required(
@@ -261,28 +636,10 @@ class StableWhisperAdapter(TranscriptionBackendAdapter):
         settings: AppConfig,
     ) -> None:
         """Downloads stable-whisper checkpoint assets when required."""
-        target_path = self._stable_whisper_download_target(
-            model_name=runtime_request.model_name,
+        _prepare_stable_whisper_assets(
+            runtime_request=runtime_request,
             settings=settings,
-        )
-        if target_path is None or target_path.is_file():
-            return
-        try:
-            whisper_module = importlib.import_module("whisper")
-        except ModuleNotFoundError:
-            return
-        model_registry = getattr(whisper_module, "_MODELS", None)
-        download_fn = getattr(whisper_module, "_download", None)
-        if not isinstance(model_registry, dict) or not callable(download_fn):
-            return
-        model_url = model_registry.get(runtime_request.model_name)
-        if not isinstance(model_url, str):
-            return
-        os.makedirs(settings.models.whisper_download_root, exist_ok=True)
-        download_fn(
-            model_url,
-            str(settings.models.whisper_download_root),
-            False,
+            resolve_download_target=self._stable_whisper_download_target,
         )
 
     def load_model(
@@ -292,147 +649,18 @@ class StableWhisperAdapter(TranscriptionBackendAdapter):
         settings: AppConfig,
     ) -> object:
         """Loads one stable-whisper model for resolved runtime device inference."""
-        with scoped_dependency_log_policy(
-            policy=_STABLE_WHISPER_IMPORT_POLICY,
-            context=DependencyPolicyContext(
-                backend_id=self.backend_id,
-                phase_name=PHASE_TRANSCRIPTION_MODEL_LOAD,
-                op_tag="stable_whisper.import",
-            ),
-            keep_demoted=False,
-        ):
-            download_root: Path = settings.models.whisper_download_root
-            torch_cache_root: Path = settings.models.torch_cache_root
-            os.makedirs(download_root, exist_ok=True)
-            os.makedirs(torch_cache_root, exist_ok=True)
-            runtime_environment = build_runtime_environment_plan(settings)
-            with temporary_process_env(
-                runtime_environment.torch_runtime.merged(runtime_environment.stable_whisper)
-            ):
-                try:
-                    stable_whisper = importlib.import_module("stable_whisper")
-                except ModuleNotFoundError as err:
-                    raise RuntimeError(
-                        "Missing stable-whisper dependencies. Ensure project dependencies "
-                        "are installed."
-                    ) from err
-
-                load_model = getattr(stable_whisper, "load_model", None)
-                if not callable(load_model):
-                    raise RuntimeError(
-                        "stable-whisper package does not expose a callable load_model()."
-                    )
-                if runtime_request.device_type == "mps":
-                    load_admission = self._resolve_mps_admission_decision(
-                        settings=settings,
-                        runtime_request=runtime_request,
-                        phase="model_load",
-                    )
-                    if load_admission is not None and not load_admission.allow_mps:
-                        self._log_mps_admission_control_fallback(
-                            phase="model_load",
-                            decision=load_admission,
-                        )
-                        model = load_model(
-                            name=runtime_request.model_name,
-                            device="cpu",
-                            dq=False,
-                            download_root=str(download_root),
-                            in_memory=True,
-                        )
-                        set_stable_whisper_mps_compatibility_enabled(
-                            model,
-                            enabled=False,
-                        )
-                        set_stable_whisper_runtime_device(model, device_type="cpu")
-                    else:
-                        model = load_model(
-                            name=runtime_request.model_name,
-                            device="cpu",
-                            dq=False,
-                            download_root=str(download_root),
-                            in_memory=True,
-                        )
-                        set_stable_whisper_runtime_device(model, device_type="cpu")
-                        try:
-                            model = enable_stable_whisper_mps_compatibility(model)
-                        except Exception as err:
-                            fallback_reason = self._mps_compatibility_fallback_reason(err)
-                            if fallback_reason is None:
-                                raise
-                            if fallback_reason == "retryable_runtime_error":
-                                self._release_torch_runtime_memory_for_retry()
-                            self._move_model_to_cpu_runtime(model)
-                            error_summary = self._summarize_runtime_error(err)
-                            logging.getLogger(__name__).warning(
-                                "MPS compatibility mode unavailable; using cpu runtime "
-                                "(reason=%s, error=%s).",
-                                fallback_reason,
-                                error_summary,
-                            )
-                            set_stable_whisper_mps_compatibility_enabled(
-                                model,
-                                enabled=False,
-                            )
-                            set_stable_whisper_runtime_device(model, device_type="cpu")
-                        else:
-                            set_stable_whisper_runtime_device(model, device_type="mps")
-                            if has_known_stable_whisper_sparse_mps_incompatibility():
-                                logging.getLogger(__name__).info(
-                                    "MPS compatibility mode enabled "
-                                    "(sparse_mps_operator_gap_detected)."
-                                )
-                            else:
-                                logging.getLogger(__name__).info("MPS compatibility mode enabled.")
-                else:
-                    try:
-                        model = load_model(
-                            name=runtime_request.model_name,
-                            device=runtime_request.device_spec,
-                            dq=False,
-                            download_root=str(download_root),
-                            in_memory=True,
-                        )
-                        set_stable_whisper_runtime_device(
-                            model,
-                            device_type=runtime_request.device_type,
-                        )
-                    except Exception as err:
-                        should_retry_on_cpu = runtime_request.device_type in {
-                            "mps",
-                            "cuda",
-                        } and self._is_retryable_precision_failure(err)
-                        if not should_retry_on_cpu:
-                            raise
-                        self._release_torch_runtime_memory_for_retry()
-                        error_summary = self._summarize_runtime_error(err)
-                        logging.getLogger(__name__).warning(
-                            "Model load failed on %s due to retryable runtime "
-                            "error; retrying on cpu (%s).",
-                            runtime_request.device_spec,
-                            error_summary,
-                        )
-                        model = load_model(
-                            name=runtime_request.model_name,
-                            device="cpu",
-                            dq=False,
-                            download_root=str(download_root),
-                            in_memory=True,
-                        )
-                        set_stable_whisper_mps_compatibility_enabled(
-                            model,
-                            enabled=False,
-                        )
-                        set_stable_whisper_runtime_device(model, device_type="cpu")
-            resolved_device_type = get_stable_whisper_runtime_device(
-                model,
-                default_device_type=runtime_request.device_type,
-            )
-            logging.getLogger(__name__).info(
-                "Runtime device ready (%s).",
-                resolved_device_type,
-            )
-            return model
+        return _load_stable_whisper_runtime_model(
+            backend_id=self.backend_id,
+            runtime_request=runtime_request,
+            settings=settings,
+            resolve_mps_admission_decision=self._resolve_mps_admission_decision,
+            log_mps_admission_control_fallback=self._log_mps_admission_control_fallback,
+            is_retryable_precision_failure=self._is_retryable_precision_failure,
+            mps_compatibility_fallback_reason=self._mps_compatibility_fallback_reason,
+            release_torch_runtime_memory_for_retry=self._release_torch_runtime_memory_for_retry,
+            move_model_to_cpu_runtime=self._move_model_to_cpu_runtime,
+            summarize_runtime_error=self._summarize_runtime_error,
+        )
 
     def transcribe(
         self,
@@ -444,108 +672,24 @@ class StableWhisperAdapter(TranscriptionBackendAdapter):
         settings: AppConfig,
     ) -> list[TranscriptWord]:
         """Runs one stable-whisper transcription call and formats word timings."""
-        transcribe = getattr(model, "transcribe", None)
-        if not callable(transcribe):
-            raise RuntimeError(
-                "Loaded stable-whisper model does not expose a callable transcribe()."
-            )
-        typed_transcribe = cast(Callable[..., object], transcribe)
-        logger = logging.getLogger(__name__)
-        runtime_device_type = get_stable_whisper_runtime_device(
-            model,
-            default_device_type=runtime_request.device_type,
-        )
-        runtime_device_type = resolve_stable_whisper_transcribe_runtime_device(
+        return _transcribe_with_stable_whisper_model(
+            backend_id=self.backend_id,
             model=model,
             runtime_request=runtime_request,
+            file_path=file_path,
+            language=language,
             settings=settings,
-            runtime_device_type=runtime_device_type,
+            build_transcribe_kwargs=self._build_transcribe_kwargs,
             resolve_mps_admission_decision=self._resolve_mps_admission_decision,
             should_enforce_transcribe_admission=self._should_enforce_transcribe_admission,
             log_mps_admission_control_fallback=self._log_mps_admission_control_fallback,
             move_model_to_cpu_runtime=self._move_model_to_cpu_runtime,
-            set_mps_compatibility_enabled=set_stable_whisper_mps_compatibility_enabled,
-            set_runtime_device=set_stable_whisper_runtime_device,
-            logger=logger,
-        )
-
-        precision_candidates = self._effective_precision_candidates(
-            runtime_request=runtime_request,
-            runtime_device_type=runtime_device_type,
-        )
-
-        def _build_transcribe_kwargs_for_runtime(
-            request: BackendRuntimeRequest,
-            precision: str,
-        ) -> dict[str, object]:
-            return self._build_transcribe_kwargs(
-                transcribe_callable=typed_transcribe,
-                runtime_request=request,
-                file_path=file_path,
-                language=language,
-                precision=precision,
-            )
-
-        def _invoke_runtime_transcribe(
-            transcribe_kwargs: dict[str, object],
-            runtime_device: str,
-        ) -> object:
-            with scoped_dependency_log_policy(
-                policy=_STABLE_WHISPER_TRANSCRIBE_POLICY,
-                context=DependencyPolicyContext(
-                    backend_id=self.backend_id,
-                    phase_name=PHASE_TRANSCRIPTION,
-                    op_tag="stable_whisper.transcribe",
-                ),
-            ):
-                mps_compat_context = (
-                    stable_whisper_mps_timing_compatibility_context()
-                    if (
-                        runtime_device == "mps"
-                        and is_stable_whisper_mps_compatibility_enabled(model)
-                    )
-                    else nullcontext()
-                )
-                with mps_compat_context:
-                    return typed_transcribe(**transcribe_kwargs)
-
-        return run_stable_whisper_transcribe_with_retry(
-            model=model,
-            runtime_request=runtime_request,
-            settings=settings,
-            runtime_device_type=runtime_device_type,
-            precision_candidates=precision_candidates,
-            typed_transcribe=typed_transcribe,
-            build_transcribe_kwargs=_build_transcribe_kwargs_for_runtime,
-            invoke_runtime_transcribe=_invoke_runtime_transcribe,
-            classify_failure=(
-                lambda err, precision, current_settings: (
-                    self._classify_transcription_failure(
-                        err=err,
-                        runtime_device_type=runtime_device_type,
-                        precision=precision,
-                        settings=current_settings,
-                    )
-                )
-            ),
+            effective_precision_candidates_fn=self._effective_precision_candidates,
+            classify_transcription_failure=self._classify_transcription_failure,
             release_runtime_memory_for_retry=self._release_torch_runtime_memory_for_retry,
             summarize_runtime_error=self._summarize_runtime_error,
-            move_model_to_cpu_runtime=self._move_model_to_cpu_runtime,
-            set_mps_compatibility_disabled=(
-                lambda runtime_model: set_stable_whisper_mps_compatibility_enabled(
-                    runtime_model,
-                    enabled=False,
-                )
-            ),
-            set_runtime_device_cpu=(
-                lambda runtime_model: set_stable_whisper_runtime_device(
-                    runtime_model,
-                    device_type="cpu",
-                )
-            ),
             normalize_result=self._normalize_result,
             format_transcript=self._format_transcript,
-            logger=logger,
         )
 
     @classmethod

--- a/tests/test_segment_canonicalization.py
+++ b/tests/test_segment_canonicalization.py
@@ -4,9 +4,22 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from hypothesis import given
+from hypothesis import settings as hypothesis_settings
+from hypothesis import strategies as st
+
 from ser.domain import EmotionSegment
 from ser.runtime.schema import SegmentPrediction
 from ser.utils.segment_canonicalization import CanonicalSegment, canonicalize_segments
+
+_PROPERTY_TEST_SETTINGS = hypothesis_settings(
+    max_examples=100,
+    deadline=None,
+    database=None,
+)
+_SEGMENT_LABELS = st.sampled_from(("angry", "calm", "happy", "sad"))
+_TIME_STEP = st.integers(min_value=-10, max_value=20).map(lambda value: value / 2.0)
+_POSITIVE_DURATION = st.integers(min_value=1, max_value=12).map(lambda value: value / 2.0)
 
 
 def test_canonicalize_segments_merges_same_label_overlap_and_adjacency() -> None:
@@ -71,6 +84,16 @@ class _ConfidenceCarrier:
     confidence: object
 
 
+@dataclass(frozen=True)
+class _GeneratedSegment:
+    """Minimal valid segment-like object for property-based canonicalization tests."""
+
+    emotion: str
+    start_seconds: float
+    end_seconds: float
+    confidence: float | None
+
+
 def test_canonicalize_segments_ignores_invalid_or_nonfinite_inputs() -> None:
     """Invalid or non-finite segments should be discarded during normalization."""
     canonical = canonicalize_segments(
@@ -83,3 +106,61 @@ def test_canonicalize_segments_ignores_invalid_or_nonfinite_inputs() -> None:
     )
 
     assert canonical == [CanonicalSegment("happy", 0.0, 1.0)]
+
+
+@st.composite
+def _generated_segment_strategy(draw: st.DrawFn) -> _GeneratedSegment:
+    """Build a valid segment with deterministic half-second timing granularity."""
+
+    start_seconds = draw(_TIME_STEP)
+    duration_seconds = draw(_POSITIVE_DURATION)
+    confidence = draw(
+        st.one_of(
+            st.none(),
+            st.floats(
+                min_value=0.0,
+                max_value=1.0,
+                allow_nan=False,
+                allow_infinity=False,
+            ),
+        )
+    )
+    return _GeneratedSegment(
+        emotion=draw(_SEGMENT_LABELS),
+        start_seconds=start_seconds,
+        end_seconds=start_seconds + duration_seconds,
+        confidence=confidence,
+    )
+
+
+@_PROPERTY_TEST_SETTINGS
+@given(st.lists(_generated_segment_strategy(), max_size=12))
+def test_canonicalize_segments_is_idempotent(
+    segments: list[_GeneratedSegment],
+) -> None:
+    """Canonicalization should stabilize after one pass."""
+
+    canonical = canonicalize_segments(segments)
+
+    assert canonicalize_segments(canonical) == canonical
+
+
+@_PROPERTY_TEST_SETTINGS
+@given(st.lists(_generated_segment_strategy(), max_size=12))
+def test_canonicalize_segments_preserves_sorted_non_overlapping_output(
+    segments: list[_GeneratedSegment],
+) -> None:
+    """Canonical output should remain ordered, positive-duration, and gap-safe."""
+
+    canonical = canonicalize_segments(segments)
+
+    assert canonical == sorted(
+        canonical,
+        key=lambda segment: (segment.start_seconds, segment.end_seconds),
+    )
+    assert all(segment.end_seconds > segment.start_seconds for segment in canonical)
+    for previous, current in zip(canonical, canonical[1:], strict=False):
+        assert previous.end_seconds <= current.start_seconds
+        assert not (
+            previous.emotion == current.emotion and previous.end_seconds == current.start_seconds
+        )

--- a/tests/test_transcription_text_metrics.py
+++ b/tests/test_transcription_text_metrics.py
@@ -2,10 +2,26 @@
 
 from __future__ import annotations
 
+import string
+
 import pytest
+from hypothesis import given
+from hypothesis import settings as hypothesis_settings
+from hypothesis import strategies as st
 
 from ser._internal.transcription import text_metrics as helpers
 from ser.domain import TranscriptWord
+
+_PROPERTY_TEST_SETTINGS = hypothesis_settings(
+    max_examples=100,
+    deadline=None,
+    database=None,
+)
+_NORMALIZED_TOKEN = st.text(
+    alphabet=string.ascii_lowercase + string.digits,
+    min_size=1,
+    max_size=8,
+)
 
 
 def test_normalize_words_lowercases_and_strips_punctuation() -> None:
@@ -55,3 +71,64 @@ def test_percentile_uses_nearest_rank_and_empty_default() -> None:
     assert helpers.percentile([], 0.9) == 1.0
     assert helpers.percentile([0.3, 0.1, 0.2, 0.4], 0.5) == 0.2
     assert helpers.percentile([0.3, 0.1, 0.2, 0.4], 0.9) == 0.4
+
+
+@_PROPERTY_TEST_SETTINGS
+@given(st.text())
+def test_normalize_words_outputs_lowercase_alphanumeric_tokens(text: str) -> None:
+    """Normalization should only emit lowercase alphanumeric comparison tokens."""
+
+    normalized = helpers.normalize_words(text)
+
+    assert all(token == token.lower() and token.isalnum() for token in normalized)
+
+
+@_PROPERTY_TEST_SETTINGS
+@given(
+    st.lists(_NORMALIZED_TOKEN, max_size=8),
+    st.lists(_NORMALIZED_TOKEN, max_size=8),
+)
+def test_levenshtein_distance_is_symmetric_and_bounded(
+    reference: list[str],
+    hypothesis: list[str],
+) -> None:
+    """Distance helper should preserve metric symmetry and length bounds."""
+
+    distance = helpers.levenshtein_distance(reference, hypothesis)
+
+    assert distance == helpers.levenshtein_distance(hypothesis, reference)
+    assert (
+        abs(len(reference) - len(hypothesis))
+        <= distance
+        <= max(
+            len(reference),
+            len(hypothesis),
+        )
+    )
+
+
+@_PROPERTY_TEST_SETTINGS
+@given(st.lists(_NORMALIZED_TOKEN, max_size=8))
+def test_levenshtein_distance_is_zero_for_identical_sequences(tokens: list[str]) -> None:
+    """Distance helper should report no edits for identical token sequences."""
+
+    assert helpers.levenshtein_distance(tokens, tokens) == 0
+
+
+@_PROPERTY_TEST_SETTINGS
+@given(
+    st.lists(_NORMALIZED_TOKEN, min_size=1, max_size=8),
+    st.lists(_NORMALIZED_TOKEN, max_size=8),
+)
+def test_compute_word_error_rate_matches_edit_distance_ratio(
+    reference: list[str],
+    hypothesis: list[str],
+) -> None:
+    """WER helper should match normalized edit distance over non-empty references."""
+
+    expected = helpers.levenshtein_distance(reference, hypothesis) / float(len(reference))
+
+    assert helpers.compute_word_error_rate(
+        " ".join(reference),
+        " ".join(hypothesis),
+    ) == pytest.approx(expected)

--- a/uv.lock
+++ b/uv.lock
@@ -291,6 +291,60 @@ wheels = [
 ]
 
 [[package]]
+name = "coverage"
+version = "7.13.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/e0/70553e3000e345daff267cec284ce4cbf3fc141b6da229ac52775b5428f1/coverage-7.13.5.tar.gz", hash = "sha256:c81f6515c4c40141f83f502b07bbfa5c240ba25bbe73da7b33f1e5b6120ff179", size = 915967, upload-time = "2026-03-17T10:33:18.341Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c3/a396306ba7db865bf96fc1fb3b7fd29bcbf3d829df642e77b13555163cd6/coverage-7.13.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:460cf0114c5016fa841214ff5564aa4864f11948da9440bc97e21ad1f4ba1e01", size = 219554, upload-time = "2026-03-17T10:30:42.208Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/16/a68a19e5384e93f811dccc51034b1fd0b865841c390e3c931dcc4699e035/coverage-7.13.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e223ce4b4ed47f065bfb123687686512e37629be25cc63728557ae7db261422", size = 219908, upload-time = "2026-03-17T10:30:43.906Z" },
+    { url = "https://files.pythonhosted.org/packages/29/72/20b917c6793af3a5ceb7fb9c50033f3ec7865f2911a1416b34a7cfa0813b/coverage-7.13.5-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:6e3370441f4513c6252bf042b9c36d22491142385049243253c7e48398a15a9f", size = 251419, upload-time = "2026-03-17T10:30:45.545Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/49/cd14b789536ac6a4778c453c6a2338bc0a2fb60c5a5a41b4008328b9acc1/coverage-7.13.5-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:03ccc709a17a1de074fb1d11f217342fb0d2b1582ed544f554fc9fc3f07e95f5", size = 254159, upload-time = "2026-03-17T10:30:47.204Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/00/7b0edcfe64e2ed4c0340dac14a52ad0f4c9bd0b8b5e531af7d55b703db7c/coverage-7.13.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3f4818d065964db3c1c66dc0fbdac5ac692ecbc875555e13374fdbe7eedb4376", size = 255270, upload-time = "2026-03-17T10:30:48.812Z" },
+    { url = "https://files.pythonhosted.org/packages/93/89/7ffc4ba0f5d0a55c1e84ea7cee39c9fc06af7b170513d83fbf3bbefce280/coverage-7.13.5-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:012d5319e66e9d5a218834642d6c35d265515a62f01157a45bcc036ecf947256", size = 257538, upload-time = "2026-03-17T10:30:50.77Z" },
+    { url = "https://files.pythonhosted.org/packages/81/bd/73ddf85f93f7e6fa83e77ccecb6162d9415c79007b4bc124008a4995e4a7/coverage-7.13.5-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8dd02af98971bdb956363e4827d34425cb3df19ee550ef92855b0acb9c7ce51c", size = 251821, upload-time = "2026-03-17T10:30:52.5Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/81/278aff4e8dec4926a0bcb9486320752811f543a3ce5b602cc7a29978d073/coverage-7.13.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f08fd75c50a760c7eb068ae823777268daaf16a80b918fa58eea888f8e3919f5", size = 253191, upload-time = "2026-03-17T10:30:54.543Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ee/fe1621488e2e0a58d7e94c4800f0d96f79671553488d401a612bebae324b/coverage-7.13.5-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:843ea8643cf967d1ac7e8ecd4bb00c99135adf4816c0c0593fdcc47b597fcf09", size = 251337, upload-time = "2026-03-17T10:30:56.663Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a6/f79fb37aa104b562207cc23cb5711ab6793608e246cae1e93f26b2236ed9/coverage-7.13.5-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:9d44d7aa963820b1b971dbecd90bfe5fe8f81cff79787eb6cca15750bd2f79b9", size = 255404, upload-time = "2026-03-17T10:30:58.427Z" },
+    { url = "https://files.pythonhosted.org/packages/75/f0/ed15262a58ec81ce457ceb717b7f78752a1713556b19081b76e90896e8d4/coverage-7.13.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:7132bed4bd7b836200c591410ae7d97bf7ae8be6fc87d160b2bd881df929e7bf", size = 250903, upload-time = "2026-03-17T10:31:00.093Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/e9/9129958f20e7e9d4d56d51d42ccf708d15cac355ff4ac6e736e97a9393d2/coverage-7.13.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a698e363641b98843c517817db75373c83254781426e94ada3197cabbc2c919c", size = 252780, upload-time = "2026-03-17T10:31:01.916Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/d7/0ad9b15812d81272db94379fe4c6df8fd17781cc7671fdfa30c76ba5ff7b/coverage-7.13.5-cp312-cp312-win32.whl", hash = "sha256:bdba0a6b8812e8c7df002d908a9a2ea3c36e92611b5708633c50869e6d922fdf", size = 222093, upload-time = "2026-03-17T10:31:03.642Z" },
+    { url = "https://files.pythonhosted.org/packages/29/3d/821a9a5799fac2556bcf0bd37a70d1d11fa9e49784b6d22e92e8b2f85f18/coverage-7.13.5-cp312-cp312-win_amd64.whl", hash = "sha256:d2c87e0c473a10bffe991502eac389220533024c8082ec1ce849f4218dded810", size = 222900, upload-time = "2026-03-17T10:31:05.651Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/fa/2238c2ad08e35cf4f020ea721f717e09ec3152aea75d191a7faf3ef009a8/coverage-7.13.5-cp312-cp312-win_arm64.whl", hash = "sha256:bf69236a9a81bdca3bff53796237aab096cdbf8d78a66ad61e992d9dac7eb2de", size = 221515, upload-time = "2026-03-17T10:31:07.293Z" },
+    { url = "https://files.pythonhosted.org/packages/74/8c/74fedc9663dcf168b0a059d4ea756ecae4da77a489048f94b5f512a8d0b3/coverage-7.13.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5ec4af212df513e399cf11610cc27063f1586419e814755ab362e50a85ea69c1", size = 219576, upload-time = "2026-03-17T10:31:09.045Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/c9/44fb661c55062f0818a6ffd2685c67aa30816200d5f2817543717d4b92eb/coverage-7.13.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:941617e518602e2d64942c88ec8499f7fbd49d3f6c4327d3a71d43a1973032f3", size = 219942, upload-time = "2026-03-17T10:31:10.708Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/13/93419671cee82b780bab7ea96b67c8ef448f5f295f36bf5031154ec9a790/coverage-7.13.5-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:da305e9937617ee95c2e39d8ff9f040e0487cbf1ac174f777ed5eddd7a7c1f26", size = 250935, upload-time = "2026-03-17T10:31:12.392Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/68/1666e3a4462f8202d836920114fa7a5ee9275d1fa45366d336c551a162dd/coverage-7.13.5-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:78e696e1cc714e57e8b25760b33a8b1026b7048d270140d25dafe1b0a1ee05a3", size = 253541, upload-time = "2026-03-17T10:31:14.247Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/5e/3ee3b835647be646dcf3c65a7c6c18f87c27326a858f72ab22c12730773d/coverage-7.13.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:02ca0eed225b2ff301c474aeeeae27d26e2537942aa0f87491d3e147e784a82b", size = 254780, upload-time = "2026-03-17T10:31:16.193Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b3/cb5bd1a04cfcc49ede6cd8409d80bee17661167686741e041abc7ee1b9a9/coverage-7.13.5-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:04690832cbea4e4663d9149e05dba142546ca05cb1848816760e7f58285c970a", size = 256912, upload-time = "2026-03-17T10:31:17.89Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/66/c1dceb7b9714473800b075f5c8a84f4588f887a90eb8645282031676e242/coverage-7.13.5-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0590e44dd2745c696a778f7bab6aa95256de2cbc8b8cff4f7db8ff09813d6969", size = 251165, upload-time = "2026-03-17T10:31:19.605Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/62/5502b73b97aa2e53ea22a39cf8649ff44827bef76d90bf638777daa27a9d/coverage-7.13.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d7cfad2d6d81dd298ab6b89fe72c3b7b05ec7544bdda3b707ddaecff8d25c161", size = 252908, upload-time = "2026-03-17T10:31:21.312Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/37/7792c2d69854397ca77a55c4646e5897c467928b0e27f2d235d83b5d08c6/coverage-7.13.5-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:e092b9499de38ae0fbfbc603a74660eb6ff3e869e507b50d85a13b6db9863e15", size = 250873, upload-time = "2026-03-17T10:31:23.565Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/23/bc866fb6163be52a8a9e5d708ba0d3b1283c12158cefca0a8bbb6e247a43/coverage-7.13.5-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:48c39bc4a04d983a54a705a6389512883d4a3b9862991b3617d547940e9f52b1", size = 255030, upload-time = "2026-03-17T10:31:25.58Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/8b/ef67e1c222ef49860701d346b8bbb70881bef283bd5f6cbba68a39a086c7/coverage-7.13.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:2d3807015f138ffea1ed9afeeb8624fd781703f2858b62a8dd8da5a0994c57b6", size = 250694, upload-time = "2026-03-17T10:31:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/46/0d/866d1f74f0acddbb906db212e096dee77a8e2158ca5e6bb44729f9d93298/coverage-7.13.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ee2aa19e03161671ec964004fb74b2257805d9710bf14a5c704558b9d8dbaf17", size = 252469, upload-time = "2026-03-17T10:31:29.472Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/f5/be742fec31118f02ce42b21c6af187ad6a344fed546b56ca60caacc6a9a0/coverage-7.13.5-cp313-cp313-win32.whl", hash = "sha256:ce1998c0483007608c8382f4ff50164bfc5bd07a2246dd272aa4043b75e61e85", size = 222112, upload-time = "2026-03-17T10:31:31.526Z" },
+    { url = "https://files.pythonhosted.org/packages/66/40/7732d648ab9d069a46e686043241f01206348e2bbf128daea85be4d6414b/coverage-7.13.5-cp313-cp313-win_amd64.whl", hash = "sha256:631efb83f01569670a5e866ceb80fe483e7c159fac6f167e6571522636104a0b", size = 222923, upload-time = "2026-03-17T10:31:33.633Z" },
+    { url = "https://files.pythonhosted.org/packages/48/af/fea819c12a095781f6ccd504890aaddaf88b8fab263c4940e82c7b770124/coverage-7.13.5-cp313-cp313-win_arm64.whl", hash = "sha256:f4cd16206ad171cbc2470dbea9103cf9a7607d5fe8c242fdf1edf36174020664", size = 221540, upload-time = "2026-03-17T10:31:35.445Z" },
+    { url = "https://files.pythonhosted.org/packages/23/d2/17879af479df7fbbd44bd528a31692a48f6b25055d16482fdf5cdb633805/coverage-7.13.5-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0428cbef5783ad91fe240f673cc1f76b25e74bbfe1a13115e4aa30d3f538162d", size = 220262, upload-time = "2026-03-17T10:31:37.184Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/4c/d20e554f988c8f91d6a02c5118f9abbbf73a8768a3048cb4962230d5743f/coverage-7.13.5-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e0b216a19534b2427cc201a26c25da4a48633f29a487c61258643e89d28200c0", size = 220617, upload-time = "2026-03-17T10:31:39.245Z" },
+    { url = "https://files.pythonhosted.org/packages/29/9c/f9f5277b95184f764b24e7231e166dfdb5780a46d408a2ac665969416d61/coverage-7.13.5-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:972a9cd27894afe4bc2b1480107054e062df08e671df7c2f18c205e805ccd806", size = 261912, upload-time = "2026-03-17T10:31:41.324Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/f6/7f1ab39393eeb50cfe4747ae8ef0e4fc564b989225aa1152e13a180d74f8/coverage-7.13.5-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4b59148601efcd2bac8c4dbf1f0ad6391693ccf7a74b8205781751637076aee3", size = 263987, upload-time = "2026-03-17T10:31:43.724Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/d7/62c084fb489ed9c6fbdf57e006752e7c516ea46fd690e5ed8b8617c7d52e/coverage-7.13.5-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:505d7083c8b0c87a8fa8c07370c285847c1f77739b22e299ad75a6af6c32c5c9", size = 266416, upload-time = "2026-03-17T10:31:45.769Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f6/df63d8660e1a0bff6125947afda112a0502736f470d62ca68b288ea762d8/coverage-7.13.5-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:60365289c3741e4db327e7baff2a4aaacf22f788e80fa4683393891b70a89fbd", size = 267558, upload-time = "2026-03-17T10:31:48.293Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/02/353ca81d36779bd108f6d384425f7139ac3c58c750dcfaafe5d0bee6436b/coverage-7.13.5-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1b88c69c8ef5d4b6fe7dea66d6636056a0f6a7527c440e890cf9259011f5e606", size = 261163, upload-time = "2026-03-17T10:31:50.125Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/16/2e79106d5749bcaf3aee6d309123548e3276517cd7851faa8da213bc61bf/coverage-7.13.5-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:5b13955d31d1633cf9376908089b7cebe7d15ddad7aeaabcbe969a595a97e95e", size = 263981, upload-time = "2026-03-17T10:31:51.961Z" },
+    { url = "https://files.pythonhosted.org/packages/29/c7/c29e0c59ffa6942030ae6f50b88ae49988e7e8da06de7ecdbf49c6d4feae/coverage-7.13.5-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:f70c9ab2595c56f81a89620e22899eea8b212a4041bd728ac6f4a28bf5d3ddd0", size = 261604, upload-time = "2026-03-17T10:31:53.872Z" },
+    { url = "https://files.pythonhosted.org/packages/40/48/097cdc3db342f34006a308ab41c3a7c11c3f0d84750d340f45d88a782e00/coverage-7.13.5-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:084b84a8c63e8d6fc7e3931b316a9bcafca1458d753c539db82d31ed20091a87", size = 265321, upload-time = "2026-03-17T10:31:55.997Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/1f/4994af354689e14fd03a75f8ec85a9a68d94e0188bbdab3fc1516b55e512/coverage-7.13.5-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ad14385487393e386e2ea988b09d62dd42c397662ac2dabc3832d71253eee479", size = 260502, upload-time = "2026-03-17T10:31:58.308Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c6/9bb9ef55903e628033560885f5c31aa227e46878118b63ab15dc7ba87797/coverage-7.13.5-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:7f2c47b36fe7709a6e83bfadf4eefb90bd25fbe4014d715224c4316f808e59a2", size = 262688, upload-time = "2026-03-17T10:32:00.141Z" },
+    { url = "https://files.pythonhosted.org/packages/14/4f/f5df9007e50b15e53e01edea486814783a7f019893733d9e4d6caad75557/coverage-7.13.5-cp313-cp313t-win32.whl", hash = "sha256:67e9bc5449801fad0e5dff329499fb090ba4c5800b86805c80617b4e29809b2a", size = 222788, upload-time = "2026-03-17T10:32:02.246Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/98/aa7fccaa97d0f3192bec013c4e6fd6d294a6ed44b640e6bb61f479e00ed5/coverage-7.13.5-cp313-cp313t-win_amd64.whl", hash = "sha256:da86cdcf10d2519e10cabb8ac2de03da1bcb6e4853790b7fbd48523332e3a819", size = 223851, upload-time = "2026-03-17T10:32:04.416Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/8b/e5c469f7352651e5f013198e9e21f97510b23de957dd06a84071683b4b60/coverage-7.13.5-cp313-cp313t-win_arm64.whl", hash = "sha256:0ecf12ecb326fe2c339d93fc131816f3a7367d223db37817208905c89bded911", size = 222104, upload-time = "2026-03-17T10:32:06.65Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ee/a4cf96b8ce1e566ed238f0659ac2d3f007ed1d14b181bcb684e19561a69a/coverage-7.13.5-py3-none-any.whl", hash = "sha256:34b02417cf070e173989b3db962f7ed56d2f644307b2cf9d5a0f258e13084a61", size = 211346, upload-time = "2026-03-17T10:33:15.691Z" },
+]
+
+[[package]]
 name = "crcmod"
 version = "1.7"
 source = { registry = "https://pypi.org/simple" }
@@ -614,6 +668,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/6d/8e/07e42bc434a847154083b315779b0a81d567154504624e181caf2c71cd98/hydra-core-1.3.2.tar.gz", hash = "sha256:8a878ed67216997c3e9d88a8e72e7b4767e81af37afb4ea3334b269a4390a824", size = 3263494, upload-time = "2023-02-23T18:33:43.03Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c6/50/e0edd38dcd63fb26a8547f13d28f7a008bc4a3fd4eb4ff030673f22ad41a/hydra_core-1.3.2-py3-none-any.whl", hash = "sha256:fa0238a9e31df3373b35b0bfb672c34cc92718d21f81311d8996a16de1141d8b", size = 154547, upload-time = "2023-02-23T18:33:40.801Z" },
+]
+
+[[package]]
+name = "hypothesis"
+version = "6.151.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/e1/ef365ff480903b929d28e057f57b76cae51a30375943e33374ec9a165d9c/hypothesis-6.151.9.tar.gz", hash = "sha256:2f284428dda6c3c48c580de0e18470ff9c7f5ef628a647ee8002f38c3f9097ca", size = 463534, upload-time = "2026-02-16T22:59:23.09Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/f7/5cc291d701094754a1d327b44d80a44971e13962881d9a400235726171da/hypothesis-6.151.9-py3-none-any.whl", hash = "sha256:7b7220585c67759b1b1ef839b1e6e9e3d82ed468cfc1ece43c67184848d7edd9", size = 529307, upload-time = "2026-02-16T22:59:20.443Z" },
 ]
 
 [[package]]
@@ -1590,6 +1656,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-cov"
+version = "6.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/30/4c/f883ab8f0daad69f47efdf95f55a66b51a8b939c430dadce0611508d9e99/pytest_cov-6.3.0.tar.gz", hash = "sha256:35c580e7800f87ce892e687461166e1ac2bcb8fb9e13aea79032518d6e503ff2", size = 70398, upload-time = "2025-09-06T15:40:14.361Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/b4/bb7263e12aade3842b938bc5c6958cae79c5ee18992f9b9349019579da0f/pytest_cov-6.3.0-py3-none-any.whl", hash = "sha256:440db28156d2468cafc0415b4f8e50856a0d11faefa38f30906048fe490f1749", size = 25115, upload-time = "2025-09-06T15:40:12.44Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1933,11 +2013,14 @@ dependencies = [
 [package.optional-dependencies]
 dev = [
     { name = "black" },
+    { name = "coverage" },
+    { name = "hypothesis" },
     { name = "isort" },
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pyright" },
     { name = "pytest" },
+    { name = "pytest-cov" },
     { name = "pyupgrade" },
     { name = "ruff" },
 ]
@@ -1954,11 +2037,13 @@ medium = [
 requires-dist = [
     { name = "black", marker = "extra == 'dev'", specifier = ">=24.10.0,<26.0.0" },
     { name = "colored", specifier = ">=2.2.4,<3.0.0" },
+    { name = "coverage", extras = ["toml"], marker = "extra == 'dev'", specifier = ">=7.6.0,<8.0.0" },
     { name = "demucs", marker = "python_full_version < '3.13' or platform_machine != 'x86_64' or sys_platform != 'darwin'", specifier = ">=4.0.1,<5.0.0" },
     { name = "faster-whisper", specifier = ">=1.1.1,<2.0.0" },
     { name = "ffmpeg-python", specifier = ">=0.2.0,<0.3.0" },
     { name = "funasr", marker = "extra == 'full'", specifier = ">=1.3.1,<2.0.0" },
     { name = "huggingface-hub", specifier = ">=0.30.0,<1.0.0" },
+    { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.130.0,<7.0.0" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.13.0,<7.0.0" },
     { name = "librosa", specifier = ">=0.10.2.post1,<0.11.0" },
     { name = "modelscope", marker = "extra == 'full'", specifier = ">=1.34.0,<2.0.0" },
@@ -1975,6 +2060,7 @@ requires-dist = [
     { name = "pyarrow", specifier = ">=18.1.0,<20.0.0" },
     { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.390,<2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0,<9.0.0" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0.0,<7.0.0" },
     { name = "python-dotenv", specifier = ">=1.0.1,<2.0.0" },
     { name = "pyupgrade", marker = "extra == 'dev'", specifier = ">=3.21.2,<4.0.0" },
     { name = "pyyaml", specifier = ">=6.0,<7.0" },
@@ -2007,6 +2093,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]
@@ -2269,6 +2364,9 @@ dependencies = [
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d3/54/a2ba279afcca44bbd320d4e73675b282fcee3d81400ea1b53934efca6462/torch-2.10.0-2-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:13ec4add8c3faaed8d13e0574f5cd4a323c11655546f91fbe6afa77b57423574", size = 79498202, upload-time = "2026-02-10T21:44:52.603Z" },
     { url = "https://files.pythonhosted.org/packages/ec/23/2c9fe0c9c27f7f6cb865abcea8a4568f29f00acaeadfc6a37f6801f84cb4/torch-2.10.0-2-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:e521c9f030a3774ed770a9c011751fb47c4d12029a3d6522116e48431f2ff89e", size = 79498254, upload-time = "2026-02-10T21:44:44.095Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7a/abada41517ce0011775f0f4eacc79659bc9bc6c361e6bfe6f7052a6b9363/torch-2.10.0-3-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:98c01b8bb5e3240426dcde1446eed6f40c778091c8544767ef1168fc663a05a6", size = 915622781, upload-time = "2026-03-11T14:17:11.354Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/c6/4dfe238342ffdcec5aef1c96c457548762d33c40b45a1ab7033bb26d2ff2/torch-2.10.0-3-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:80b1b5bfe38eb0e9f5ff09f206dcac0a87aadd084230d4a36eea5ec5232c115b", size = 915627275, upload-time = "2026-03-11T14:16:11.325Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f0/72bf18847f58f877a6a8acf60614b14935e2f156d942483af1ffc081aea0/torch-2.10.0-3-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:46b3574d93a2a8134b3f5475cfb98e2eb46771794c57015f6ad1fb795ec25e49", size = 915523474, upload-time = "2026-03-11T14:17:44.422Z" },
     { url = "https://files.pythonhosted.org/packages/cc/af/758e242e9102e9988969b5e621d41f36b8f258bb4a099109b7a4b4b50ea4/torch-2.10.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:5fd4117d89ffd47e3dcc71e71a22efac24828ad781c7e46aaaf56bf7f2796acf", size = 145996088, upload-time = "2026-01-21T16:24:44.171Z" },
     { url = "https://files.pythonhosted.org/packages/23/8e/3c74db5e53bff7ed9e34c8123e6a8bfef718b2450c35eefab85bb4a7e270/torch-2.10.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:787124e7db3b379d4f1ed54dd12ae7c741c16a4d29b49c0226a89bea50923ffb", size = 915711952, upload-time = "2026-01-21T16:23:53.503Z" },
     { url = "https://files.pythonhosted.org/packages/6e/01/624c4324ca01f66ae4c7cd1b74eb16fb52596dce66dbe51eff95ef9e7a4c/torch-2.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:2c66c61f44c5f903046cc696d088e21062644cbe541c7f1c4eaae88b2ad23547", size = 113757972, upload-time = "2026-01-21T16:24:39.516Z" },


### PR DESCRIPTION
## Summary
- refactor the CLI composition root plus accurate/medium/stable-whisper hotspot owners into smaller helper seams while preserving public behavior
- add quantitative quality instrumentation with pytest-cov, coverage configuration, a CI coverage job, and Hypothesis-based property tests for pure helper modules
- keep the new subtitle export CLI surface from origin/main integrated into the refactored command path
