### PR TITLE
docs: sync architecture references

### DIFF
--- a/docs/codebase-architecture.md
+++ b/docs/codebase-architecture.md
@@ -11,7 +11,7 @@ formal artifacts in [`docs/architecture-diagram.md`](architecture-diagram.md),
 These counts are a current working-tree snapshot taken on March 27, 2026.
 
 - Source modules under `ser/`: `228`
-- Test modules under `tests/`: `145`
+- Test modules under `tests/`: `150`
 - Public modules outside `_internal/`: `167`
 - Internal owner/helper modules under `_internal/`: `61`
 - Public modules importing `_internal` directly: `24`

--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -1,11 +1,12 @@
 # Compatibility Matrix (Live Snapshot)
 
 Date initialized: 2026-02-19
-Last updated: 2026-02-26
+Last updated: 2026-03-27
 Purpose: Track compatibility coverage across Python versions, dependency extras, and runtime profiles.
 Evidence source:
-1. `ser_refactor_implementation_journal.md` (latest: Iteration 57, ratified default/profile policy + Darwin 3.13 support-scope clarification)
-2. `ser_refactor_status.md`
+1. `.github/workflows/darwin-x86_64-validation.yml`
+2. `.github/workflows/linux-python-3_13-cli-validation.yml`
+3. `README.md`
 
 ## Matrix
 

--- a/tests/suites/integration/docs/test_architecture_docs.py
+++ b/tests/suites/integration/docs/test_architecture_docs.py
@@ -13,11 +13,36 @@ _README_DOC_LINK_PATTERN = re.compile(
     r"https://github\.com/jsugg/ser/(?:blob|tree)/main/(docs/[A-Za-z0-9_./-]+)"
 )
 _ARCHITECTURE_RELATIVE_LINK_PATTERN = re.compile(r"\(([^)]+)\)")
+_ARCHITECTURE_COUNT_PATTERN = re.compile(
+    r"- (?P<label>Source modules under `ser/`|Test modules under `tests/`|"
+    r"Public modules outside `_internal/`|Internal owner/helper modules under `_internal/`): "
+    r"`(?P<count>\d+)`"
+)
+_REMOVED_TRACKER_REFERENCES = (
+    "ser_refactor_implementation_journal.md",
+    "ser_refactor_status.md",
+)
 
 
 def _repo_root() -> Path:
     """Returns the repository root for docs contract tests."""
     return Path(__file__).resolve().parents[4]
+
+
+def _expected_codebase_counts(root: Path) -> dict[str, int]:
+    """Builds the current architecture snapshot counts from the working tree."""
+    source_files = list((root / "ser").rglob("*.py"))
+    test_files = list((root / "tests").rglob("*.py"))
+    return {
+        "Source modules under `ser/`": len(source_files),
+        "Test modules under `tests/`": len(test_files),
+        "Public modules outside `_internal/`": sum(
+            1 for path in source_files if "_internal" not in path.parts
+        ),
+        "Internal owner/helper modules under `_internal/`": sum(
+            1 for path in source_files if "_internal" in path.parts
+        ),
+    }
 
 
 def test_readme_architecture_links_resolve_to_existing_docs() -> None:
@@ -43,3 +68,23 @@ def test_architecture_index_links_resolve_to_existing_docs() -> None:
 
     assert root / "docs" / "adr" / "README.md" in resolved_targets
     assert all(target.is_file() for target in resolved_targets)
+
+
+def test_codebase_architecture_snapshot_counts_match_current_tree() -> None:
+    """Architecture snapshot counts should match the current repository tree."""
+    root = _repo_root()
+    architecture_text = (root / "docs" / "codebase-architecture.md").read_text(encoding="utf-8")
+    reported_counts = {
+        match.group("label"): int(match.group("count"))
+        for match in _ARCHITECTURE_COUNT_PATTERN.finditer(architecture_text)
+    }
+
+    assert reported_counts == _expected_codebase_counts(root)
+
+
+def test_compatibility_matrix_does_not_reference_removed_tracker_docs() -> None:
+    """Compatibility matrix should not point contributors at removed tracker files."""
+    root = _repo_root()
+    compatibility_text = (root / "docs" / "compatibility-matrix.md").read_text(encoding="utf-8")
+
+    assert all(reference not in compatibility_text for reference in _REMOVED_TRACKER_REFERENCES)


### PR DESCRIPTION
## Summary
- sync the architecture snapshot doc with the current test-module count
- replace removed tracker references in the compatibility matrix with current maintained evidence sources
- extend the docs contract test to catch snapshot drift and removed tracker references
