### PR TITLE
Align coverage gate with coverage.py multiprocessing support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,5 @@ ser/models/*.json
 .hypothesis
 .local/
 .coverage
+.coverage.*
 coverage.xml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,7 @@ make fmt       # pyupgrade --py312-plus + ruff --fix + isort + black
 make lint      # ruff + black --check + isort --check-only
 make type      # mypy + pyright (pythonversion 3.12)
 make test      # pytest -q
+make test-cov  # coverage.py branch gate, including multiprocessing workers
 make prepush-check      # canonical pre-push hook command
 make prepush-hook       # hook workflow: autofix + verify + abort if files changed
 make import-lint        # API boundary import lint lane (TID251 banned-api policy)

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,11 @@ test:
 	uv run pytest -q
 
 test-cov:
-	uv run --frozen --extra dev pytest -q --cov=ser --cov-report=term-missing --cov-report=xml
+	uv run --frozen --extra dev coverage erase
+	uv run --frozen --extra dev coverage run -m pytest -q
+	uv run --frozen --extra dev coverage combine
+	uv run --frozen --extra dev coverage report
+	uv run --frozen --extra dev coverage xml
 
 check: lint type test
 
@@ -79,3 +83,4 @@ quality-gate-full:
 clean:
 	find . -type d -name "__pycache__" -prune -exec rm -rf {} +
 	rm -rf .pytest_cache .mypy_cache .ruff_cache dist build .pkg-smoke
+	find . -maxdepth 1 -type f \( -name ".coverage" -o -name ".coverage.*" -o -name "coverage.xml" \) -delete

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,6 @@ dependencies = [
 dev = [
   "pre-commit>=4.0.0,<5.0.0",
   "pytest>=8.0.0,<9.0.0",
-  "pytest-cov>=6.0.0,<7.0.0",
   "coverage[toml]>=7.6.0,<8.0.0",
   "hypothesis>=6.130.0,<7.0.0",
   "ruff>=0.9.0,<1.0.0",
@@ -184,7 +183,10 @@ reportMissingTypeStubs = "none"
 
 [tool.coverage.run]
 branch = true
+concurrency = ["multiprocessing"]
+parallel = true
 relative_files = true
+sigterm = true
 source = ["ser"]
 
 [tool.coverage.report]

--- a/uv.lock
+++ b/uv.lock
@@ -1656,20 +1656,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pytest-cov"
-version = "6.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "coverage" },
-    { name = "pluggy" },
-    { name = "pytest" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/30/4c/f883ab8f0daad69f47efdf95f55a66b51a8b939c430dadce0611508d9e99/pytest_cov-6.3.0.tar.gz", hash = "sha256:35c580e7800f87ce892e687461166e1ac2bcb8fb9e13aea79032518d6e503ff2", size = 70398, upload-time = "2025-09-06T15:40:14.361Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/80/b4/bb7263e12aade3842b938bc5c6958cae79c5ee18992f9b9349019579da0f/pytest_cov-6.3.0-py3-none-any.whl", hash = "sha256:440db28156d2468cafc0415b4f8e50856a0d11faefa38f30906048fe490f1749", size = 25115, upload-time = "2025-09-06T15:40:12.44Z" },
-]
-
-[[package]]
 name = "python-dotenv"
 version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2020,7 +2006,6 @@ dev = [
     { name = "pre-commit" },
     { name = "pyright" },
     { name = "pytest" },
-    { name = "pytest-cov" },
     { name = "pyupgrade" },
     { name = "ruff" },
 ]
@@ -2060,7 +2045,6 @@ requires-dist = [
     { name = "pyarrow", specifier = ">=18.1.0,<20.0.0" },
     { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.390,<2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0,<9.0.0" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0.0,<7.0.0" },
     { name = "python-dotenv", specifier = ">=1.0.1,<2.0.0" },
     { name = "pyupgrade", marker = "extra == 'dev'", specifier = ">=3.21.2,<4.0.0" },
     { name = "pyyaml", specifier = ">=6.0,<7.0" },


### PR DESCRIPTION
## Summary
- remove the `pytest-cov` plugin from the dev toolchain and run the branch coverage gate through `coverage.py` directly
- configure coverage for multiprocessing workers and keep repo hygiene aligned with generated `.coverage.*` shard files
- document `make test-cov` as the multiprocessing-aware coverage gate for contributors

## Why
The stray `.coverage.*.pid...` files were being produced by real `multiprocessing` spawn workers in the process-isolation suite. The upstream-aligned fix is to use coverage.py's native multiprocessing support rather than layering repo-local behavior on top of legacy plugin subprocess handling.