### PR TITLE
ci: upgrade artifact actions to current major versions

### DIFF
--- a/.github/workflows/darwin-x86_64-validation.yml
+++ b/.github/workflows/darwin-x86_64-validation.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Upload validation artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: darwin-x86_64-validation-artifacts
           path: |

--- a/.github/workflows/full-dataset-quality-gate-regression.yml
+++ b/.github/workflows/full-dataset-quality-gate-regression.yml
@@ -121,7 +121,7 @@ jobs:
         run: uv run --extra medium ser --train
 
       - name: Upload full-gate training artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: full-dataset-quality-gate-artifacts
           path: |
@@ -175,7 +175,7 @@ jobs:
         run: ./scripts/workflows/configure_runtime_dirs.sh --models-dir "${SER_MODELS_DIR}"
 
       - name: Download full-gate training artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: full-dataset-quality-gate-artifacts
           path: ${{ env.SER_MODELS_DIR }}
@@ -196,7 +196,7 @@ jobs:
 
       - name: Upload full-dataset gate report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: full-dataset-quality-gate-report
           path: ${{ inputs.out_file }}

--- a/.github/workflows/linux-python-3_13-cli-validation.yml
+++ b/.github/workflows/linux-python-3_13-cli-validation.yml
@@ -121,7 +121,7 @@ jobs:
 
       - name: Upload validation artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: linux-python-3_13-cli-validation-artifacts
           path: |

--- a/.github/workflows/linux-selfhosted-gpu-validation.yml
+++ b/.github/workflows/linux-selfhosted-gpu-validation.yml
@@ -196,7 +196,7 @@ jobs:
 
       - name: Upload CUDA validation artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: linux-selfhosted-cuda-validation-artifacts
           path: |
@@ -305,7 +305,7 @@ jobs:
 
       - name: Upload XPU validation artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: linux-selfhosted-xpu-validation-artifacts
           path: |

--- a/.github/workflows/macos15-mps-validation.yml
+++ b/.github/workflows/macos15-mps-validation.yml
@@ -155,7 +155,7 @@ jobs:
 
       - name: Upload validation artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: macos15-mps-validation-artifacts
           path: |

--- a/.github/workflows/python-publish-testpypi.yml
+++ b/.github/workflows/python-publish-testpypi.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Check distribution metadata
         run: python -m twine check --strict dist/*
       - name: Upload distributions artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: python-package-distributions
           path: dist/
@@ -84,7 +84,7 @@ jobs:
 
     steps:
       - name: Download distributions artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: python-package-distributions
           path: dist/

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Check distribution metadata
         run: python -m twine check --strict dist/*
       - name: Upload distributions artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: python-package-distributions
           path: dist/
@@ -117,7 +117,7 @@ jobs:
 
     steps:
       - name: Download distributions artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: python-package-distributions
           path: dist/


### PR DESCRIPTION
## Summary
- upgrade workflow artifact upload action from v4 to v7
- upgrade workflow artifact download action from v4 to v8
- keep all existing workflow logic and artifact names unchanged

## Why
GitHub has announced the Node.js 20 action runtime deprecation. These upgrades reduce breakage risk on hosted runners while preserving current behavior.