### PR TITLE
Harden validation scripts and dataset downloads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,22 +31,22 @@ setup-runtime:
 	SER_SETUP_INCLUDE_DEV=false ./scripts/setup_compatible_env.sh
 
 fmt:
-	uv run --extra dev pyupgrade --py312-plus --exit-zero-even-if-changed $$(rg --files ser tests -g '*.py')
-	uv run ruff check --fix ser tests
-	uv run isort ser tests
-	uv run black ser tests
+	uv run --frozen --extra dev pyupgrade --py312-plus --exit-zero-even-if-changed $$(rg --files ser tests -g '*.py')
+	uv run --frozen --extra dev ruff check --fix ser tests
+	uv run --frozen --extra dev isort ser tests
+	uv run --frozen --extra dev black ser tests
 
 lint:
-	uv run ruff check ser tests
-	uv run black --check ser tests
-	uv run isort --check-only ser tests
+	uv run --frozen --extra dev ruff check ser tests
+	uv run --frozen --extra dev black --check ser tests
+	uv run --frozen --extra dev isort --check-only ser tests
 
 type:
-	uv run mypy ser tests
-	uv run pyright --pythonversion 3.12 ser tests
+	uv run --frozen --extra dev mypy ser tests
+	uv run --frozen --extra dev pyright --pythonversion 3.12 ser tests
 
 test:
-	uv run pytest -q
+	uv run --frozen --extra dev pytest -q
 
 test-cov:
 	uv run --frozen --extra dev coverage erase

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -10,7 +10,6 @@ The repository currently keeps its architecture guidance in these maintained doc
 - [`../codebase-architecture.md`](../codebase-architecture.md): narrative codebase analysis
 - [`../subsystem-dependency-map.md`](../subsystem-dependency-map.md): subsystem dependency directions and soft-boundary policy
 - [`../refactor-hotspot-checks.md`](../refactor-hotspot-checks.md): hotspot inventory for careful refactors
-- [`../architecture-refactor-roadmap.md`](../architecture-refactor-roadmap.md): staged refactor priorities
 
 ## How this directory should be used
 

--- a/scripts/run_full_dataset_quality_gate.sh
+++ b/scripts/run_full_dataset_quality_gate.sh
@@ -12,7 +12,19 @@ medium_model_file_name="${SER_FULL_GATE_MEDIUM_MODEL_FILE_NAME:-ser_model_medium
 medium_training_report_file_name="${SER_FULL_GATE_MEDIUM_TRAINING_REPORT_FILE_NAME:-training_report_medium_full.json}"
 report_path="${SER_FULL_GATE_REPORT_PATH:-profile_quality_gate_report_full.json}"
 progress_every="${SER_FULL_GATE_PROGRESS_EVERY:-120}"
-models_dir="${SER_MODELS_DIR:-$HOME/Library/Application Support/ser/models}"
+
+default_models_dir() {
+  case "$(uname -s)" in
+    Darwin)
+      printf '%s\n' "$HOME/Library/Application Support/ser/models"
+      ;;
+    *)
+      printf '%s\n' "${XDG_DATA_HOME:-$HOME/.local/share}/ser/models"
+      ;;
+  esac
+}
+
+models_dir="${SER_MODELS_DIR:-$(default_models_dir)}"
 
 if [[ "$run_training" != "true" && "$run_training" != "false" ]]; then
   printf 'SER_FULL_GATE_RUN_TRAINING must be true or false, got: %s\n' "$run_training" >&2

--- a/scripts/setup_compatible_env.sh
+++ b/scripts/setup_compatible_env.sh
@@ -75,6 +75,12 @@ done
 os_name="$(uname -s)"
 arch_name="$(uname -m)"
 default_python="3.13"
+if [[ -f .python-version ]]; then
+  pinned_python="$(head -n 1 .python-version | tr -d '[:space:]')"
+  if [[ -n "$pinned_python" ]]; then
+    default_python="$pinned_python"
+  fi
+fi
 
 python_version="${SER_SETUP_PYTHON:-$default_python}"
 include_dev="$(normalize_bool "${SER_SETUP_INCLUDE_DEV:-true}" "SER_SETUP_INCLUDE_DEV")"

--- a/scripts/workflows/smoke_test_wheel_install.sh
+++ b/scripts/workflows/smoke_test_wheel_install.sh
@@ -11,10 +11,11 @@ if [[ ${#wheels[@]} -eq 0 ]]; then
   exit 2
 fi
 
+rm -rf .pkg-smoke
 python -m venv .pkg-smoke
 . .pkg-smoke/bin/activate
 python -m pip install --upgrade pip
-pip install --no-deps "${wheels[@]}"
+pip install --force-reinstall --no-deps "${wheels[@]}"
 
 tmp_dir="$(mktemp -d)"
 cd "$tmp_dir"

--- a/ser/data/provider_downloads.py
+++ b/ser/data/provider_downloads.py
@@ -13,8 +13,9 @@ import subprocess
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
+from email.message import Message
 from pathlib import Path
-from typing import Protocol
+from typing import Protocol, runtime_checkable
 from urllib import error, request
 
 
@@ -61,6 +62,69 @@ class RunWithRetries(Protocol):
         description: str,
         action: Callable[[], None],
     ) -> None: ...
+
+
+@runtime_checkable
+class _ResponseWithGetHeader(Protocol):
+    """HTTP response subset exposing header lookup."""
+
+    def getheader(self, name: str, default: str | None = None) -> str | None: ...
+
+
+def _format_bytes(size_bytes: int) -> str:
+    """Formats byte counts for actionable diagnostics."""
+    units = ("B", "KB", "MB", "GB", "TB")
+    value = float(size_bytes)
+    unit = units[0]
+    for current_unit in units:
+        unit = current_unit
+        if value < 1024.0 or current_unit == units[-1]:
+            break
+        value /= 1024.0
+    if unit == "B":
+        return f"{int(value)} {unit}"
+    return f"{value:.2f} {unit}"
+
+
+def _parse_content_length(value: str | None) -> int | None:
+    """Parses a positive HTTP content length value."""
+    if value is None:
+        return None
+    normalized = value.strip()
+    if not normalized:
+        return None
+    try:
+        parsed = int(normalized)
+    except ValueError:
+        return None
+    if parsed <= 0:
+        return None
+    return parsed
+
+
+def _response_content_length(response: object) -> int | None:
+    """Returns a response content length when the server exposes one."""
+    if isinstance(response, _ResponseWithGetHeader):
+        return _parse_content_length(response.getheader("Content-Length"))
+    headers = getattr(response, "headers", None)
+    if isinstance(headers, Message):
+        return _parse_content_length(headers.get("Content-Length"))
+    return None
+
+
+def _ensure_download_disk_space(*, destination_path: Path, required_bytes: int | None) -> None:
+    """Raises when known download size exceeds free space at the destination."""
+    if required_bytes is None or required_bytes <= 0:
+        return
+    free_bytes = shutil.disk_usage(destination_path.parent).free
+    if free_bytes >= required_bytes:
+        return
+    raise RuntimeError(
+        "Dataset download aborted due to insufficient disk space. "
+        f"Required at least {_format_bytes(required_bytes)}, "
+        f"free {_format_bytes(free_bytes)} at {destination_path.parent}. "
+        "Use `--dataset-root` on a volume with enough space or free local storage first."
+    )
 
 
 def is_retryable_http_status(status_code: int) -> bool:
@@ -168,6 +232,8 @@ def download_file_with_retries(
         elif existing_size > 0:
             return destination_path
     tmp_path = destination_path.with_suffix(destination_path.suffix + ".partial")
+    tmp_path.unlink(missing_ok=True)
+    _ensure_download_disk_space(destination_path=destination_path, required_bytes=expected_size)
 
     def _action() -> None:
         req = request.Request(
@@ -179,6 +245,13 @@ def download_file_with_retries(
             method="GET",
         )
         with request.urlopen(req, timeout=timeout_seconds) as response:
+            response_size = _response_content_length(response)
+            if response_size is not None:
+                required_bytes = max(expected_size or 0, response_size)
+                _ensure_download_disk_space(
+                    destination_path=destination_path,
+                    required_bytes=required_bytes,
+                )
             with tmp_path.open("wb") as output_handle:
                 while True:
                     chunk = response.read(chunk_size)

--- a/ser/transcript/backends/stable_whisper_mps_compat.py
+++ b/ser/transcript/backends/stable_whisper_mps_compat.py
@@ -229,8 +229,8 @@ def _resolve_mps_log_mel_target_device(
         if explicit_device is None or explicit_device.type != "mps":
             return None
         return explicit_device
-    if torch.is_tensor(audio) and cast(torch.Tensor, audio).device.type == "mps":
-        return cast(torch.Tensor, audio).device
+    if isinstance(audio, torch.Tensor) and audio.device.type == "mps":
+        return audio.device
     return None
 
 
@@ -256,7 +256,7 @@ def _build_mps_safe_log_mel_spectrogram(
                     device=device,
                 ),
             )
-        cpu_audio = cast(torch.Tensor, audio).float().cpu() if torch.is_tensor(audio) else audio
+        cpu_audio = audio.float().cpu() if isinstance(audio, torch.Tensor) else audio
         cpu_log_mel = cast(
             torch.Tensor,
             original_log_mel_spectrogram(

--- a/tests/suites/integration/architecture/test_documentation_links.py
+++ b/tests/suites/integration/architecture/test_documentation_links.py
@@ -1,0 +1,46 @@
+"""Repository documentation link contract tests."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_MARKDOWN_LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
+_EXTERNAL_LINK_RE = re.compile(r"^[a-z][a-z0-9+.-]*://", re.IGNORECASE)
+
+
+def _markdown_files(repo_root: Path) -> list[Path]:
+    """Returns repository Markdown files covered by local link checks."""
+    return [
+        repo_root / "README.md",
+        repo_root / "CONTRIBUTING.md",
+        *sorted((repo_root / "docs").rglob("*.md")),
+    ]
+
+
+def _local_markdown_link_targets(markdown_file: Path) -> list[str]:
+    """Extracts non-external Markdown link targets from one file."""
+    targets: list[str] = []
+    for match in _MARKDOWN_LINK_RE.finditer(markdown_file.read_text(encoding="utf-8")):
+        raw_target = match.group(1).split("#", 1)[0]
+        if (
+            not raw_target
+            or _EXTERNAL_LINK_RE.match(raw_target)
+            or raw_target.startswith("mailto:")
+        ):
+            continue
+        targets.append(raw_target)
+    return targets
+
+
+def test_local_markdown_links_resolve(repo_root: Path) -> None:
+    """Local documentation links should point at files present in this repository."""
+    missing_links: list[str] = []
+    for markdown_file in _markdown_files(repo_root):
+        for target in _local_markdown_link_targets(markdown_file):
+            resolved_target = (markdown_file.parent / target).resolve()
+            if not resolved_target.exists():
+                relative_source = markdown_file.relative_to(repo_root)
+                missing_links.append(f"{relative_source}: {target}")
+
+    assert missing_links == []

--- a/tests/suites/unit/data/test_provider_downloads.py
+++ b/tests/suites/unit/data/test_provider_downloads.py
@@ -5,12 +5,20 @@ from __future__ import annotations
 from collections.abc import Callable
 from email.message import Message
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 from urllib import error
 
 import pytest
 
 from ser.data import provider_downloads
+
+
+class _DiskUsage(NamedTuple):
+    """Minimal disk-usage result for download preflight tests."""
+
+    total: int
+    used: int
+    free: int
 
 
 def test_download_file_with_retries_reuses_existing_file_without_hash(
@@ -97,6 +105,151 @@ def test_download_file_with_retries_streams_and_validates_payload(
     assert headers["user-agent"] == "ser-data-downloader/1.0"
     assert headers["x-test"] == "1"
     assert not destination_path.with_suffix(".zip.partial").exists()
+
+
+def test_download_file_with_retries_aborts_before_request_when_expected_size_exceeds_disk(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Known-size downloads should fail before network I/O when disk is too small."""
+    destination_path = tmp_path / "archive.zip"
+    urlopen_called = False
+    retried = False
+
+    def _urlopen(req: object, timeout: float) -> object:
+        nonlocal urlopen_called
+        del req, timeout
+        urlopen_called = True
+        raise AssertionError("network I/O should not start")
+
+    def _with_retries(*, description: str, action: Callable[[], None]) -> None:
+        nonlocal retried
+        del description, action
+        retried = True
+
+    monkeypatch.setattr(provider_downloads.request, "urlopen", _urlopen)
+    monkeypatch.setattr(
+        provider_downloads.shutil,
+        "disk_usage",
+        lambda _path: _DiskUsage(total=10, used=9, free=1),
+    )
+
+    with pytest.raises(RuntimeError, match="insufficient disk space"):
+        provider_downloads.download_file_with_retries(
+            url="https://example.invalid/archive.zip",
+            destination_path=destination_path,
+            expected_size=10,
+            with_retries=_with_retries,
+            compute_file_md5=lambda _path: "unused",
+            timeout_seconds=1.0,
+            chunk_size=1024,
+        )
+
+    assert retried is False
+    assert urlopen_called is False
+    assert not destination_path.exists()
+
+
+def test_download_file_with_retries_aborts_on_content_length_when_disk_is_too_small(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Unknown-size downloads should use Content-Length for disk-space preflight."""
+    destination_path = tmp_path / "archive.zip"
+
+    class _FakeResponse:
+        def __enter__(self) -> _FakeResponse:
+            return self
+
+        def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+            del exc_type, exc, tb
+
+        def getheader(self, name: str, default: str | None = None) -> str | None:
+            if name.lower() == "content-length":
+                return "10"
+            return default
+
+        def read(self, _size: int) -> bytes:
+            raise AssertionError("payload should not be read after disk-space failure")
+
+    def _urlopen(req: object, timeout: float) -> _FakeResponse:
+        del req, timeout
+        return _FakeResponse()
+
+    def _with_retries(*, description: str, action: Callable[[], None]) -> None:
+        del description
+        action()
+
+    monkeypatch.setattr(provider_downloads.request, "urlopen", _urlopen)
+    monkeypatch.setattr(
+        provider_downloads.shutil,
+        "disk_usage",
+        lambda _path: _DiskUsage(total=10, used=9, free=1),
+    )
+
+    with pytest.raises(RuntimeError, match="insufficient disk space"):
+        provider_downloads.download_file_with_retries(
+            url="https://example.invalid/archive.zip",
+            destination_path=destination_path,
+            with_retries=_with_retries,
+            compute_file_md5=lambda _path: "unused",
+            timeout_seconds=1.0,
+            chunk_size=1024,
+        )
+
+    assert not destination_path.exists()
+    assert not destination_path.with_suffix(".zip.partial").exists()
+
+
+def test_download_file_with_retries_uses_larger_content_length_than_expected_size(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Response size should protect disk even when stale metadata underestimates bytes."""
+    destination_path = tmp_path / "archive.zip"
+
+    class _FakeResponse:
+        def __enter__(self) -> _FakeResponse:
+            return self
+
+        def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+            del exc_type, exc, tb
+
+        def getheader(self, name: str, default: str | None = None) -> str | None:
+            if name.lower() == "content-length":
+                return "10"
+            return default
+
+        def read(self, _size: int) -> bytes:
+            raise AssertionError("payload should not be read after disk-space failure")
+
+    def _urlopen(req: object, timeout: float) -> _FakeResponse:
+        del req, timeout
+        return _FakeResponse()
+
+    def _with_retries(*, description: str, action: Callable[[], None]) -> None:
+        del description
+        action()
+
+    monkeypatch.setattr(provider_downloads.request, "urlopen", _urlopen)
+    monkeypatch.setattr(
+        provider_downloads.shutil,
+        "disk_usage",
+        lambda _path: _DiskUsage(total=10, used=5, free=5),
+    )
+
+    with pytest.raises(RuntimeError, match="insufficient disk space"):
+        provider_downloads.download_file_with_retries(
+            url="https://example.invalid/archive.zip",
+            destination_path=destination_path,
+            expected_size=2,
+            with_retries=_with_retries,
+            compute_file_md5=lambda _path: "unused",
+            timeout_seconds=1.0,
+            chunk_size=1024,
+        )
+
+    assert not destination_path.exists()
 
 
 def test_read_github_latest_release_assets_parses_expected_payload() -> None:

--- a/tests/suites/unit/scripts/test_run_full_dataset_quality_gate_script.py
+++ b/tests/suites/unit/scripts/test_run_full_dataset_quality_gate_script.py
@@ -1,0 +1,26 @@
+"""Contracts for full-dataset quality gate shell script defaults."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def test_full_dataset_quality_gate_script_has_valid_bash_syntax(repo_root: Path) -> None:
+    """Full-gate script should parse before CI invokes expensive profile work."""
+    script_path = repo_root / "scripts" / "run_full_dataset_quality_gate.sh"
+
+    subprocess.run(["bash", "-n", str(script_path)], check=True)
+
+
+def test_full_dataset_quality_gate_default_models_dir_is_platform_aware(repo_root: Path) -> None:
+    """Default artifact lookup should match SER platform data-dir conventions."""
+    script_path = repo_root / "scripts" / "run_full_dataset_quality_gate.sh"
+    script_text = script_path.read_text(encoding="utf-8")
+
+    assert "Library/Application Support/ser/models" in script_text
+    assert "${XDG_DATA_HOME:-$HOME/.local/share}/ser/models" in script_text
+    assert (
+        'models_dir="${SER_MODELS_DIR:-$HOME/Library/Application Support/ser/models}"'
+        not in script_text
+    )

--- a/tests/suites/unit/scripts/test_smoke_test_wheel_install_script.py
+++ b/tests/suites/unit/scripts/test_smoke_test_wheel_install_script.py
@@ -1,0 +1,22 @@
+"""Contracts for wheel-install smoke test script."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def test_wheel_smoke_script_has_valid_bash_syntax(repo_root: Path) -> None:
+    """Wheel smoke script should parse before packaging CI invokes it."""
+    script_path = repo_root / "scripts" / "workflows" / "smoke_test_wheel_install.sh"
+
+    subprocess.run(["bash", "-n", str(script_path)], check=True)
+
+
+def test_wheel_smoke_script_forces_fresh_same_version_install(repo_root: Path) -> None:
+    """Wheel smoke should install the current wheel even when package version is unchanged."""
+    script_path = repo_root / "scripts" / "workflows" / "smoke_test_wheel_install.sh"
+    script_text = script_path.read_text(encoding="utf-8")
+
+    assert "rm -rf .pkg-smoke" in script_text
+    assert "pip install --force-reinstall --no-deps" in script_text


### PR DESCRIPTION
## Summary
- Make local quality/setup commands reproducible with frozen dev envs.
- Add disk-space preflight for dataset downloads using expected size and HTTP Content-Length.
- Fix validation scripts: platform-aware full-gate artifact directories and fresh wheel smoke installs.
- Add regression tests for download disk guards, docs links, and shell script contracts.
- Clean stale ADR link and simplify MPS tensor checks.
